### PR TITLE
bootstrap apt mirrors

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -144,7 +144,7 @@ default['bcpc']['floating']['available_subnet'] = "192.168.43.128/25"
 default['bcpc']['floating']['interface'] = nil
 # if 'interface' is a VLAN interface, specifying a parent allows MTUs
 # to be set properly
-default['bcpc']['floating']['interface-parent'] = nil
+default['bcpc']['floating']['interface-parent'] nil
 
 default['bcpc']['fixed']['cidr'] = "1.127.0.0/16"
 default['bcpc']['fixed']['vlan_start'] = "1000"
@@ -316,3 +316,23 @@ default['bcpc']['kibana']['version'] = '4.0.2'
 # Default retention rates
 # http://graphite.readthedocs.org/en/latest/config-carbon.html#storage-schemas-conf
 default['bcpc']['graphite']['retention'] = '60s:1d'
+#
+###########################################
+#
+# defaults for the bcpc.bootstrap settings
+#
+###########################################
+#
+# A value of nil means to let the Ubuntu installer work it out - it
+# will try to find the nearest one. However the selected mirror is
+# often slow.
+default['bcpc']['bootstrap']['mirror'] = nil
+#
+# if you do specify a mirror, you can adjust the file path that comes
+# after the hostname in the URL here
+default['bcpc']['bootstrap']['mirror_path'] = "/ubuntu"
+#
+# worked example for the columbia mirror mentioned above which has a
+# non-standard path
+#default['bcpc']['bootstrap']['mirror']      = "mirror.cc.columbia.edu"
+#default['bcpc']['bootstrap']['mirror_path'] = "/pub/linux/ubuntu/archive"

--- a/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
@@ -74,10 +74,10 @@ d-i     apt-setup/local0/repository string \
           deb http://apt.opscode.com/chef precise-0.10 main
 <% else %>
 d-i     mirror/country string manual
-d-i     mirror/http/hostname string <%= @node['bcpc']['bootstrap']['mirror'] %>
-d-i     mirror/http/directory string /ubuntu
-d-i     apt-setup/security_host <%= @node['bcpc']['bootstrap']['mirror'] %>
-d-i     apt-setup/security_path string /ubuntu
+d-i     mirror/http/hostname string    <%= @node['bcpc']['bootstrap']['mirror'] %>
+d-i     mirror/http/directory string   <%= @node['bcpc']['bootstrap']['mirror_path'] %>
+d-i     apt-setup/security_host        <%= @node['bcpc']['bootstrap']['mirror'] %>
+d-i     apt-setup/security_path string <%= @node['bcpc']['bootstrap']['mirror_path'] %>
 d-i     apt-setup/local0/comment string OpsCode Repo
 d-i     apt-setup/local0/repository string \
           deb http://<%= @node['bcpc']['bootstrap']['mirror'] %>/chef precise-0.10 main


### PR DESCRIPTION
- Provide more general support of non-default apt mirrors for booting
- Fixes https://github.com/bloomberg/chef-bcpc/issues/561