### PR TITLE
Parameterize Graphite metrics default retention

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -297,6 +297,7 @@ default['bcpc']['cpupower']['governor'] = "ondemand"
 #
 # Package version to pin to
 default['bcpc']['elasticsearch']['version'] = '1.5.1'
+
 ###########################################
 #
 # Kibana settings
@@ -305,3 +306,13 @@ default['bcpc']['elasticsearch']['version'] = '1.5.1'
 #
 # Package version to pin to
 default['bcpc']['kibana']['version'] = '4.0.2'
+
+###########################################
+#
+# Graphite settings
+#
+###########################################
+#
+# Default retention rates
+# http://graphite.readthedocs.org/en/latest/config-carbon.html#storage-schemas-conf
+default['bcpc']['graphite']['retention'] = '60s:1d'

--- a/cookbooks/bcpc/templates/default/carbon-storage-schemas.conf.erb
+++ b/cookbooks/bcpc/templates/default/carbon-storage-schemas.conf.erb
@@ -10,6 +10,6 @@
 pattern = ^carbon\.
 retentions = 60:90d
 
-[default_1min_for_1day]
+[default]
 pattern = .*
-retentions = 60s:1d
+retentions = <%=node['bcpc']['graphite']['retention']%>


### PR DESCRIPTION
It will likely be desirable to override value in non-VM (larger) deployments.