### PR TITLE
Disable glance caching

### DIFF
--- a/cookbooks/bcpc/templates/default/glance-api.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-api.conf.erb
@@ -671,7 +671,7 @@ signing_dir = /var/lib/glance
 # service name removed. For example, if your paste section name is
 # [pipeline:glance-api-keystone], you would configure the flavor below
 # as 'keystone'.
-flavor = keystone+cachemanagement
+flavor = keystone
 
 [store_type_location_strategy]
 # The scheme list to use to get store preference order. The scheme must be


### PR DESCRIPTION
This is a recommended change to prevent glance from caching a copy of each uploaded image on the glance server since we're using RBD backend (caching doesn't help and causes large disk I/O spikes when uploading new images). More details available [here](http://www.sebastien-han.fr/blog/2014/11/03/openstack-glance-disable-cache-management-while-using-ceph-rbd/).