### PR TITLE
Remove python dependency from vbox_create.sh.

### DIFF
--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -31,8 +31,7 @@ CLUSTER_VM_CPUs=2
 CLUSTER_VM_DRIVE_SIZE=20480
 
 VBOX_DIR="`dirname ${BASH_SOURCE[0]}`/vbox"
-P=`python -c "import os.path; print os.path.abspath(\"${VBOX_DIR}/\")"`
-
+P="$(cd $VBOX_DIR ; /bin/pwd)" || exit
 
 # from EVW packer branch
 vbm_import() {


### PR DESCRIPTION
Use shell builtin cd and /bin/pwd instead to determine fully qualified path.
Fixes #466.