### PR TITLE
Reconfigure Kibana to use local Elasticsearch node instead of VIP

### DIFF
--- a/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
@@ -70,7 +70,7 @@ backend graphite-web-backend
 
 backend kibana-backend
   balance source
-  option httpchk GET /
+  option httpchk HEAD /elasticsearch/ HTTP/1.1\r\nHost: <%=node['bcpc']['management']['monitoring']['vip']%>
   http-check expect status 200
   reqrep ^([^\ :]*)\ /kibana/(.*) \1\ /\2
 <% @servers.each do |server| -%>
@@ -116,5 +116,5 @@ listen elasticsearch <%=node['bcpc']['management']['monitoring']['vip']%>:9200
   option httpchk GET /
   http-check expect status 200
 <% @servers.each do |server| -%>
- <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:9200 check inter 5s rise 1 fall 1" %>
+  <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:9200 check inter 5s rise 1 fall 1" %>
 <% end -%>

--- a/cookbooks/bcpc/templates/default/kibana-config.yml.erb
+++ b/cookbooks/bcpc/templates/default/kibana-config.yml.erb
@@ -5,7 +5,7 @@ port: 5601
 host: "0.0.0.0"
 
 # The Elasticsearch instance to use for all your queries.
-elasticsearch_url: "http://<%=node['bcpc']['management']['monitoring']['vip']%>:9200"
+elasticsearch_url: "http://<%=node['bcpc']['management']['ip']%>:9200"
 
 # preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
 # then the host you use to connect to *this* Kibana instance will be sent.


### PR DESCRIPTION
Use of VIP here is unnecessary since Elasticsearch nodes also act as coordinators.