### PR TITLE
Modified for handle large number of requests.

### DIFF
--- a/cookbooks/bcpc/templates/default/apache-radosgw.conf.erb
+++ b/cookbooks/bcpc/templates/default/apache-radosgw.conf.erb
@@ -4,6 +4,19 @@
 #
 ################################################
 
+# Changed MaxKeepAliveRequest from 100 to 0 to allow for maximum limit.
+MaxKeepAliveRequests 0
+
+# The below mpm_prefork_module settings can change based on environment resources/needs.
+<IfModule mpm_prefork_module>
+    ServerLimit          500
+    StartServers         250
+    MinSpareServers       50
+    MaxSpareServers      200
+    MaxClients           500
+    MaxRequestsPerChild    0
+</IfModule>
+
 NameVirtualHost <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw']}"%>
 
 


### PR DESCRIPTION
Modified the ServerLimit to 500 and increased the number of start up server/processes so as to keep new instances from being created with large load. These values can be lowered for simple installs or laptop installs.