### PR TITLE
Check get_config for nil return

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -211,6 +211,10 @@ default['bcpc']['protocol']['nova'] = "https"
 default['bcpc']['protocol']['cinder'] = "https"
 default['bcpc']['protocol']['heat'] = "https"
 
+# Hour for the cron job to run keystone_token_cleaner script which
+# runs `keystone-manage token_flush` to clean out stale tokens
+default['bcpc']['keystone_token_clean_hour'] = "2"
+
 ###########################################
 #
 #  Nova Settings

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -65,7 +65,9 @@ end
 def get_config(key)
     init_config if $dbi.nil?
     puts "------------ Fetching value for key \"#{key}\""
-    return (node['bcpc']['enabled']['encrypt_data_bag']) ? $edbi[key] : $dbi[key]
+    result = (node['bcpc']['enabled']['encrypt_data_bag']) ? $edbi[key] : $dbi[key]
+    raise "No config found for get_config(#{key})!!!" if result.nil?
+    return result
 end
 
 def get_all_nodes

--- a/cookbooks/bcpc/recipes/certs.rb
+++ b/cookbooks/bcpc/recipes/certs.rb
@@ -34,7 +34,9 @@ ruby_block "initialize-ssh-keys" do
         pubkey = "#{key.ssh_type} #{[key.to_blob].pack('m0')}"
         make_config('ssh-private-key', key.to_pem)
         make_config('ssh-public-key', pubkey)
-        if get_config('ssl-certificate').nil? then
+        begin
+            get_config('ssl-certificate')
+        rescue
             temp = %x[openssl req -config /tmp/openssl.cnf -extensions v3_req -new -x509 -passout pass:temp_passwd -newkey rsa:4096 -out /dev/stdout -keyout /dev/stdout -days 1095 -subj "/C=#{node['bcpc']['country']}/ST=#{node['bcpc']['state']}/L=#{node['bcpc']['location']}/O=#{node['bcpc']['organization']}/OU=#{node['bcpc']['region_name']}/CN=#{node['bcpc']['domain_name']}/emailAddress=#{node['bcpc']['admin_email']}"]
             make_config('ssl-private-key', %x[echo "#{temp}" | openssl rsa -passin pass:temp_passwd -out /dev/stdout])
             make_config('ssl-certificate', %x[echo "#{temp}" | openssl x509])

--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -27,7 +27,9 @@ ruby_block "initialize-keystone-config" do
         make_config('keystone-admin-token', secure_password)
         make_config('keystone-admin-user', "admin")
         make_config('keystone-admin-password', secure_password)
-        if get_config('keystone-pki-certificate').nil? then
+        begin
+            get_config('keystone-pki-certificate')
+        rescue
             temp = %x[openssl req -new -x509 -passout pass:temp_passwd -newkey rsa:2048 -out /dev/stdout -keyout /dev/stdout -days 1095 -subj "/C=#{node['bcpc']['country']}/ST=#{node['bcpc']['state']}/L=#{node['bcpc']['location']}/O=#{node['bcpc']['organization']}/OU=#{node['bcpc']['region_name']}/CN=keystone.#{node['bcpc']['domain_name']}/emailAddress=#{node['bcpc']['admin_email']}"]
             make_config('keystone-pki-private-key', %x[echo "#{temp}" | openssl rsa -passin pass:temp_passwd -out /dev/stdout])
             make_config('keystone-pki-certificate', %x[echo "#{temp}" | openssl x509])

--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -156,12 +156,6 @@ ruby_block "keystone-add-test-admin-role" do
     end
 end
 
-ruby_block "generate-random-time" do
-    block do
-        make_config('keystone-token-clean-hour', rand(24))
-    end
-end
-
 template "/usr/local/bin/keystone_token_cleaner" do
     source "keystone.token_cleaner.erb"
     owner "root"
@@ -172,5 +166,5 @@ end
 cron "keystone-token-flush" do
   action :create
   command "/usr/local/bin/keystone_token_cleaner"
-  hour get_config('keystone-token-clean-hour')
+  hour node['bcpc']['keystone_token_clean_hour']
 end

--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -133,21 +133,27 @@ ruby_block "initialize-keystone-test-config" do
     end
 end
 
-bash "keystone-create-test-tenants" do
-    code <<-EOH
-        . /root/adminrc
-        export KEYSTONE_ADMIN_TENANT_ID=`keystone tenant-get "#{node['bcpc']['admin_tenant']}" | grep " id " | awk '{print $4}'`
-        keystone user-create --name #{get_config('keystone-test-user')} --tenant-id $KEYSTONE_ADMIN_TENANT_ID --pass  #{get_config('keystone-test-password')} --enabled true
-    EOH
-    only_if ". /root/keystonerc; . /root/adminrc; keystone user-get #{get_config('keystone-test-user')} 2>&1 | grep -e '^No user'"
+ruby_block "keystone-create-test-tenants" do
+    block do
+        system ". /root/keystonerc; . /root/adminrc; keystone user-get #{get_config('keystone-test-user')} 2>&1 | grep -e '^No user'"
+        if $?.success? then
+            %x[ . /root/adminrc
+                export KEYSTONE_ADMIN_TENANT_ID=`keystone tenant-get "#{node['bcpc']['admin_tenant']}" | grep " id " | awk '{print $4}'`
+                keystone user-create --name #{get_config('keystone-test-user')} --tenant-id $KEYSTONE_ADMIN_TENANT_ID --pass  #{get_config('keystone-test-password')} --enabled true
+            ]
+        end
+    end
 end
 
