### PR TITLE
Make fpm fetch the correct version of requests-aws

### DIFF
--- a/cookbooks/bcpc/files/default/build_bins.sh
+++ b/cookbooks/bcpc/files/default/build_bins.sh
@@ -254,10 +254,7 @@ FILES="zabbix-agent.tar.gz zabbix-server.tar.gz $FILES"
 
 # Get some python libs 
 if [ ! -f python-requests-aws_0.1.5_all.deb ]; then
-    ccurl http://pypi.python.org/packages/source/r/requests-aws/requests-aws-0.1.5.tar.gz
-    tar zxf requests-aws-0.1.5.tar.gz
-    fpm -s python -t deb requests-aws
-    rm -rf requests-aws-0.1.5 requests-aws-0.1.5.tar.gz
+    fpm -s python -t deb -v 0.1.5 requests-aws
 fi
 FILES="python-requests-aws_0.1.5_all.deb $FILES"
 


### PR DESCRIPTION
As it stands, fpm will get the latest version of python-requests-aws (0.1.6) and build that into a .deb, ignoring the source just downloaded. Asking fpm for a specific version will make it download it. The URL fpm uses is identical to the one passed to ccurl.