### PR TITLE
Limit Apache's dependency on Ceph recipe to only apt repo

### DIFF
--- a/cookbooks/bcpc/recipes/apache2.rb
+++ b/cookbooks/bcpc/recipes/apache2.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe "bcpc::ceph-common"
+include_recipe "bcpc::ceph-apt"
 
 package "apache2" do
     action :upgrade


### PR DESCRIPTION
This is required in order to reuse current Apache recipe verbatim on nodes that do not run Ceph (i.e. monitoring nodes proposed in https://github.com/bloomberg/chef-bcpc/pull/461/).