### PR TITLE
Stable/release 5.x cpufreq add ondemand value tuning

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -305,13 +305,15 @@ default['bcpc']['mysql-head']['max_connections'] = 0
 ###########################################
 #
 # Available options: conservative, ondemand, userspace, powersave, performance
-# Different states (cribbed from https://wiki.archlinux.org/index.php/CPU_frequency_scaling):
-# - ondemand: Dynamically switch between CPU(s) available if at 95% cpu load
-# - performance: Run the cpu at max frequency
-# - conservative: Dynamically switch between CPU(s) available if at 75% load
-# - powersave: Run the cpu at the minimum frequency
-# - userspace: Run the cpu at user specified frequencies
+# Review documentation at https://www.kernel.org/doc/Documentation/cpu-freq/governors.txt
 default['bcpc']['cpupower']['governor'] = "ondemand"
+default['bcpc']['cpupower']['ondemand_ignore_nice_load'] = nil
+default['bcpc']['cpupower']['ondemand_io_is_busy'] = nil
+default['bcpc']['cpupower']['ondemand_powersave_bias'] = nil
+default['bcpc']['cpupower']['ondemand_sampling_down_factor'] = nil
+default['bcpc']['cpupower']['ondemand_sampling_rate'] = nil
+default['bcpc']['cpupower']['ondemand_sampling_rate_min'] = nil
+default['bcpc']['cpupower']['ondemand_up_threshold'] = nil
 
 ###########################################
 #

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -312,7 +312,6 @@ default['bcpc']['cpupower']['ondemand_io_is_busy'] = nil
 default['bcpc']['cpupower']['ondemand_powersave_bias'] = nil
 default['bcpc']['cpupower']['ondemand_sampling_down_factor'] = nil
 default['bcpc']['cpupower']['ondemand_sampling_rate'] = nil
-default['bcpc']['cpupower']['ondemand_sampling_rate_min'] = nil
 default['bcpc']['cpupower']['ondemand_up_threshold'] = nil
 
 ###########################################

--- a/cookbooks/bcpc/providers/cpupower.rb
+++ b/cookbooks/bcpc/providers/cpupower.rb
@@ -26,15 +26,43 @@ action :set do
   base_cpu_dir = ::File.join('/', 'sys', 'devices', 'system', 'cpu')
   cpu0_gov_file = ::File.join(base_cpu_dir, 'cpu0', 'cpufreq', 'scaling_governor')
   cpu0_all_govs_file = ::File.join(base_cpu_dir, 'cpu0', 'cpufreq', 'scaling_available_governors')
-  
+  ondemand_tunable_dir = ::File.join(base_cpu_dir, 'cpufreq', 'ondemand')
+
   unless ::File.exists?(cpu0_gov_file)
     Chef::Log.warn("\nCurrent platform hardware/OS combination does not support CPU scaling governors")
     next
   end
