### PR TITLE
Enable sub domain bucket format for RGW

### DIFF
--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -454,6 +454,7 @@ if node['bcpc']['enabled']['dns'] then
                 if not $?.success? then
                     %x[ mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['pdns']} <<-EOH
                             INSERT INTO records_static (domain_id, name, content, type, ttl, prio) VALUES ((SELECT id FROM domains WHERE name='#{node['bcpc']['domain_name']}'),'#{static}.#{node['bcpc']['domain_name']}','#{node['bcpc']['floating']['vip']}','A',300,NULL);
+                            INSERT INTO records_static (domain_id, name, content, type, ttl, prio) VALUES ((SELECT id FROM domains WHERE name='#{node[:bcpc][:domain_name]}'),'*.#{static}.#{node[:bcpc][:domain_name]}','#{static}.#{node[:bcpc][:domain_name]}','CNAME',300,NULL);
                     ]
                 end
             end

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -45,4 +45,4 @@
     rgw enable ops log = false
     rgw enable usage log = false
     debug rgw = 0/0
-
+    rgw dns name = s3.<%=node['bcpc']['domain_name'] %>


### PR DESCRIPTION
Most 3rd part s3 tools expect the url format: `<bucketname>.s3.bcpc.example.com`. I kept having to hack in the old calling format `s3.bcpc.example.com/<bucketname`. This PR fixes that. 

I tested that I was still able to use the old "path bucket names" and the subdomain bucket names side by side. I also checked it works over http and https. 

fixes #152 

:warning: This will not be a straight "chef in" but will require the pdns database to be dropped and reloaded by chef OR just the `*.s3.bcpc.example.com` CNAME records added by hand to the pdns.recrods_static table. 
