### PR TITLE
Stop creating junk files.

### DIFF
--- a/cluster-check.sh
+++ b/cluster-check.sh
@@ -233,7 +233,7 @@ if [[ -f cluster.txt ]]; then
                     # Apache can be wedged even when apparently
                     # running, so perform an operational test instead
                     # of relying on upstart
-                    wget http://$HOST -t1 -T1 >/dev/null 2>&1
+                    wget http://$HOST -O- -t1 -T1 >/dev/null 2>&1
                     if [[ "$?" != 0 ]]; then
                         STAT=" !! not responding !!"
                     else


### PR DESCRIPTION
The apache funtional test here creates junk files index.html. To fix,
get the file to stdout and redirect to /dev/null