### PR TITLE
basic tpm recipe

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -46,6 +46,8 @@ default['bcpc']['enabled']['keepalived_checks'] = true
 default['bcpc']['enabled']['network_tests'] = true
 # This will enable httpd disk caching for radosgw
 default['bcpc']['enabled']['radosgw_cache'] = false
+# This will enable using TPM-based hwrngd
+default['bcpc']['enabled']['tpm'] = false
 
 # This can be either 'sql' or 'ldap' to either store identities
 # in the mysql DB or the LDAP server

--- a/cookbooks/bcpc/recipes/tpm.rb
+++ b/cookbooks/bcpc/recipes/tpm.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: tpm
+#
+# Copyright 2014, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+if node['bcpc']['enabled']['tpm'] then
+
+  include_recipe "bcpc::default"
+
+  package "rng-tools"
+  package "tpm-tools"
+  package "trousers"
+
+  service "rng-tools" do
+    action :stop
+  end
+
+  bash "enable-tpm" do
+    user "root"
+    code <<-EOH
+       if [[ ! -f /etc/default/rng-tools.orig ]]; then cp /etc/default/rng-tools /etc/default/rng-tools.orig ; fi
+       sed -i -e '/^#RNG.*tpm.*/s/^#//' /etc/default/rng-tools 
+       sed -i -e '/^#HRNGD.*null/s/^#//' /etc/default/rng-tools 
+       EOH
+  end 
+
+
+  service "rng-tools" do
+    action :start
+  end
+
+end

--- a/roles/BCPC-Worknode.json
+++ b/roles/BCPC-Worknode.json
@@ -17,7 +17,8 @@
       "recipe[bcpc::diamond]",
       "recipe[bcpc::fluentd]",
       "recipe[bcpc::zabbix-work]",
-      "recipe[bcpc::checks-work]"
+      "recipe[bcpc::checks-work]",
+      "recipe[bcpc::tpm]"
     ],
     "description": "A functional compute node in a BCPC cluster",
     "chef_type": "role",


### PR DESCRIPTION
This can enable use of a hardware based random number generator as provided by some TPM modules. Default disabled - VMs don't have this support.