### PR TITLE
Update cluster-assign-roles for OpenStack or Hadoop install type

### DIFF
--- a/cluster-assign-roles.sh
+++ b/cluster-assign-roles.sh
@@ -1,66 +1,172 @@
 #!/bin/bash
-# Script to assign roles to cluster nodes based on a definition in cluster.txt :
+# Script to assign roles to cluster nodes based on a definition in cluster.txt:
 #
-# - If no hostname is provided, all nodes will be attempted
+# * The environment is needed to find the root password of the machines
+#   and to provide the environment in which to chef them
 #
-# - if a nodename is provided, either by hostname or ip address, only
-#   that node will be attempted
+# * An install_type is needed; options are OpenStack
 #
-# - if the special nodename "heads" is given, all head nodes will be
-#   attempted
+# * A node specifier may be provided:
+#   If no specifier is provided, all nodes will be attempted
 #
-# - if the special nodename "workers" is given, all work nodes will be
-#   attempted
+#   - if a nodename is provided, either by hostname or IP address, only
+#     that node will be attempted
 #
-# - A node may be excluded by setting its role to something other than
-#   "head" or "work" in cluster.txt. For example "done" might be
-#   useful for nodes that have been completed
+#   - if a chef object is provided, e.g. role[ROLE-NAME] or
+#     recipe[RECIPE-NAME], only nodes marked for that action are attempted
+#
+# * A node may be excluded by setting its action to SKIP in cluster.txt
 
