### PR TITLE
Ignore IntellIJ project files/directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .rake_test_cache
 .chef/
+.idea/
+*.iml
 id_rsa
 secret_file
 cookbooks/apt/


### PR DESCRIPTION
Adding `.idea/` and `*.iml` to `.gitignore` so that IntelliJ/RubyMine project files aren't checked in.