### PR TITLE
Routemon v2

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -221,3 +221,16 @@ default['bcpc']['protocol']['heat'] = "https"
 default['bcpc']['nova']['ram_allocation_ratio'] = 1.0
 default['bcpc']['nova']['reserved_host_memory_mb'] = 1024
 default['bcpc']['nova']['cpu_allocation_ratio'] = 2.0
+###########################################
+#
+# Routemon settings
+#
+###########################################
+#
+
+# numfixes is how many times to try and fix default routes in the mgmt
+# and storage networks when they disappear. If numfixes starts off at
+# 0, or after 'numfixes' attempts have been made, then routemon
+# subsequently only monitors and reports
+#
+default['bcpc']['routemon']['numfixes'] = 0

--- a/cookbooks/bcpc/files/default/routemon.pl
+++ b/cookbooks/bcpc/files/default/routemon.pl
@@ -37,13 +37,18 @@ sub hasdefaultroute {
 }
 
 # number of times we are allowed to fix the routes
-my $fixes = 1000;
+# default 0 => do not try at all
+my $fixes = 0;
 
 my $override = shift @ARGV;
-if ($override) {
+if ($override>0) {
     $fixes = $override;
-    myprint "Allowable fix attempts set to: $fixes\n";
 }
+
+myprint "-----------------------------------------------------\n";
+myprint "Service \"routemon\" starting ...\n";
+myprint "-----------------------------------------------------\n";
+myprint "Allowable fix attempts set to: $fixes\n";
 
 # check and retain current status of routes for comparison later
 my $mgmt_up    = hasdefaultroute ("mgmt", 1);

--- a/cookbooks/bcpc/files/default/routemon.pl
+++ b/cookbooks/bcpc/files/default/routemon.pl
@@ -25,7 +25,7 @@ sub hasdefaultroute {
     my $network = shift(@_);
     my $verbose = shift(@_);
     myprint "checking $network network\n" if "$verbose";
-    my $command = "ip route show table $network | grep -i default";
+    my $command = "ip route show table $network | grep -i '^default'";
     my $result = system("$command >/dev/null 2>&1");
     if ($result) {
         myprint "WARN: No default route in table $network\n" if "$verbose";

--- a/cookbooks/bcpc/files/default/routemon.pl
+++ b/cookbooks/bcpc/files/default/routemon.pl
@@ -42,6 +42,8 @@ my $storage = checkroute ("storage", 1);
 
 myprint "Monitoring default routes status  ...\n";
 
+my @scrollback;
+
 # monitor all IP events and after each one check to see whether the
 # default route appeared or disappeared
 open (IPEVENTS, "ip monitor all |") or die "Failed $!\n";
@@ -49,26 +51,41 @@ while (<IPEVENTS> )
 {
     my $LINE = $_;
 
+    push @scrollback, $LINE;
+
     my $currentmgmt = checkroute("mgmt",0);
     if ($currentmgmt != $mgmt) {
-	if ($currentmgmt) {
-	    myprint "Info: Default route established on mgmt network after \n $LINE\n";
-	} else {
-	    myprint "WARN: Default route disappeared on mgmt network after \n $LINE\n";
-	}
+        if ($currentmgmt) {
+            myprint "Info: Default route established on mgmt network after \n $LINE\n";
+        } else {
+            myprint "WARN: Default route disappeared on mgmt network after \n $LINE\n";
+        }
     }
     $mgmt = $currentmgmt;
 
     my $currentstorage = checkroute("storage",0);
 
     if ($currentstorage != $storage) {
-	if ($currentstorage) {
-	    myprint "Info: Default route established on storage network after \n $LINE\n";
-	} else {
-	    myprint "WARN: Default route disappeared on storage network after \n $LINE\n";
-	}
+        if ($currentstorage) {
+            myprint "Info: Default route established on storage network after \n $LINE\n";
+        } else {
+            myprint "WARN: Default route disappeared on storage network after \n $LINE\n";
+        }
     }
     $storage = $currentstorage;
+
+    if ($#scrollback >= 10) {
+        shift @scrollback;          
+    }
+
+    myprint "\n-----------------------------------------------------\n";
+
+    foreach (@scrollback) {
+        myprint "$_";
+    }
+
+    myprint "\n-----------------------------------------------------\n";
+
 }
 close IPEVENTS
 

--- a/cookbooks/bcpc/files/default/routemon.pl
+++ b/cookbooks/bcpc/files/default/routemon.pl
@@ -1,5 +1,20 @@
 #!/usr/bin/perl
 use strict;
+use warnings;
+
+sub getLoggingTime {
+
+    my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst)=localtime(time);
+    my $nice_timestamp = sprintf ( "[%04d/%02d/%02d %02d:%02d:%02d] ",
+                                   $year+1900,$mon+1,$mday,$hour,$min,$sec);
+    return $nice_timestamp;
+}
+
+# timestamped print
+sub myprint {
+    my $timestamp = getLoggingTime();
+    print "$timestamp " . "@_";
+}
 
 # subroutine to verify that the named table in param 1 has a default
 # route.
@@ -9,14 +24,14 @@ sub checkroute {
 
     my $network = shift(@_);
     my $verbose = shift(@_);
-    print "checking $network network\n" if "$verbose";
+    myprint "checking $network network\n" if "$verbose";
     my $command = "ip route show table $network | grep -i default";
     my $result = system("$command >/dev/null 2>&1");
     if ($result) {
-        print "No default route in table $network\n" if "$verbose";
+        myprint "WARN: No default route in table $network\n" if "$verbose";
         return 0;
     } else {
-        print "$network passes (has default route)\n" if "$verbose";
+        myprint "Info: $network passes (has default route)\n" if "$verbose";
         return 1;
     }
 }
@@ -25,7 +40,7 @@ sub checkroute {
 my $mgmt    = checkroute ("mgmt", 1);
 my $storage = checkroute ("storage", 1);
 
-print "Monitoring default routes status  ...\n";
+myprint "Monitoring default routes status  ...\n";
 
 # monitor all IP events and after each one check to see whether the
 # default route appeared or disappeared
@@ -37,9 +52,9 @@ while (<IPEVENTS> )
     my $currentmgmt = checkroute("mgmt",0);
     if ($currentmgmt != $mgmt) {
 	if ($currentmgmt) {
-	    print "Info: Default route established on mgmt network after \n $LINE\n";
+	    myprint "Info: Default route established on mgmt network after \n $LINE\n";
 	} else {
-	    print "WARN: Default route disappeared on mgmt network after \n $LINE\n";
+	    myprint "WARN: Default route disappeared on mgmt network after \n $LINE\n";
 	}
     }
     $mgmt = $currentmgmt;
@@ -48,9 +63,9 @@ while (<IPEVENTS> )
 
     if ($currentstorage != $storage) {
 	if ($currentstorage) {
-	    print "Info: Default route established on storage network after \n $LINE\n";
+	    myprint "Info: Default route established on storage network after \n $LINE\n";
 	} else {
-	    print "WARN: Default route disappeared on storage network after \n $LINE\n";
+	    myprint "WARN: Default route disappeared on storage network after \n $LINE\n";
 	}
     }
     $storage = $currentstorage;

--- a/cookbooks/bcpc/recipes/networking-route-test.rb
+++ b/cookbooks/bcpc/recipes/networking-route-test.rb
@@ -29,6 +29,13 @@ if node['bcpc']['enabled']['network_tests'] then
         source "routemon.conf.erb"
         owner "root"
         mode "0644"
+
+        # using a simple 'restart' here fails. Something is holding
+        # onto the command-line used to invoke routemon.pl too long so
+        # the service restarts with a stale numfixes parameter.
+        notifies :stop, "service[routemon]", :immediately
+        notifies :start, "service[routemon]", :delayed
+
     end
 
     service "routemon" do

--- a/cookbooks/bcpc/templates/default/routemon.conf.erb
+++ b/cookbooks/bcpc/templates/default/routemon.conf.erb
@@ -7,4 +7,4 @@ respawn
 
 console log
 
-exec /usr/local/bin/routemon.pl
+exec /usr/local/bin/routemon.pl <%= node['bcpc']['routemon']['numfixes']%>


### PR DESCRIPTION
This pull request significantly upgrades the "routemon" service. Previously it just attempted to log when routes in the 'mgmt' and 'storage' tables went away and what the very last event reported by "ip monitor" was.

Now when routes go away it reports the last 10 or so events. This is so that if the critical event was a couple of events ago, we stll record it.

Additionally (and optionally) routemon can attempt to actually fix the routes. This may be of use when routes in the BCPC named routing tables disappear as they sometimes do (not sure why).

For this you need to set the numfixes attribute to > 0 so for example in an environment file this could look like 

```
   "name": "Test-Laptop",
   "override_attributes": {
     "bcpc": {
+      "routemon": {
+          "numfixes": "1000"
+       },
```

When routes are "fixed" the routemon service throws away the resultant output (which is noisy) by re-running the "ip monitor" command and emptying the trace buffer of previous events. The actual fix involves simply re-running /etc/network/if-up.d/bcpc-routing