### PR TITLE
Put all VNC console connections over SSL

### DIFF
--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -88,6 +88,20 @@ end
 #    not_if "test -f /usr/lib/python2.7/dist-packages/nova/nova-sql.patch"
 #end
 
+template "/etc/nova/ssl-bcpc.pem" do
+    source "ssl-bcpc.pem.erb"
+    owner "nova"
+    group "nova"
+    mode 00644
+end
+
+template "/etc/nova/ssl-bcpc.key" do
+    source "ssl-bcpc.key.erb"
+    owner "nova"
+    group "nova"
+    mode 00600
+end
+
 directory "/var/lib/nova/.ssh" do
     owner "nova"
     group "nova"

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -99,8 +99,11 @@ libvirt_inject_partition=-2
 libvirt_live_migration_flag="VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRATE_LIVE,VIR_MIGRATE_PERSIST_DEST"
 
 # Nova VNC settings
+ssl_only=True
+key=/etc/nova/ssl-bcpc.key
+cert=/etc/nova/ssl-bcpc.pem
 novnc_enabled=True
-novncproxy_base_url=http://<%=node['bcpc']['management']['ip']%>:6080/vnc_auto.html
+novncproxy_base_url=https://<%=node['bcpc']['management']['ip']%>:6080/vnc_auto.html
 vncserver_proxyclient_address=127.0.0.1
 novncproxy_host=<%=node['bcpc']['management']['ip']%>
 memcached_servers=<%=node['bcpc']['management']['vip']%>:11211


### PR DESCRIPTION
This also has the side benefit of re-enabling the embedded console in the 'Console' tab of an instance's detailed view (as opposed to having to click the `Click here to show only console`).