### PR TITLE
Added user to knife configure command in setup_chef_cookbooks.sh

### DIFF
--- a/setup_chef_cookbooks.sh
+++ b/setup_chef_cookbooks.sh
@@ -26,7 +26,7 @@ if [[ -f .chef/knife.rb ]]; then
   knife client delete $USER -y || true
   mv .chef/ ".chef_found_$(date +"%m-%d-%Y %H:%M:%S")"
 fi
-echo -e ".chef/knife.rb\nhttp://$BOOTSTRAP_IP:4000\n\n\n/etc/chef-server/chef-webui.pem\n\n/etc/chef-server/chef-validator.pem\n.\n" | knife configure --initial
+echo -e ".chef/knife.rb\nhttp://$BOOTSTRAP_IP:4000\n$USER\n\n/etc/chef-server/chef-webui.pem\n\n/etc/chef-server/chef-validator.pem\n.\n" | knife configure --initial
 
 cp -p .chef/knife.rb .chef/knife-proxy.rb
 


### PR DESCRIPTION
Pass the user into 'knife configure --initial' 
Currently uses the default user (usually ubuntu); however, this should be the $USER variable provided as an argument to setup_chef_cookbooks.sh