### PR TITLE
Turn on s3 keystone auth

### DIFF
--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -45,4 +45,11 @@
     rgw enable ops log = false
     rgw enable usage log = false
     debug rgw = 0/0
+    rgw keystone url = <%=node['bcpc']['management']['vip']%>:35358
+    rgw keystone admin token = <%=get_config('keystone-admin-token')%>
+    rgw keystone accepted roles = admin Member _member_
+    rgw keystone token cache size = 1000
+    rgw keystone revocation interval = 1200
+    rgw s3 auth use keystone = true
+
 

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -91,6 +91,16 @@ listen keystone-admin
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:35357 check inter 5s rise 1 fall 1" %>
 <% end -%>
 
+listen keystone-admin-http
+  bind <%=node['bcpc']['management']['vip']%>:35358
+  balance source
+  option tcplog
+  option httpchk GET /
+  http-check expect status 300
+<% @servers.each do |server| -%>
+  <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:35357 check inter 5s rise 1 fall 1" %>
+<% end -%>
+
 listen glance-api
   bind <%=node['bcpc']['management']['vip']%>:9292 <%= (node['bcpc']['protocol']['glance'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source

--- a/cookbooks/bcpc/templates/default/keystone-default_catalog.templates.erb
+++ b/cookbooks/bcpc/templates/default/keystone-default_catalog.templates.erb
@@ -9,6 +9,11 @@ catalog.<%=node['bcpc']['region_name']%>.identity.adminURL = <%=node['bcpc']['pr
 catalog.<%=node['bcpc']['region_name']%>.identity.internalURL = <%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['management']['vip']%>:5000/v2.0
 catalog.<%=node['bcpc']['region_name']%>.identity.name = Identity Service
 
+catalog.<%=node['bcpc']['region_name']%>.object-store.publicURL = http://<%=node['bcpc']['floating']['vip']%>/swift/v1
+catalog.<%=node['bcpc']['region_name']%>.object-store.adminURL = http://<%=node['bcpc']['floating']['vip']%>/swift/v1
+catalog.<%=node['bcpc']['region_name']%>.object-store.internalURL = http://<%=node['bcpc']['floating']['vip']%>/swift/v1
+catalog.<%=node['bcpc']['region_name']%>.object-store.name = Object Store Service
+
 catalog.<%=node['bcpc']['region_name']%>.image.publicURL = <%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1
 catalog.<%=node['bcpc']['region_name']%>.image.adminURL = <%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1
 catalog.<%=node['bcpc']['region_name']%>.image.internalURL = <%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1


### PR DESCRIPTION

# Problem Statement 

I'm taking at a look at AUTH in BCPC. As part of that I revisited the way the we do s3 auth. Currently, RGW is a separate provisioning. This just causes headaches when trying to disable users and is prob just "a bad thing". 

# Solution 

Enable s3 authing against keystone.  Rados will use the keystone "ec2" creds to auth access to buckets. This has several implications for operations of a bcpc cluster
1. s3 buckets are now tied to *tenancies* rather than *users*. This mirrors the AWS functionality better. 
2. The openstack object store dashboard is also enabled, its pretty but prob useless for anything more than just new users poking around. 
3. When provisioning users you must create an ec2 cred for them like so:
```
root@bcpc-vm1:~# keystone ec2-credentials-create
+-----------+----------------------------------+
|  Property |              Value               |
+-----------+----------------------------------+
|   access  | 62633e68d8a8424aa7ff5d538bc086aa |
|   secret  | 264c9b78b7544c3cbdf663eaad491d63 |
| tenant_id | 83ca199b8d954e44a7e47c2ed78ff236 |
|  trust_id |                                  |
|  user_id  | a0d4633a027c4f7283435ea76dc7079e |
+-----------+----------------------------------+
```

As the ubuntu ceph packages dont seem to support nss (I'll check with the ceph guys) out the box. I enabled a second keystone http lb in haproxy. The iptables rules block access to this outside the cluster. Talked to @pchandra about this, will let him comment below if he likes.  In the future, we might just want to build ceph and enable this feature so RGW can speak ssl to keystone. 

# Notes on upgrades

This *is* a change that can be chefed in to an existing 3.x cluster. Note, that users in RGW created before this change will still work.  