### PR TITLE
Increase Horizon API_RESULT_PAGE_SIZE FROM 20 TO 128

### DIFF
--- a/cookbooks/bcpc/templates/default/horizon.local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/horizon.local_settings.py.erb
@@ -268,7 +268,7 @@ IMAGE_CUSTOM_PROPERTY_TITLES = {
 # on a single page before providing a paging element (a "more" link)
 # to paginate results.
 API_RESULT_LIMIT = 1000
-API_RESULT_PAGE_SIZE = 20
+API_RESULT_PAGE_SIZE = 128
 
 # The timezone of the server. This should correspond with the timezone
 # of your entire OpenStack installation, and hopefully be in UTC.


### PR DESCRIPTION
Increase the results displayed on the horizon UI FROM 20 to 128.  