### PR TITLE
Add a flag to enable/disable ip rules from permitting VMs talking to APIs

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -50,6 +50,8 @@ default['bcpc']['enabled']['network_tests'] = true
 default['bcpc']['enabled']['radosgw_cache'] = false
 # This will enable using TPM-based hwrngd
 default['bcpc']['enabled']['tpm'] = false
+# This will block VMs from talking to the management network
+default['bcpc']['enabled']['secure_fixed_networks'] = true
 
 # This can be either 'sql' or 'ldap' to either store identities
 # in the mysql DB or the LDAP server

--- a/cookbooks/bcpc/templates/default/bcpc-routing.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-routing.erb
@@ -38,10 +38,12 @@ ip rule del pref 0
 
 # Prevent any fixed network traffic from seeing our management and storage
 # by skipping past the local table and using the main routing table
+<% if node['bcpc']['enabled']['secure_fixed_networks'] -%>
 ip rule del pref 100
 ip rule del pref 200
 ip rule add from <%=@node["bcpc"]["fixed"]["cidr"]%> to <%=@node["bcpc"]["management"]["cidr"]%> pref 100 table main
 ip rule add from <%=@node["bcpc"]["fixed"]["cidr"]%> to <%=@node["bcpc"]["storage"]["cidr"]%> pref 200 table main
+<% end -%>
 
 # Let traffic to/from fixed IPs route via main table
 ip rule del pref 9000

--- a/cookbooks/bcpc/templates/default/bcpc-routing.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-routing.erb
@@ -36,9 +36,9 @@ ip rule add from all lookup local pref 1000
 ip rule del pref 0
 ip rule del pref 0
 
+<% if node['bcpc']['enabled']['secure_fixed_networks'] -%>
 # Prevent any fixed network traffic from seeing our management and storage
 # by skipping past the local table and using the main routing table
-<% if node['bcpc']['enabled']['secure_fixed_networks'] -%>
 ip rule del pref 100
 ip rule del pref 200
 ip rule add from <%=@node["bcpc"]["fixed"]["cidr"]%> to <%=@node["bcpc"]["management"]["cidr"]%> pref 100 table main

--- a/environments/Test-Laptop-VMware.json
+++ b/environments/Test-Laptop-VMware.json
@@ -2,6 +2,9 @@
   "name": "Test-Laptop-VMware",
   "override_attributes": {
     "bcpc": {
+      "enabled" : {
+        "secure_fixed_networks" : false
+      },
       "keepalived" : {
         "checks" : false
       },

--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -7,7 +7,8 @@
         "logging": true,
         "monitoring": true,
         "metrics": true,
-        "dns": true
+        "dns": true,
+        "secure_fixed_networks" : false
       },
       "ceph": {
         "pgp_auto_adjust" : true,


### PR DESCRIPTION
Without this patch, VMs can't talk to the API endpoints on a laptop.

(In a production environment, it is expected that you'd have a fully routable network that has appropriate ACLing to permit VMs to talk to the API endpoints...or not.)