### PR TITLE
Replace execute resources with mount resource

### DIFF
--- a/cookbooks/bcpc/recipes/ceph-work.rb
+++ b/cookbooks/bcpc/recipes/ceph-work.rb
@@ -80,16 +80,8 @@ ruby_block "reap-ceph-disks-from-dead-servers" do
     end
 end
 
-execute "cephfs-in-fstab" do
-    command <<-EOH
-        echo "-- /mnt fuse.ceph-fuse rw,nosuid,nodev,noexec,noatime,noauto 0 2" >> /etc/fstab
-    EOH
-    not_if "cat /etc/fstab | grep ceph-fuse"
-end
-
-execute "cephfs-mount-fs" do
-    command <<-EOH
-        mount -a
-    EOH
-    not_if "mount | grep ceph-fuse"
+mount 'cephfs' do
+  fstype 'fuse.ceph-fuse'
+  options %w(rw nosuid nodev noexec noatime noauto)
+  action [:mount, :enable]
 end

--- a/cookbooks/bcpc/recipes/ceph-work.rb
+++ b/cookbooks/bcpc/recipes/ceph-work.rb
@@ -81,7 +81,7 @@ ruby_block "reap-ceph-disks-from-dead-servers" do
 end
 
 mount 'cephfs' do
-  fstype 'fuse.ceph-fuse'
-  options %w(rw nosuid nodev noexec noatime noauto)
-  action [:mount, :enable]
+    fstype 'fuse.ceph-fuse'
+    options %w(rw nosuid nodev noexec noatime noauto)
+    action [:mount, :enable]
 end


### PR DESCRIPTION
The `mount` resource is idempotent, and will only act as-needed.

* Less code
* Doesn’t execute every time
* Just as functional