### PR TITLE
Bug Fix And Switched to using the bcpc_cephpool LWRP rather than bash

### DIFF
--- a/cookbooks/bcpc/providers/cephpool.rb
+++ b/cookbooks/bcpc/providers/cephpool.rb
@@ -1,0 +1,76 @@
+
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  if @current_resource.exists
+    Chef::Log.info "#{ @new_resource } already exists"
+    if (@current_resource.pgp_num != @new_resource.pg_num and @new_resource.change_pg and @new_resource.change_pgp) or
+      (@current_resource.pg_num < @new_resource.pg_num  and  @new_resource.change_pg ) or
+      ( @current_resource.replicas != @new_resource.replicas)
+      converge_by("Resetting pg(p)_num") do
+        reset_pgs
+      end
+    end    
+  else
+    converge_by("Create #{ @new_resource }") do
+      create_pool
+    end
+  end
+end
+
+action :delete do
+ if not @current_resource.exists
+    Chef::Log.info "#{ @new_resource } already deleted"    
+  else
+    converge_by("delete #{ @new_resource }") do
+      delete_pool
+    end
+  end
+  
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::BcpcCephpool.new(@new_resource.name)
+  @current_resource.exists = system("rados lspools | egrep '^#{@new_resource.name}$'") 
+  if @current_resource.exists
+	@current_resource.replicas (`ceph osd pool get  #{@new_resource.name} size  | awk '{}{print $2}' | tr -d '\n'`.to_i)
+	@current_resource.pg_num(`ceph osd pool get #{@new_resource.name} pg_num | awk '{}{print $2}' | tr -d '\n'`.to_i)
+	@current_resource.pgp_num = `ceph osd pool get #{@new_resource.name} pgp_num | awk '{}{print $2}' | tr -d '\n'`.to_i
+	@current_resource.ruleset(`ceph osd pool get #{@new_resource.name} crush_ruleset | awk '{}{print $2}' | tr -d '\n'`.to_i)
+  end
+ end
+
+ def create_pool
+    %x[ceph osd pool create #{new_resource.name} #{new_resource.pg_num}]
+    %x[ceph osd pool set #{new_resource.name} crush_ruleset #{new_resource.ruleset}]    
+    %x[ceph osd pool set #{new_resource.name} size #{new_resource.replicas}]
+ end
+
+def delete_pool
+     %x[ceph osd pool create #{new_resource.name}  #{new_resource.name} --yes-i-really-really-mean-it]
+end
+
+def wait_for_pg_created
+ while (`ceph -s | grep -v mdsmap | grep creating`.length > 0 ) do
+   puts "waiting for pgs to create"
+   sleep 1
+ end
+end
+
+def reset_pgs
+  if  @new_resource.change_pg and (@current_resource.pg_num < @new_resource.pg_num)
+    %x[ceph osd pool set #{new_resource.name} pg_num #{new_resource.pg_num}]    
+    wait_for_pg_created
+  end
+  if  @new_resource.change_pg and @new_resource.change_pgp and (@current_resource.pgp_num != @new_resource.pg_num)
+     %x[ceph osd pool set #{new_resource.name} pgp_num #{new_resource.pg_num}]    
+    wait_for_pg_created
+  end
+  if @current_resource.replicas != @new_resource.replicas
+    %x[ceph osd pool set #{new_resource.name} size #{new_resource.replicas}]    
+  end
+ end
+

--- a/cookbooks/bcpc/recipes/cinder.rb
+++ b/cookbooks/bcpc/recipes/cinder.rb
@@ -76,32 +76,12 @@ bash "cinder-database-sync" do
 end
 
 node['bcpc']['ceph']['enabled_pools'].each do |type|
-    bash "create-cinder-rados-pool-#{type}" do
-        user "root"
-        optimal = power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['volumes']['replicas']*node['bcpc']['ceph']['volumes']['portion']/100/node['bcpc']['ceph']['enabled_pools'].length)
-        code <<-EOH
-            ceph osd pool create #{node['bcpc']['ceph']['volumes']['name']}-#{type} #{optimal}
-            ceph osd pool set #{node['bcpc']['ceph']['volumes']['name']}-#{type} crush_ruleset #{(type=="ssd") ? node['bcpc']['ceph']['ssd']['ruleset'] : node['bcpc']['ceph']['hdd']['ruleset']}
-        EOH
-        not_if "rados lspools | grep #{node['bcpc']['ceph']['volumes']['name']}-#{type}"
-        notifies :run, "bash[wait-for-pgs-creating]", :immediately
-    end
-
-    bash "set-cinder-rados-pool-replicas-#{type}" do
-        user "root"
-        replicas = [get_all_nodes.length, node['bcpc']['ceph']['volumes']['replicas']].min
-        code "ceph osd pool set #{node['bcpc']['ceph']['volumes']['name']}-#{type} size #{replicas}"
-        not_if "ceph osd pool get #{node['bcpc']['ceph']['volumes']['name']}-#{type} size | grep #{replicas}"
-    end
-
-    (node['bcpc']['ceph']['pgp_auto_adjust'] ? %w{pg_num pgp_num} : %w{pg_num}).each do |pg|
-        bash "set-cinder-rados-pool-#{pg}-#{type}" do
-            user "root"
-            optimal = power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['volumes']['replicas']*node['bcpc']['ceph']['volumes']['portion']/100/node['bcpc']['ceph']['enabled_pools'].length)
-            code "ceph osd pool set #{node['bcpc']['ceph']['volumes']['name']}-#{type} #{pg} #{optimal}"
-            not_if "((`ceph osd pool get #{node['bcpc']['ceph']['volumes']['name']}-#{type} #{pg} | awk '{print $2}'` >= #{optimal}))"
-            notifies :run, "bash[wait-for-pgs-creating]", :immediately
-        end
+    bcpc_cephpool "#{node['bcpc']['ceph']['volumes']['name']}-#{type}" do
+        action :create
+        ruleset (type=="ssd") ? node['bcpc']['ceph']['ssd']['ruleset'] : node['bcpc']['ceph']['hdd']['ruleset']
+        pg_num power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['volumes']['replicas']*node['bcpc']['ceph']['volumes']['portion']/100/node['bcpc']['ceph']['enabled_pools'].length)
+        replicas [get_all_nodes.length, node['bcpc']['ceph']['volumes']['replicas']].min
+        change_pgp node['bcpc']['ceph']['pgp_auto_adjust']
     end
 
     bash "cinder-make-type-#{type}" do

--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -100,32 +100,12 @@ bash "glance-database-sync" do
     notifies :restart, "service[glance-registry]", :immediately
 end
 
-bash "create-glance-rados-pool" do
-    user "root"
-    optimal = power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['images']['replicas']*node['bcpc']['ceph']['images']['portion']/100)
-    code <<-EOH
-        ceph osd pool create #{node['bcpc']['ceph']['images']['name']} #{optimal}
-        ceph osd pool set #{node['bcpc']['ceph']['images']['name']} crush_ruleset #{(node['bcpc']['ceph']['images']['type']=="ssd") ? node['bcpc']['ceph']['ssd']['ruleset'] : node['bcpc']['ceph']['hdd']['ruleset']}
-    EOH
-    not_if "rados lspools | grep #{node['bcpc']['ceph']['images']['name']}"
-    notifies :run, "bash[wait-for-pgs-creating]", :immediately
-end
-
-bash "set-glance-rados-pool-replicas" do
-    user "root"
-    replicas = [get_all_nodes.length, node['bcpc']['ceph']['images']['replicas']].min
-    code "ceph osd pool set #{node['bcpc']['ceph']['images']['name']} size #{replicas}"
-    not_if "ceph osd pool get #{node['bcpc']['ceph']['images']['name']} size | grep #{replicas}"
-end
-
-(node['bcpc']['ceph']['pgp_auto_adjust'] ? %w{pg_num pgp_num} : %w{pg_num}).each do |pg|
-    bash "set-glance-rados-pool-#{pg}" do
-        user "root"
-        optimal = power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['images']['replicas']*node['bcpc']['ceph']['images']['portion']/100)
-        code "ceph osd pool set #{node['bcpc']['ceph']['images']['name']} #{pg} #{optimal}"
-        not_if "((`ceph osd pool get #{node['bcpc']['ceph']['images']['name']} #{pg} | awk '{print $2}'` >= #{optimal}))"
-        notifies :run, "bash[wait-for-pgs-creating]", :immediately
-    end
+bcpc_cephpool "#{node['bcpc']['ceph']['images']['name']}" do
+    action :create
+    ruleset (node['bcpc']['ceph']['images']['type']=="ssd") ? node['bcpc']['ceph']['ssd']['ruleset'] : node['bcpc']['ceph']['hdd']['ruleset']
+    pg_num power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['images']['replicas']*node['bcpc']['ceph']['images']['portion']/100)    
+    replicas [get_all_nodes.length, node['bcpc']['ceph']['images']['replicas']].min
+    change_pgp node['bcpc']['ceph']['pgp_auto_adjust']
 end
 
 cookbook_file "/tmp/cirros-0.3.2-x86_64-disk.img" do

--- a/cookbooks/bcpc/resources/cephpool.rb
+++ b/cookbooks/bcpc/resources/cephpool.rb
@@ -1,0 +1,18 @@
+#
+# Cookbook Name:: bcpc
+# Resource:: cephpool
+#
+actions :create, :delete 
+
+default_action :create
+
+attribute :name, :name_attribute => true, :kind_of => String, :required => true
+attribute :pg_num, :kind_of => Fixnum, :required => true
+attribute :change_pgp,  :kind_of => [ TrueClass, FalseClass ], :default => false
+attribute :change_pg,  :kind_of => [ TrueClass, FalseClass ], :default => true
+attribute :replicas    , :kind_of => Fixnum, :required => true
+attribute :ruleset  , :kind_of => Fixnum, :required => true
+
+attr_accessor :exists
+attr_accessor :pgp_num
+


### PR DESCRIPTION
This PR was motivated by a bug in all the pg number setting bash blocks that are scattered about the code. 

The Bug: 

consider,
```
bash "set-glance-rados-pool-#{pg}" do
        user "root"
        optimal = power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['images']['replicas']*node['bcpc']['ceph']['images']['portion']/100)
        code "ceph osd pool set #{node['bcpc']['ceph']['images']['name']} #{pg} #{optimal}"
        not_if "((`ceph osd pool get #{node['bcpc']['ceph']['images']['name']} #{pg} | awk '{print $2}'` >= #{optimal}))"
        notifies :run, "bash[wait-for-pgs-creating]", :immediately
end
```

The not_if is actually evaluated in sh not bash, so this clause doesn't actually work. You can see this by just looking at a chef run. It will always execute this bash block even on a system with the correct number of pgs.

The impact:

This means that if you have a cluster with pg_num > optimal, which you may have due to historical reasons, the chef run bombs as ceph refuses to lower the number of pgs. It is also potentially dangerous as things get notified of a change when there wasn't one.

The solution:

In later versions of chef you can specify the guard interpreter (http://docs.getchef.com/resource_common.html#guard-interpreters). But in the version used in this project this isn't possible.

I could get the desired behavior by some even more funky shell code or by using a ruby block and computing the current and optimal on the fly and use an if, e.g.
```
ruby_block "pool-tests" do
	block do
    	current = `ceph osd pool get volumes-ssd  pgp_num | awk '{}{print $2}' | tr -d '\n'`.to_i
    	optimal = power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['volumes']['replicas']*node['bcpc']['ceph']['volumes']['portion']/100/node['bcpc']['ceph']['enabled_pools'].length)	
    	
    	if current < optimal
    		%[ceph osd pool set volumes-ssd pgp_num #{optimal}]
    	end

	end
end
```
(I would have to do something to trigger the notifies but you get the idea)

This works, but then I was faced with editing the 5 or so places with the same structure.  When you think about what the ruby_block is actually doing, it is creating an ad-hoc LWRP by inlining a block of code into a skeleton provider. So might was well write a proper LWRP and be done with it. 

This makes the code much more readable and maintainable, and it turns out to be pretty easy to do.

The LWRP correctly waits for pgs to create before completing  (so no need for the current "wait-for-pgs-creating" notify), and also correctly fires a changed event if we add any notifies in future. 

This PR works for me pretty well, but as its a big change I would like others to try bringing this up themselves before merging.  

There are some improvements that could be made in the future like: not using the converge_by and directly firing the notifies so we don't have to replicate logic in the provider. That said I still think its a solid first pass.