### PR TITLE
Cpufreq scaling governor control

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -273,6 +273,22 @@ default['bcpc']['routemon']['numfixes'] = 0
 # If set to 0, max_connections for MySQL on heads will default to an
 # auto-calculated value.
 default['bcpc']['mysql-head']['max_connections'] = 0
+
+###########################################
+#
+# CPU governor settings
+#
+###########################################
+#
+# Available options: conservative, ondemand, userspace, powersave, performance
+# Different states (cribbed from https://wiki.archlinux.org/index.php/CPU_frequency_scaling):
+# - ondemand: Dynamically switch between CPU(s) available if at 95% cpu load
+# - performance: Run the cpu at max frequency
+# - conservative: Dynamically switch between CPU(s) available if at 75% load
+# - powersave: Run the cpu at the minimum frequency
+# - userspace: Run the cpu at user specified frequencies
+default['bcpc']['cpupower']['governor'] = "ondemand"
+
 ###########################################
 #
 # Elasticsearch settings

--- a/cookbooks/bcpc/providers/cpupower.rb
+++ b/cookbooks/bcpc/providers/cpupower.rb
@@ -1,0 +1,58 @@
+#
+# Cookbook Name:: bcpc
+# Provider:: cpupower
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def whyrun_supported?
+  true
+end
+
+action :set do
+  # get the current CPU governor on CPU0 (considered representative)
+  base_cpu_dir = ::File.join('/', 'sys', 'devices', 'system', 'cpu')
+  cpu0_gov_file = ::File.join(base_cpu_dir, 'cpu0', 'cpufreq', 'scaling_governor')
+  cpu0_all_govs_file = ::File.join(base_cpu_dir, 'cpu0', 'cpufreq', 'scaling_available_governors')
+  
+  unless ::File.exists?(cpu0_gov_file)
+    Chef::Log.warn("\nCurrent platform hardware/OS combination does not support CPU scaling governors")
+    next
+  end
+  
+  current_governor = ::File.read(cpu0_gov_file).chomp
+  # next out of the block here so that Chef records the resource as being up to date if no change is needed
+  next if current_governor == @new_resource.governor
+
+  unless ::File.exists?(cpu0_all_govs_file)
+    raise("Your system is seriously broken because you have a CPU scaling governor active but no available list of scaling governors")
+  end
+  
+  available_governors = ::File.read(cpu0_all_govs_file).chomp.split
+  
+  unless available_governors.include?(@new_resource.governor)
+    raise("Requested governor #{@new_resource.governor} not an available CPU scaling governor (available governors: #{available_governors.join(', ')})")
+  end
+  
+  converge_by("set CPU scaling governor to #{@new_resource.governor}") do
+    cpus = Dir.entries(base_cpu_dir).select { |entry| entry =~ /cpu[0-9]+/ }
+    cpu_governor_paths = cpus.map { |cpu| ::File.join(base_cpu_dir, cpu, 'cpufreq', 'scaling_governor') }
+    cpu_governor_paths.each do |cpu_governor_path|
+      ::File.open(cpu_governor_path, 'w') do |governor|
+        governor.write @new_resource.governor
+      end
+    end
+  end
+end

--- a/cookbooks/bcpc/recipes/cpupower.rb
+++ b/cookbooks/bcpc/recipes/cpupower.rb
@@ -1,0 +1,38 @@
+
+# Cookbook Name:: bcpc
+# Recipe:: cpupower
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# CPU frequency governor utils
+template "/etc/default/cpufrequtils" do
+  source "cpufrequtils.erb"
+  owner "root"
+  group "root"
+  mode 00644
+  notifies :restart, "service[cpufrequtils]", :delayed
+end
+
+package "cpufrequtils"
+
+# this service conflicts with the bcpc_cpupower provider, so ensure it is off
+service "cpufrequtils" do
+  action [:disable, :stop]
+end
+
+bcpc_cpupower "cpu governor" do
+  governor node['bcpc']['cpupower']['governor']
+end

--- a/cookbooks/bcpc/resources/cpupower.rb
+++ b/cookbooks/bcpc/resources/cpupower.rb
@@ -1,0 +1,24 @@
+
+# Cookbook Name:: bcpc
+# Resource:: cpupower
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :set
+default_action :set
+
+attribute :name, :name_attribute => true, :kind_of => String, :required => true
+attribute :governor, :kind_of => String, :required => true

--- a/cookbooks/bcpc/templates/default/cpufrequtils.erb
+++ b/cookbooks/bcpc/templates/default/cpufrequtils.erb
@@ -1,0 +1,5 @@
+<% if node['bcpc']['enabled']['cpu_governor'] -%>
+ENABLE=true
+<% else %>
+ENABLE=false
+<% end -%>

--- a/roles/Basic.json
+++ b/roles/Basic.json
@@ -7,6 +7,7 @@
       "recipe[ubuntu]",
       "recipe[bcpc::packages-common]",
       "recipe[bcpc::packages-debugging]",
+      "recipe[bcpc::cpupower]",
       "recipe[ntp]",
       "recipe[chef-client::delete_validation]",
       "recipe[chef-client::config]"


### PR DESCRIPTION
This PR is difficult to test because the vCPUs in VirtualBox do not have cpufreq enabled, and thusly the recipe just skips over them. I tested each part in isolation on my desktop outside of Chef and verified that the behavior is as intended (it reads the current and available governors correctly and writes the requested governor mode out).