### PR TITLE
Add hooks to restart radosgw daemon

### DIFF
--- a/cookbooks/bcpc/recipes/ceph-rgw.rb
+++ b/cookbooks/bcpc/recipes/ceph-rgw.rb
@@ -54,6 +54,7 @@ bash "write-client-radosgw-key" do
         chmod 644 /var/lib/ceph/radosgw/ceph-radosgw.gateway/keyring
     EOH
     not_if "test -f /var/lib/ceph/radosgw/ceph-radosgw.gateway/keyring"
+    notifies :restart, "service[radosgw-all]", :delayed
 end
 
 rgw_optimal_pg = power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['rgw']['replicas']*node['bcpc']['ceph']['rgw']['portion']/100)
@@ -95,6 +96,7 @@ file "/var/www/s3gw.fcgi" do
     group "root"
     mode 0755
     content "#!/bin/sh\n exec /usr/bin/radosgw -c /etc/ceph/ceph.conf -n client.radosgw.gateway"
+    notifies :restart, "service[radosgw-all]", :immediately
 end
 
 template "/etc/apache2/sites-available/radosgw" do


### PR DESCRIPTION
I needed to add these in order to get the `radosgw` process to come up correctly on new cluster builds. Without it, I was seeing that the package would install it and upstart would try to start it, but then it would die since it wasn't set up yet (directories and keys and such), and then our recipes would never call for a restart. Manual restart cured it, this should just automate that.