-  
-  current_governor = ::File.read(cpu0_gov_file).chomp
-  # next out of the block here so that Chef records the resource as being up to date if no change is needed
-  next if current_governor == @new_resource.governor
+
+  # since we have several resources that may be changed, iterate through them and get their values, pushing
+  # any that need updated onto this list
+  unconverged_resources = []
+
+  begin
+    current_governor = ::File.read(cpu0_gov_file).chomp
+    unconverged_resources.push('governor') if current_governor != @new_resource.governor
+  rescue Errno::ENOENT
+    Chef::Log.warn("\nThis system is misconfigured and is missing a scaling governor at #{cpu0_gov_file}, please configure the power profile in the BIOS for OS control")
+  end
+
+  %w{ondemand_ignore_nice_load
+     ondemand_io_is_busy
+     ondemand_powersave_bias
+     ondemand_sampling_down_factor
+     ondemand_sampling_rate
+     ondemand_sampling_rate_min
+     ondemand_up_threshold}.each do |ondemand_tunable|
+    tunable = @new_resource.send(ondemand_tunable)
+    unless tunable.nil? or tunable.empty?
+      tunable_file_name = ondemand_tunable.gsub(/^ondemand_/, '')
+      tunable_path = ::File.join(ondemand_tunable_dir, tunable_file_name)
+      begin
+        current_tunable = ::File.read(tunable_path).chomp
+        unconverged_resources.push(ondemand_tunable) if current_tunable.to_i != tunable
+      rescue Error::ENOENT
+        Chef::Log.warn("\nThis system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
+      end
+    end
+  end
 
   unless ::File.exists?(cpu0_all_govs_file)
     raise("Your system is seriously broken because you have a CPU scaling governor active but no available list of scaling governors")
@@ -45,13 +73,43 @@ action :set do
   unless available_governors.include?(@new_resource.governor)
     raise("Requested governor #{@new_resource.governor} not an available CPU scaling governor (available governors: #{available_governors.join(', ')})")
   end
-  
+
+  # next out of the block here so that Chef records the resource as being up to date if no changes are needed
+  next unless unconverged_resources.length > 0
+
   converge_by("set CPU scaling governor to #{@new_resource.governor}") do
+    # set CPU scaling governor, failing nicely if system configuration is weird and one or more governors are missing (complete with helpful error message!)
     cpus = Dir.entries(base_cpu_dir).select { |entry| entry =~ /cpu[0-9]+/ }
     cpu_governor_paths = cpus.map { |cpu| ::File.join(base_cpu_dir, cpu, 'cpufreq', 'scaling_governor') }
     cpu_governor_paths.each do |cpu_governor_path|
-      ::File.open(cpu_governor_path, 'w') do |governor|
-        governor.write @new_resource.governor
+      begin
+        ::File.open(cpu_governor_path, 'w') do |governor|
+          governor.write @new_resource.governor
+        end
+      rescue Errno::ENOENT
+        Chef::Log.warn("\nThis system is misconfigured and is missing a scaling governor at #{cpu_governor_path}, please configure the power profile in the BIOS for OS control")
+      end
+    end
+
+    # walk through the ondemand tunable attributes, setting any that are provided in the resource and ignoring those that are not
+    %w{ondemand_ignore_nice_load
+       ondemand_io_is_busy
+       ondemand_powersave_bias
+       ondemand_sampling_down_factor
+       ondemand_sampling_rate
+       ondemand_sampling_rate_min
+       ondemand_up_threshold}.each do |ondemand_tunable|
+      tunable = @new_resource.send(ondemand_tunable)
+      unless tunable.nil? or tunable.empty?
+        tunable_file_name = ondemand_tunable.gsub(/^ondemand_/, '')
+        tunable_path = ::File.join(ondemand_tunable_dir, tunable_file_name)
+        begin
+          ::File.open(tunable_path, 'w') do |f|
+            f.write tunable.to_s
+          end
+        rescue Error::ENOENT
+          Chef::Log.warn("\nThis system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
+        end
       end
     end
   end

--- a/cookbooks/bcpc/providers/cpupower.rb
+++ b/cookbooks/bcpc/providers/cpupower.rb
@@ -44,6 +44,7 @@ action :set do
     Chef::Log.warn("\nThis system is misconfigured and is missing a scaling governor at #{cpu0_gov_file}, please configure the power profile in the BIOS for OS control")
   end
 
+  # TODO: short-circuit out here if ondemand_tunable_dir doesn't exist)
   %w{ondemand_ignore_nice_load
      ondemand_io_is_busy
      ondemand_powersave_bias
@@ -92,6 +93,7 @@ action :set do
     end
 
     # walk through the ondemand tunable attributes, setting any that are provided in the resource and ignoring those that are not
+    # TODO: short-circuit out here if ondemand_tunable_dir doesn't exist)
     %w{ondemand_ignore_nice_load
        ondemand_io_is_busy
        ondemand_powersave_bias

--- a/cookbooks/bcpc/providers/cpupower.rb
+++ b/cookbooks/bcpc/providers/cpupower.rb
@@ -44,37 +44,45 @@ action :set do
     Chef::Log.warn("\nThis system is misconfigured and is missing a scaling governor at #{cpu0_gov_file}, please configure the power profile in the BIOS for OS control")
   end
 
-  # TODO: short-circuit out here if ondemand_tunable_dir doesn't exist)
-  %w{ondemand_ignore_nice_load
-     ondemand_io_is_busy
-     ondemand_powersave_bias
-     ondemand_sampling_down_factor
-     ondemand_sampling_rate
-     ondemand_sampling_rate_min
-     ondemand_up_threshold}.each do |ondemand_tunable|
-    tunable = @new_resource.send(ondemand_tunable)
-    unless tunable.nil? or tunable.empty?
-      tunable_file_name = ondemand_tunable.gsub(/^ondemand_/, '')
-      tunable_path = ::File.join(ondemand_tunable_dir, tunable_file_name)
-      begin
-        current_tunable = ::File.read(tunable_path).chomp
-        unconverged_resources.push(ondemand_tunable) if current_tunable.to_i != tunable
-      rescue Error::ENOENT
-        Chef::Log.warn("\nThis system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
+  sampling_rate_min_val = nil
+  if ::Dir.exists?(ondemand_tunable_dir)
+    %w{ondemand_ignore_nice_load
+       ondemand_io_is_busy
+       ondemand_powersave_bias
+       ondemand_sampling_down_factor
+       ondemand_sampling_rate
+       ondemand_up_threshold}.each do |ondemand_tunable|
+      tunable = @new_resource.send(ondemand_tunable)
+      unless tunable.nil?
+        tunable_file_name = ondemand_tunable.gsub(/^ondemand_/, '')
+        tunable_path = ::File.join(ondemand_tunable_dir, tunable_file_name)
+        begin
+          current_tunable = ::File.read(tunable_path).chomp.to_i
+          unconverged_resources.push(ondemand_tunable) if current_tunable != tunable
+        rescue Error::ENOENT
+          Chef::Log.warn("\nThis system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
+        end
       end
     end
+    # also attempt to record the value of sampling_rate_min because sampling_rate cannot be set lower than that, so that
+    # we can provide a warning if the requested value of sampling_rate is not possible
+    srm_file = ::File.join(ondemand_tunable_dir, 'sampling_rate_min')
+    sampling_rate_min_val = ::File.read(srm_file).to_i if ::File.exists?(srm_file)
+  else
+    Chef::Log.warn("\nThis system is misconfigured and is missing the directory for ondemand tunables (#{ondemand_tunable_dir})")
   end
+
+  Chef::Log.debug("Converging #{unconverged_resources.join(', ')}")
 
   unless ::File.exists?(cpu0_all_govs_file)
     raise("Your system is seriously broken because you have a CPU scaling governor active but no available list of scaling governors")
   end
   
   available_governors = ::File.read(cpu0_all_govs_file).chomp.split
-  
   unless available_governors.include?(@new_resource.governor)
     raise("Requested governor #{@new_resource.governor} not an available CPU scaling governor (available governors: #{available_governors.join(', ')})")
   end
-
+  
   # next out of the block here so that Chef records the resource as being up to date if no changes are needed
   next unless unconverged_resources.length > 0
 
@@ -91,28 +99,39 @@ action :set do
         Chef::Log.warn("\nThis system is misconfigured and is missing a scaling governor at #{cpu_governor_path}, please configure the power profile in the BIOS for OS control")
       end
     end
+  end
 
-    # walk through the ondemand tunable attributes, setting any that are provided in the resource and ignoring those that are not
-    # TODO: short-circuit out here if ondemand_tunable_dir doesn't exist)
+  # walk through the ondemand tunable attributes, setting any that are provided in the resource and ignoring those that are not
+  # TODO: short-circuit out here if ondemand_tunable_dir doesn't exist)
+  if ::Dir.exists?(ondemand_tunable_dir)
     %w{ondemand_ignore_nice_load
        ondemand_io_is_busy
        ondemand_powersave_bias
        ondemand_sampling_down_factor
        ondemand_sampling_rate
-       ondemand_sampling_rate_min
        ondemand_up_threshold}.each do |ondemand_tunable|
       tunable = @new_resource.send(ondemand_tunable)
-      unless tunable.nil? or tunable.empty?
-        tunable_file_name = ondemand_tunable.gsub(/^ondemand_/, '')
-        tunable_path = ::File.join(ondemand_tunable_dir, tunable_file_name)
-        begin
-          ::File.open(tunable_path, 'w') do |f|
-            f.write tunable.to_s
-          end
-        rescue Error::ENOENT
-          Chef::Log.warn("\nThis system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
+      # if setting sampling_rate, do a sanity check against the value of sampling_rate_min that was recorded earlier
+      # (can be allowed to try to converge anyway, the kernel will just silently reject it)
+      if ondemand_tunable == 'ondemand_sampling_rate' and not sampling_rate_min_val.nil?
+        if sampling_rate_min_val > tunable
+          Chef::Log.warn("Requested value of #{tunable} for sampling_rate is higher than sampling_rate_min of #{sampling_rate_min_val}")
         end
       end
-    end
-  end
-end
+
+      unless tunable.nil?
+        converge_by("set #{ondemand_tunable} to #{tunable}") do
+          tunable_file_name = ondemand_tunable.gsub(/^ondemand_/, '')
+          tunable_path = ::File.join(ondemand_tunable_dir, tunable_file_name)
+          begin
+            ::File.open(tunable_path, 'w') do |f|
+              f.write(tunable.to_s)
+            end
+          rescue Errno::ENOENT
+            Chef::Log.warn("\nThis system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
+          end # begin
+        end # converge_by
+      end # unless
+    end # ondemand.each
+  end # if dir exists
+end # action

--- a/cookbooks/bcpc/recipes/cpupower.rb
+++ b/cookbooks/bcpc/recipes/cpupower.rb
@@ -34,5 +34,12 @@ service "cpufrequtils" do
 end
 
 bcpc_cpupower "cpu governor" do
-  governor node['bcpc']['cpupower']['governor']
+  governor                      node['bcpc']['cpupower']['governor']
+  ondemand_ignore_nice_load     node['bcpc']['cpupower']['ondemand_ignore_nice_load']
+  ondemand_io_is_busy           node['bcpc']['cpupower']['ondemand_io_is_busy']
+  ondemand_powersave_bias       node['bcpc']['cpupower']['ondemand_powersave_bias']
+  ondemand_sampling_down_factor node['bcpc']['cpupower']['ondemand_sampling_down_factor']
+  ondemand_sampling_rate        node['bcpc']['cpupower']['ondemand_sampling_rate']
+  ondemand_sampling_rate_min    node['bcpc']['cpupower']['ondemand_sampling_rate_min']
+  ondemand_up_threshold         node['bcpc']['cpupower']['ondemand_up_threshold']
 end

--- a/cookbooks/bcpc/recipes/cpupower.rb
+++ b/cookbooks/bcpc/recipes/cpupower.rb
@@ -40,6 +40,5 @@ bcpc_cpupower "cpu governor" do
   ondemand_powersave_bias       node['bcpc']['cpupower']['ondemand_powersave_bias']
   ondemand_sampling_down_factor node['bcpc']['cpupower']['ondemand_sampling_down_factor']
   ondemand_sampling_rate        node['bcpc']['cpupower']['ondemand_sampling_rate']
-  ondemand_sampling_rate_min    node['bcpc']['cpupower']['ondemand_sampling_rate_min']
   ondemand_up_threshold         node['bcpc']['cpupower']['ondemand_up_threshold']
 end

--- a/cookbooks/bcpc/resources/cpupower.rb
+++ b/cookbooks/bcpc/resources/cpupower.rb
@@ -22,3 +22,10 @@ default_action :set
 
 attribute :name, :name_attribute => true, :kind_of => String, :required => true
 attribute :governor, :kind_of => String, :required => true
+attribute :ondemand_ignore_nice_load, :kind_of => Integer, :default => nil
+attribute :ondemand_io_is_busy, :kind_of => Integer, :default => nil
+attribute :ondemand_powersave_bias, :kind_of => Integer, :default => nil
+attribute :ondemand_sampling_down_factor, :kind_of => Integer, :default => nil
+attribute :ondemand_sampling_rate, :kind_of => Integer, :default => nil
+attribute :ondemand_sampling_rate_min, :kind_of => Integer, :default => nil
+attribute :ondemand_up_threshold, :kind_of => Integer, :default => nil

--- a/cookbooks/bcpc/resources/cpupower.rb
+++ b/cookbooks/bcpc/resources/cpupower.rb
@@ -27,5 +27,4 @@ attribute :ondemand_io_is_busy, :kind_of => Integer, :default => nil
 attribute :ondemand_powersave_bias, :kind_of => Integer, :default => nil
 attribute :ondemand_sampling_down_factor, :kind_of => Integer, :default => nil
 attribute :ondemand_sampling_rate, :kind_of => Integer, :default => nil
-attribute :ondemand_sampling_rate_min, :kind_of => Integer, :default => nil
 attribute :ondemand_up_threshold, :kind_of => Integer, :default => nil


### PR DESCRIPTION
This PR extends the capabilities of the cpupower provider to also manage individual tunables.