-bash "keystone-add-test-admin-role" do
-    code <<-EOH
-        . /root/adminrc
-        keystone user-role-add --user #{get_config('keystone-test-user')} --role '#{node['bcpc']['admin_role']}' --tenant '#{node['bcpc']['admin_tenant']}'
-    EOH
-    not_if ". /root/keystonerc; . /root/adminrc; keystone user-role-list --user #{get_config('keystone-test-user')} --tenant '#{node['bcpc']['admin_tenant']}' 2>&1 | grep '#{node['bcpc']['admin_role']}'"
+ruby_block "keystone-add-test-admin-role" do
+    block do
+        system ". /root/keystonerc; . /root/adminrc; keystone user-role-list --user #{get_config('keystone-test-user')} --tenant '#{node['bcpc']['admin_tenant']}' 2>&1 | grep '#{node['bcpc']['admin_role']}'"
+        if $?.success? then
+            %x[ . /root/adminrc
+                keystone user-role-add --user #{get_config('keystone-test-user')} --role '#{node['bcpc']['admin_role']}' --tenant '#{node['bcpc']['admin_tenant']}'
+            ]
+        end
+    end
 end
 
 ruby_block "generate-random-time" do

--- a/cookbooks/bcpc/recipes/mysql.rb
+++ b/cookbooks/bcpc/recipes/mysql.rb
@@ -27,6 +27,7 @@ ruby_block "initialize-mysql-config" do
         make_config('mysql-galera-password', secure_password)
         make_config('mysql-check-user', "check")
         make_config('mysql-check-password', secure_password)
+        make_config('mysql-phpmyadmin-password', secure_password)
     end
 end
 

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -224,9 +224,16 @@ cookbook_file "/usr/local/bin/nova-service-restart" do
   mode "00755"
 end
 
+template "/usr/local/bin/nova-service-restart-wrapper" do
+    source "nova-service-restart-wrapper.erb"
+    owner "root"
+    group "root"
+    mode 00700
+end
+
 cron "restart-nova-kludge" do
   action :create
-  command "/usr/local/bin/nova-service-restart -i #{node['bcpc']['management']['vip']} -u #{get_config('mysql-nova-user')} -p '#{get_config('mysql-nova-password')}'  > /dev/null 2>&1"
+  command "/usr/local/bin/nova-service-restart-wrapper"
   minute '*/5'   # run this every 5 mins
 end
 

--- a/cookbooks/bcpc/templates/default/nova-service-restart-wrapper.erb
+++ b/cookbooks/bcpc/templates/default/nova-service-restart-wrapper.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#
+# Invokes nova-service-restart with the creds for this cluster 
+#
+
+/usr/local/bin/nova-service-restart -i <%=node['bcpc']['management']['vip']%> -u <%=get_config('mysql-nova-user')%> -p '<%=get_config('mysql-nova-password')%>'  > /dev/null 2>&1

--- a/roles/BCPC-Headnode.json
+++ b/roles/BCPC-Headnode.json
@@ -29,8 +29,8 @@
       "recipe[bcpc::elasticsearch]",
       "recipe[bcpc::kibana]",
       "recipe[bcpc::zabbix-head]",
-      "recipe[bcpc::checks-head]",
-      "role[BCPC-Worknode]"
+      "role[BCPC-Worknode]",
+      "recipe[bcpc::checks-head]"
     ],
     "description": "A highly-available head node in a BCPC cluster",
     "chef_type": "role",

--- a/roles/BCPC-Worknode.json
+++ b/roles/BCPC-Worknode.json
@@ -17,8 +17,8 @@
       "recipe[bcpc::diamond]",
       "recipe[bcpc::fluentd]",
       "recipe[bcpc::zabbix-work]",
-      "recipe[bcpc::checks-work]",
-      "recipe[bcpc::tpm]"
+      "recipe[bcpc::tpm]",
+      "recipe[bcpc::checks-work]"
     ],
     "description": "A functional compute node in a BCPC cluster",
     "chef_type": "role",


### PR DESCRIPTION
To prevent timing bugs in the future, I added a quick check to raise an exception when get_config is about to return nil. As it turns out, this is a very good lint test and it turned up a number of bugs that needed to be fixed in order to build a new cluster. So, this PR includes all those fixes too. It's probably a lot easier to review this commit-by-commit instead of all at once.