### PR TITLE
add cacert checking to build_bins

### DIFF
--- a/build_bins.sh
+++ b/build_bins.sh
@@ -262,9 +262,19 @@ chmod -R 755 .
 # but can't upgrade setuptools first as:
 # "/usr/bin/pip install: error: no such option: --no-use-wheel"
 if ! hash dir2pi; then
+  # auto-detect cacert.pem file and use for MITM SSL verification
+  cert="cacert.pem"
+  if [[ -e $cert ]]; then
+      echo "Using $cert as pip cert file"
+      cert="--cert $cert"
+  else
+      echo "Not using a pip cert file. If behind a MITM proxy, put a $cert in `pwd`"
+      cert=""
+  fi
+
   /usr/bin/pip install pip2pi || /bin/true
-  /usr/local/bin/pip install setuptools --no-use-wheel --upgrade
-  /usr/local/bin/pip install pip2pi
+  /usr/local/bin/pip $cert install setuptools --no-use-wheel --upgrade
+  /usr/local/bin/pip $cert install pip2pi
 fi
 
 dir2pi python


### PR DESCRIPTION
Look for a cacert.pem file in the bins file while running build_bins.sh. If there, then use it as a SSL verification cert for pip; if not, behave normally.