-set -e
-if [[ -z "$1" ]]; then
-    echo "Usage : $0 environment (hostname)"
-    exit 1
+set -x
+set -o errtrace
+set -o errexit
+set -o nounset
+
+# We use exclamation point as a separator but it is a pain to use in
+# strings with variables make it a variable to include in strings
+BANG='!'
+# Global Regular Expression for parsing parse_cluster_txt output
+REGEX='(.*)!(.*)!(.*)'
+
+########################################################################
+# install_machines -  Install a set of machines (will run chefit.sh if no node object for machine)
+# Argument: $1 - a string of role!IP!FQDN pairs separated by white space
+# Will install the machine with role $role in the order passed (left to right)
+function install_machines {
+  passwd=`knife data bag show configs $ENVIRONMENT | grep "cobbler-root-password:" | awk ' {print $2}'`
+  for h in $(sort <<< ${*// /\\n}); do
+    [[ "$h" =~ $REGEX ]]
+    local run_list="${BASH_REMATCH[1]}"
+    local ip="${BASH_REMATCH[2]}"
+    local fqdn="${BASH_REMATCH[3]}"
+    printf "About to bootstrap node $fqdn to $ENVIRONMENT ${run_list}...\n"
+    knife node show $fqdn 2>/dev/null >/dev/null || ./chefit.sh $ip $ENVIRONMENT
+    local SSHCMD="./nodessh.sh $ENVIRONMENT $ip"
+    sudo knife bootstrap -E $ENVIRONMENT -r "$run_list" $ip -x ubuntu  -P $passwd -u admin -k /etc/chef-server/admin.pem --sudo <<< $passwd
+  done
+}
+
+#############################################################################################
+# parse cluster.txt 
+# Argument: $1 - optional case insensitive match text (e.g. hostname, ipaddress, chef object)
+# Returns: List of matching hosts (or all non-skipped hosts) one host per line with ! delimited fields
+# (Note: if you want to skip a machine, set its role to SKIP in cluster.txt)
+function parse_cluster_txt {
+  local match_text=${1-}
+  local hosts=""
+  while read host macaddr ipaddr iloipaddr domain role; do
+    shopt -s nocasematch
+    if [[ -z "${match_text-}" || "$match_text" = "$host" || "$match_text" = "$ipaddr" || "$match_text" = "$role" ]] && \
+       [[ ! "|$role" =~ '|SKIP' ]]; then
+      hosts="$hosts ${role}${BANG}${ipaddr}${BANG}${host}.$domain"
+    fi
+    shopt -u nocasematch
+  done < cluster.txt
+  printf "$hosts"
+}
+
+##########################################
+# Install Machine Stub
+# Function to create basic machine representation (in parallel) if Chef does not
+# already know about machine
+# Runs: Chef role[Basic], Chef recipe[bcpc::default]
+# Argument: $* - hosts are returned by parse_cluster_txt
+function install_stub {
+  printf "Creating stubs for nodes...\n"
+  for h in $*; do
+    [[ "$h" =~ $REGEX ]]
+    local role="${BASH_REMATCH[1]}"
+    local ip="${BASH_REMATCH[2]}"
+    local fqdn="${BASH_REMATCH[3]}"
+    knife node show $fqdn 2>/dev/null >/dev/null ||  install_machines "role[Basic],recipe[bcpc::default]${BANG}${ip}${BANG}${fqdn}" &
+  done
+  wait
+}
+
+########################################################################
+# Perform OpenStack install
+# Arguments: $* - hosts (as output from parse_cluster_txt)
+# Runs the end-to-end install in the proper order for OpenStack installs
+# Install method:
+# First, install first headnode -- which needs to be an admin
+# Next, install head-nodes start to finish and back to start synchronously
+# (this ensures all headnodes know of each other)
+# Lastly, install workers in parallel)
+function openstack_install {
+  local hosts="$*"
+  printf "Doing OpenStack style install...\n"
+
+  first_head_node=$(printf ${hosts// /\\n} | grep -i "head" | sort | head -1)
+  if [[ "$first_head_node" =~ $REGEX ]]; then
+    first_head_node_fqdn="${BASH_REMATCH[3]}" || \
+      (printf "Failed to parse hosts\n"; exit 1 )
+    # chef does not always use the same hostname as cluster.txt (be fast and loose and find the chef hostname)
+    first_head_node_hostname=${first_head_node_fqdn%%.*}
+    install_stub "$first_head_node"
+    # set the first node to admin for creating data bags (short-circuit failures in-case machine already is an admin)
+    chef_head_node_name=$(knife client list | egrep "^[ ]*${first_head_node_hostname}\..*$|^${first_head_node_hostname}$")
+    printf "/\"admin\": false\ns/false/true\nw\nq\n" | EDITOR=ed knife client edit $chef_head_node_name || /bin/true
+  fi
+
+  # Do head nodes first and group by type of head
+  printf "Installing heads...\n"
+  install_machines $(printf ${hosts// /\\n} | grep -i "head" | sort)
+  # Redo head nodes in reverse order to ensure they know about each other
+  # (the last node already knows everyone in the universe of heads)
+  printf "Acquainting heads...\n"
+  install_machines $(printf ${hosts// /\\n} | grep -i "head" | sort | head -n -1 | tac)
+  # Do everything else next and group by type of node
+  printf "Installing workers...\n"
+  for m in $(printf ${hosts// /\\n} | grep -vi "head" | sort); do
+    ( install_machines $m || exit 1 )&
+  done
+  wait
+  if [[ -n "${chef_head_node_name-}" ]]; then
+    # remove admin from first headnode
+    printf "/\"admin\": true\ns/true/false\nw\nq\n" | EDITOR=ed knife client edit $chef_head_node_name
+  fi
+}
+
+############
+# Main Below
+#
+
+if [[ "${#*}" -lt "2" ]]; then
+  printf "Usage : $0 environment install_type (hostname)\n" > /dev/stderr
+  exit 1
 fi
 
 ENVIRONMENT=$1
-EXACTHOST=$2
+INSTALL_TYPE=$2
+MATCHKEY=${3-}
+
+shopt -s nocasematch
+if [[ ! "$INSTALL_TYPE" =~ openstack ]]; then
+  printf "Error: Need install type of OpenStack\n" > /dev/stderr
+  exit 1
+fi
+shopt -u nocasematch
 
 if [[ ! -f "environments/$ENVIRONMENT.json" ]]; then
-    echo "Error: Couldn't find '$ENVIRONMENT.json'. Did you forget to pass the environment as first param?"
-    exit 1
+  printf "Error: Couldn't find '$ENVIRONMENT.json'. Did you forget to pass the environment as first param?\n" > /dev/stderr
+  exit 1
 fi
 
+# Report which hosts were found
+hosts="$(parse_cluster_txt $MATCHKEY)"
+for h in $hosts; do
+  [[ "$h" =~ $REGEX ]]
+  role="${BASH_REMATCH[1]}"
+  ip="${BASH_REMATCH[2]}"
+  fqdn="${BASH_REMATCH[3]}"
+  printf "%s\t-\t%s\n" $role $fqdn
+done | sort 
 
-while read HOST MACADDR IPADDR ILOIPADDR DOMAIN ROLE; do
-    if [[ -z "$EXACTHOST" || "$EXACTHOST" = "$HOST" || "$EXACTHOST" = "$IPADDR" || "$EXACTHOST" = "heads" && "$ROLE" = "head" || "$EXACTHOST" = "workers" && "$ROLE" = "work" ]]; then
-	if   [[ "$ROLE" = head ]]; then
-	    HEADS="$HEADS $IPADDR"
-	elif [[ "$ROLE" = work ]]; then
-	    WORKERS="$WORKERS $IPADDR"
-	fi	
-    fi
-done < cluster.txt
-echo "heads : $HEADS"
-echo "workers : $WORKERS"
-
-PASSWD=`knife data bag show configs $ENVIRONMENT | grep "cobbler-root-password:" | awk ' {print $2}'`
-
-for HEAD in $HEADS; do
-    MATCH=$HEAD
-    echo "About to bootstrap head node $HEAD..."
-    ./chefit.sh $HEAD $ENVIRONMENT
-    echo $PASSWD | sudo knife bootstrap -E $ENVIRONMENT -r 'role[BCPC-Headnode]' $HEAD -x ubuntu  -P $PASSWD --sudo
-    SSHCMD="./nodessh.sh $ENVIRONMENT $HEAD"
-    $SSHCMD "/home/ubuntu/finish-head.sh" sudo	
-done
-for WORKER in $WORKERS; do
-    MATCH=$WORKER
-    echo "About to bootstrap worker worker $WORKER..."
-    ./chefit.sh $WORKER $ENVIRONMENT
-    echo $PASSWD | sudo knife bootstrap -E $ENVIRONMENT -r 'role[BCPC-Worknode]' $WORKER -x ubuntu -P $PASSWD --sudo
-    SSHCMD="./nodessh.sh $ENVIRONMENT $WORKER"
-    $SSHCMD "/home/ubuntu/finish-worker.sh" sudo	
-done
-if [[ -z "$MATCH" ]]; then
-    echo "Warning: No nodes found"
+if [[ -z "${hosts-}" ]]; then
+  printf "Warning: No nodes found\n" > /dev/stderr
+  exit 0
 fi
+
+openstack_install $hosts
+
+printf "#### Install finished\n"

--- a/cluster.txt
+++ b/cluster.txt
@@ -1,4 +1,3 @@
-bcpc-vm1 08:00:27:56:A2:28 10.0.100.11 - bloomberg.com head
-bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bloomberg.com work
-bcpc-vm3 08:00:27:AD:1D:EA 10.0.100.13 - bloomberg.com work
-end
+bcpc-vm1 08:00:27:56:A2:28 10.0.100.11 - bloomberg.com role[BCPC-Headnode]
+bcpc-vm2 08:00:27:E5:3A:00 10.0.100.12 - bloomberg.com role[BCPC-Worknode]
+bcpc-vm3 08:00:27:AD:1D:EA 10.0.100.13 - bloomberg.com role[BCPC-Worknode]

--- a/tests/automated_install.sh
+++ b/tests/automated_install.sh
@@ -26,7 +26,7 @@ printf "#### Setup configuration files\n"
 sed -i 's/vb.gui = true/vb.gui = false/' Vagrantfile
 
 # setup proxy_setup.sh
-sed -i "s/#export PROXY=.*\"/export PROXY=\"$PROXY\"/" proxy_setup.sh
+[[ -n "$PROXY" ]] && sed -i "s/#export PROXY=.*\"/export PROXY=\"$PROXY\"/" proxy_setup.sh
 
 # setup environment file
 sed -i "s/\"dns_servers\" : \[ \"8.8.8.8\", \"8.8.4.4\" \]/\"dns_servers\" : \[ $DNS_SERVERS \]/" environments/${ENVIRONMENT}.json
@@ -70,19 +70,12 @@ printf "Snapshotting post-Cobbler\n"
 printf "#### Chef all the nodes\n"
 vagrant ssh -c "sudo apt-get install -y sshpass"
 
-cobbler_pass=$(vagrant ssh -c "cd chef-bcpc; knife data bag show configs $ENVIRONMENT | grep 'cobbler-root-password:'|sed 's/.* //'")
-
-printf "#### Chef the first headnode(s)\n"
-if ! vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT bcpc-vm1"; then 
-  printf "## set the first machine to admin\n"
-  vagrant ssh -c 'cd chef-bcpc; echo -e "/\"admin\": false\ns/false/true\nw\nq\n" | EDITOR=ed knife client edit `knife client list | grep bcpc-vm1`'
-  # re-run chef
-  vagrant ssh -c "cd chef-bcpc; echo $cobbler_pass | sudo knife bootstrap -E $ENVIRONMENT -r 'role[BCPC-Headnode]' 10.0.100.11 -x ubuntu --sudo"
-fi
+printf "#### Chef the headnode\n"
+vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT OpenStack bcpc-vm1"
 
 for i in 2 3; do
-  printf "## Machine bcpc-vm${i}\n"
-  vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT bcpc-vm$i"
+  printf "#### Chef machine bcpc-vm${i}\n"
+  vagrant ssh -c "cd chef-bcpc; ./cluster-assign-roles.sh $ENVIRONMENT OpenStack bcpc-vm$i"
 done
 
 printf "Snapshotting post-Cobbler\n"


### PR DESCRIPTION
This update to cluster-assign-roles.sh provides for a more configurable Chef experience. Instead of requiring all nodes to fit into a model of being uniform head nodes or worker nodes, the cluster.txt now allows arbitrary role assignment (e.g. one node could be installed with multiple roles) and allows for pluggable installation types.

The reason to extend allowing pluggable installation types is due to a philosophical difference in how the original OpenStack BCPC code and newer Hadoop BCPC code was written to support cluster installs.

Graphically it can be seen (as red to green being first to latest Chef run):
![Diagram showing Chef install of OpenStack versus Hadoop cluster](http://clayb.net/Cluster_Chefing.png)

In the OpenStack case, all headnodes are incrementally created. As each headnode is created, all future headnode's will know about it but all previous headnodes will be ignorant. As such, to install a cluster of headnodes, one runs an entire full Chef run from first to last headnode and then re-Chef and full Chef run last to first headnode. Daemons which need to know about future headnodes will thus need a bounce on a re-Chefing; luckily for our OpenStack clusters, this works fine as there's little need for a priori knowledge of the cluster layout or for daemons to be bounced on a re-Chefing.

For the Hadoop case, all headnodes are created by running a trivial bootstrap to create the Chef client and node object on the Chef server and create the necessary keys on the client. Then, we can go ahead and assign roles to all headnodes, on the Chef server. Lastly, we perform the full Chef run only once and all daemons can know where other Hadoop services will be on the cluster (even should they not yet be up). This requires one to install the cluster in order of the required daemon boot order (e.g. install HDFS and ensure it is started before installing HBase, which needs HDFS to be up and established). However, this allows us to install components with full a priori knowledge of the cluster layout.

Some other features:
* Add the admin credential to headnode client objects needing to touch Chef data bags
* Remove the admin credential from headnode client objects once Chef'ing is done
* Install worker nodes in parallel