### PR TITLE
Preseed ssh keys during OS installation

### DIFF
--- a/bootstrap_chef.sh
+++ b/bootstrap_chef.sh
@@ -115,5 +115,7 @@ echo "Setting up chef environment, roles, and uploading cookbooks"
 $SSH_CMD "cd $BCPC_DIR && knife environment from file environments/${CHEF_ENVIRONMENT}.json && knife role from file roles/*.json && knife cookbook upload -a -o cookbooks"
 echo "Enrolling local bootstrap node into chef"
 $SSH_CMD "cd $BCPC_DIR && ./setup_chef_bootstrap_node.sh ${IP} ${CHEF_ENVIRONMENT}"
+echo "Configuring SSH access keys for bootstrap procedure"
+$SSH_CMD "cd $BCPC_DIR && sudo ./install_bootstrap_ssh_key.sh"
 
 popd

--- a/cookbooks/bcpc/recipes/bootstrap.rb
+++ b/cookbooks/bcpc/recipes/bootstrap.rb
@@ -1,0 +1,34 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: bootstrap
+#
+# Copyright 2014, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# should extract prefix
+
+directory "/var/www/cobbler/pub/scripts" do
+    action :create
+    owner "root"
+    group "adm"
+    mode 02775
+end
+
+template "/var/www/cobbler/pub/scripts/get-ssh-keys" do
+    source "get-ssh-keys"
+    owner "root"
+    group "root"
+    mode 00755
+end

--- a/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
@@ -102,7 +102,11 @@ d-i     pkgsel/include string openssh-server
 d-i     preseed/late_command string true && \
         wget "http://$http_server:$http_port/cblr/svc/op/nopxe/system/$system_name" -O /dev/null ;\
         <% if @node['bcpc']['preseed'] && @node['bcpc']['preseed']['kernel'] %>
-        in-target apt-get install -y <%= @node['bcpc']['preseed']['kernel'] %>
+        in-target apt-get install -y <%= @node['bcpc']['preseed']['kernel'] %> ;\
         <% else %>
-        true
+        true ;\
         <% end %>
+        wget "http://$http_server:$http_port/cblr/svc/op/nopxe/system/$system_name" -O /dev/null ;\
+        in-target env no_proxy=$http_server wget "http://$http_server:$http_port/cobbler/pub/scripts/get-ssh-keys" -O /root/get-ssh-keys ;\
+        in-target chmod 0755 /root/get-ssh-keys ; in-target install -d -m0600 /root/.ssh ;\
+        in-target env no_proxy=$http_server /root/get-ssh-keys root -o /root/.ssh/authorized_keys

--- a/cookbooks/bcpc/templates/default/get-ssh-keys
+++ b/cookbooks/bcpc/templates/default/get-ssh-keys
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+hash -r
+PROG=${0##*/}
+
+export PATH=/bin:/usr/bin
+
+usage(){
+    local ret=${1:-0}
+    if [ $ret -eq 0 ] ; then
+        exec 3>&1
+    else
+        exec 3>&2
+    fi
+    cat <<EoF >&3
+${PROG} username
+
+Grabs the SSH public key for the user from a webserver
+EoF
+    exec 3>&-
+    exit ${ret}
+}
+
+error(){
+    echo "$@" >&2
+}
+
+parseopts() {
+    local short_opts="ho:"
+    local long_opts="help,output-file:"
+    local getopt_out getopt_ret
+    getopt_out=$(getopt --name "${PROG}" \
+        --options "${short_opts}" --long "${long_opts}" -- "$@" 2>/dev/null) ||
+        :
+    getopt_ret=$?
+    if [ $getopt_ret -eq 0 ]; then
+        eval set -- "${getopt_out}" ||
+        { error "Unexpected error reading usage"; usage 1; }
+    fi
+
+    local cur="" next=""
+
+    while [ $# -ne 0 ]; do
+        cur="$1" ; next="$2" ;
+        case "$cur" in
+            -h|--help) usage ;;
+            -o|--output-file) outfile="$next" ; shift  ;;
+            --) shift ; break ;;
+            *) error "$PROG: internal parser error." ; exit 2 ;;
+        esac
+        shift;
+    done
+
+    username="$1"
+    if [ -z "${username}" ] ; then usage 1 ; fi
+}
+
+baseurl=http://<%= @node['bcpc']['bootstrap']['server'] %>/cobbler/pub/keys
+outfile="-"
+parseopts "$@"
+
+wget -q -O "${outfile}" "${baseurl}/${username}"

--- a/install_bootstrap_ssh_key.sh
+++ b/install_bootstrap_ssh_key.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+hash -r
+PROG=${0##*/}
+
+usage(){
+    local ret=${1:-0}
+    if [ $ret -eq 0 ] ; then
+        exec 3>&1
+    else
+        exec 3>&2
+    fi
+    cat <<EoF >&3
+${PROG} path-to-keyfile
+EoF
+    exec 3>&-
+    exit ${ret}
+}
+
+keypath="${1:-$HOME/.ssh/id_rsa.bcpc}"
+distroot=/var/www/cobbler/pub/keys
+
+yes | ssh-keygen -N '' -f "${keypath}"
+if [ -n "${SUDO_UID}" ] ; then
+  chown "${SUDO_UID}" "${keypath}"
+fi
+
+install -D "${keypath}.pub" "${distroot}/root"

--- a/roles/BCPC-Bootstrap.json
+++ b/roles/BCPC-Bootstrap.json
@@ -7,6 +7,7 @@
       "role[Basic]",
       "recipe[bcpc::cobbler]",
       "recipe[bcpc::cobbler-centos]",
+      "recipe[bcpc::bootstrap]",
       "recipe[bcpc::ufw]"
     ],
     "description": "A bootstrap node in a BCPC cluster",


### PR DESCRIPTION
Adds mechanism to generate and authorize temporary root key for `knife bootstrap`. It should be noted that the generated key is only readable by the initial user calling `vbox_create` on the bootstrap node and it will be unauthorized during the bootstrap procedure when another key is generated/authorized. closes #380 