### PR TITLE
Add wildcard to s3 dns for bucket subdomain resolution.

### DIFF
--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -399,8 +399,10 @@ end
         block do
             system "mysql -uroot -p#{get_config('mysql-root-password')} #{node[:bcpc][:pdns_dbname]} -e 'SELECT name FROM records_static' | grep -q \"#{static}.#{node[:bcpc][:domain_name]}\""
             if not $?.success? then
+                # Create both the main s3 entry and the s3 wildcard entry "*.s3.domain.com" so buckets resolve.
                 %x[ mysql -uroot -p#{get_config('mysql-root-password')} #{node[:bcpc][:pdns_dbname]} <<-EOH
                         INSERT INTO records_static (domain_id, name, content, type, ttl, prio) VALUES ((SELECT id FROM domains WHERE name='#{node[:bcpc][:domain_name]}'),'#{static}.#{node[:bcpc][:domain_name]}','#{node[:bcpc][:floating][:vip]}','A',300,NULL);
+                        INSERT INTO records_static (domain_id, name, content, type, ttl, prio) VALUES ((SELECT id FROM domains WHERE name='#{node[:bcpc][:domain_name]}'),'*.#{static}.#{node[:bcpc][:domain_name]}','#{static}.#{node[:bcpc][:domain_name]}','CNAME',300,NULL);
                 ]
             end
         end


### PR DESCRIPTION
Amazon's S3 exposes bucket names as subdomains of the s3 service name, of the form  bucketname.s3.amazon.com. S3 then serves the contents of that bucket from the root of that virtual host. 

The first step in allowing our S3 gateway to do that is to allow DNS wildcarding for subdomains of the s3 record. This pull request does that. It does *not* make the ceph changes required. While the addition is harmless and makes no change to existing functionality, I understand if you want this to pend until the ceph component is ready. 

From a Cirros host on a VM cluster (I changed resolv.conf to point to the vip):


$ nslookup foo.bar.s3.bcpc.example.com
Server:    10.0.100.5
Address 1: 10.0.100.5

Name:      foo.bar.s3.bcpc.example.com
Address 1: 192.168.100.5 s3.bcpc.example.com


$ nslookup s3.bcpc.example.com
Server:    10.0.100.5
Address 1: 10.0.100.5

Name:      s3.bcpc.example.com
Address 1: 192.168.100.5 s3.bcpc.example.com


$ nslookup baz.s3.bcpc.example.com
Server:    10.0.100.5
Address 1: 10.0.100.5

Name:      baz.s3.bcpc.example.com
Address 1: 192.168.100.5 s3.bcpc.example.com
