### PR TITLE
Maybe a fix for get_all_nodes

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -84,7 +84,7 @@ def search_nodes(key, value)
 end
 
 def get_all_nodes
-    results = search(:node, "recipes:bcpc\\:\\:default AND chef_environment:#{node.chef_environment}")
+    results = search(:node, "recipes:bcpc AND chef_environment:#{node.chef_environment}")
     if results.any? { |x| x['hostname'] == node['hostname'] }
         results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
     else


### PR DESCRIPTION
With the code that specifies `search(:node, "recipes:bcpc\\:\\:default ...")`, I would consistently get back an empty set from the search (which broke a bunch of things including giving me rabbit split-brain on new cluster builds). I verified the return using `shef -c /etc/chef/client.rb` on the local machine and also checked that `search(:node, "recipes:bcpc")` would return the right thing. Admittedly, I was testing on an older version of chef (10), but the fix seemed to be to simply specify `bcpc` instead of `bcpc::default`. If this is just an artifact of old chef versions, just close this PR and I'll upgrade my clients in my test setup.