### PR TITLE
Turn off martian logging.

### DIFF
--- a/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
+++ b/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
@@ -40,9 +40,6 @@ net.ipv4.ip_forward=1
 # Set keepalive timeout for TCP
 net.ipv4.tcp_keepalive_time=1800
 
-# Log packets with impossible addresses for security
-net.ipv4.conf.all.log_martians = 0
-
 # Enable binding to non-local IP addresses
 net.ipv4.ip_nonlocal_bind=1
 

--- a/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
+++ b/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
@@ -41,7 +41,7 @@ net.ipv4.ip_forward=1
 net.ipv4.tcp_keepalive_time=1800
 
 # Log packets with impossible addresses for security
-net.ipv4.conf.all.log_martians = 1 
+net.ipv4.conf.all.log_martians = 0
 
 # Enable binding to non-local IP addresses
 net.ipv4.ip_nonlocal_bind=1


### PR DESCRIPTION
On a hardware deployment, we observed that some of our private network
ranges in use were considered "martian" so this caused damaging rates
of logging. This isn't a safe default, so disable.