### PR TITLE
Increase max_connections for mysql

### DIFF
--- a/cookbooks/bcpc/recipes/mysql.rb
+++ b/cookbooks/bcpc/recipes/mysql.rb
@@ -84,7 +84,7 @@ template "/etc/mysql/conf.d/wsrep.cnf" do
     source "wsrep.cnf.erb"
     mode 00644
     variables(
-        :max_connections => [get_head_nodes.length*50+get_all_nodes.length*5, 200].max,
+        :max_connections => [get_head_nodes.length*100+get_all_nodes.length*10, 200].max,
         :servers => get_head_nodes
     )
     notifies :restart, "service[mysql]", :immediately


### PR DESCRIPTION
In the newer builds, we run very close to the max_connections for mysql which can sometimes cause connection errors (when restarting lots of processes for example). This should provide ample headroom.