### PR TITLE
Unify keystone-admin backends in haproxy

### DIFF
--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -81,20 +81,18 @@ listen keystone-api
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:5000 check inter 5s rise 1 fall 1" %>
 <% end -%>
 
-listen keystone-admin
+frontend keystone-admin
   bind <%=node['bcpc']['management']['vip']%>:35357 <%= (node['bcpc']['protocol']['keystone'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
-  balance source
   option tcplog
-  option httpchk GET /
-  http-check expect status 300
-<% @servers.each do |server| -%>
-  <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:35357 check inter 5s rise 1 fall 1" %>
-<% end -%>
+  default_backend keystone-admin-backend
 
-listen keystone-admin-http
+frontend keystone-admin-httponly
   bind <%=node['bcpc']['management']['vip']%>:35358
-  balance source
   option tcplog
+  default_backend keystone-admin-backend
+
+backend keystone-admin-backend
+  balance source
   option httpchk GET /
   http-check expect status 300
 <% @servers.each do |server| -%>


### PR DESCRIPTION
Pretty straightforward and avoids double-checking the backends