### PR TITLE
delete default PowerDNS config file to avoid conflict

### DIFF
--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -216,6 +216,13 @@ end
     end
   end
 
+  # this file is added by the pdns-server package and will conflict with
+  # our config file
+  file "/etc/powerdns/pdns.d/pdns.local.gmysql.conf" do
+    action :delete
+    notifies :restart, "service[pdns]", :delayed
+  end
+
   template "/etc/powerdns/pdns.d/pdns.local.gmysql" do
     source "pdns.local.gmysql.erb"
     owner "pdns"


### PR DESCRIPTION
This file conflicts with our config and causes PowerDNS to get Very Sad.