### PR TITLE
Override CPU and RAM allocation numbers to be useful on a laptop.

### DIFF
--- a/environments/Test-Laptop-VMware.json
+++ b/environments/Test-Laptop-VMware.json
@@ -11,6 +11,10 @@
         "ssd_disks" : [ "sdd", "sde" ],
         "chooseleaf" : "host"
       },
+      "nova" : {
+        "ram_allocation_ratio" : "20.0",
+        "cpu_allocation_ratio": "20.0"
+      },
       "domain_name" : "bcpc.example.com",
       "management": {
         "vip" : "10.0.100.5",

--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -15,6 +15,10 @@
         "ssd_disks" : [ "sdd", "sde" ],
         "chooseleaf" : "host"
       },
+      "nova" : {
+        "ram_allocation_ratio" : "20.0",
+        "cpu_allocation_ratio": "20.0"
+      },
       "domain_name" : "bcpc.example.com",
       "management": {
         "vip" : "10.0.100.5",


### PR DESCRIPTION
This makes a laptop useful when creating VMs by upping from a CPU/RAM allocation from 2.0/1.0 to 20.0/20.0.