### PR TITLE
Proposed fix for https://github.com/bloomberg/chef-bcpc/issues/496

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -62,6 +62,13 @@ def make_config(key, value)
     end
 end
 
+def config_defined(key)
+    init_config if $dbi.nil?
+    puts "------------ Checking if key \"#{key}\" is defined"
+    result = (node['bcpc']['enabled']['encrypt_data_bag']) ? $edbi[key] : $dbi[key]
+    return !result.nil?
+end
+
 def get_config(key)
     init_config if $dbi.nil?
     puts "------------ Fetching value for key \"#{key}\""

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -48,7 +48,6 @@
 
 <% if config_defined('keystone-admin-token') %>
     rgw keystone url = <%=node['bcpc']['management']['vip']%>:35358
-
     rgw keystone admin token = <%=get_config('keystone-admin-token')%>
     rgw keystone accepted roles = admin Member _member_
     rgw keystone token cache size = 1000

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -45,10 +45,14 @@
     rgw enable ops log = false
     rgw enable usage log = false
     debug rgw = 0/0
+
+<% if config_defined('keystone-admin-token') %>
     rgw keystone url = <%=node['bcpc']['management']['vip']%>:35358
+
     rgw keystone admin token = <%=get_config('keystone-admin-token')%>
     rgw keystone accepted roles = admin Member _member_
     rgw keystone token cache size = 1000
     rgw keystone revocation interval = 1200
     rgw s3 auth use keystone = true
+<% end %>
     rgw dns name = s3.<%=node['bcpc']['domain_name'] %>


### PR DESCRIPTION
Wait to define keystone-auth'd rgw until the keystone-admin-token is defined. Since we need to chef all nodes at least twice to achieve consistency, this will converge upon the intended configuration - the first node during run 2, all others during run 1.