### PR TITLE
safety checks for routemon

### DIFF
--- a/cookbooks/bcpc/templates/default/routemon.conf.erb
+++ b/cookbooks/bcpc/templates/default/routemon.conf.erb
@@ -7,4 +7,9 @@ respawn
 
 console log
 
-exec /usr/local/bin/routemon.pl <%= node['bcpc']['routemon']['numfixes']%>
+exec /usr/local/bin/routemon.pl \
+<%= node['bcpc']['routemon']['numfixes']%> \
+<%= node['bcpc']['management']['interface']%> \
+<%= node['bcpc']['storage']['interface']%> \
+<%= node['bcpc']['floating']['interface']%>
+


### PR DESCRIPTION
If any BCPC network interface is down, routemon will disable itself
for 10 seconds and then restart. This stops it meddling if machine is
coming up, going down or having a problem.