### PR TITLE
Add support for bootstrap-specific apt mirror when using Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,17 +6,23 @@
 # See http://www.vagrantup.com/ for info on Vagrant.
 
 $local_environment = "Test-Laptop"
-$local_mirror = nil
-#$local_mirror = "10.0.100.4"
+$local_mirror = ENV["BOOTSTRAP_APT_MIRROR"]
 
 if $local_mirror.nil?
   $repos_script = <<EOH
 EOH
 else
+  puts "Configuring inline provisioner with local apt mirror for bootstrap"
   $repos_script = <<EOH
-    sed -i s/archive.ubuntu.com/#{$local_mirror}/g /etc/apt/sources.list
-    sed -i s/security.ubuntu.com/#{$local_mirror}/g /etc/apt/sources.list
-    sed -i s/^deb-src/\#deb-src/g /etc/apt/sources.list
+#!/bin/bash
+hash -r
+install -d -m0755 -g adm /var/log/vagrant
+exec &>>/var/log/vagrant/provision.log
+date --rfc-3339=s
+set -x
+sed -i s/archive.ubuntu.com/#{$local_mirror}/g /etc/apt/sources.list
+sed -i s/security.ubuntu.com/#{$local_mirror}/g /etc/apt/sources.list
+sed -i s/^deb-src/\#deb-src/g /etc/apt/sources.list
 EOH
 end
 

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -299,7 +299,7 @@ ip=${2-10.0.100.3}
     vagrant ssh -c "test -f /etc/default/grub.ucf-dist && sudo mv /etc/default/grub.ucf-dist /etc/default/grub" || true
     # Duplicate what d-i's apt-setup generators/50mirror does when set in preseed
     if [ -n "$http_proxy" ]; then
-      if ! vagrant ssh -c "grep -z Acquire::http::Proxy /etc/apt/apt.conf"; then
+      if ! vagrant ssh -c "grep -z '^Acquire::http::Proxy ' /etc/apt/apt.conf"; then
         vagrant ssh -c "echo 'Acquire::http::Proxy \"$http_proxy\";' | sudo tee -a /etc/apt/apt.conf"
       fi
 

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -25,6 +25,9 @@ export BOOTSTRAP_VM_VRAM=16
 # instructions on using an apt-mirror towards the end of bootstrap.md)
 # -- Vagrant VMs do not use this size --
 #BOOTSTRAP_VM_DRIVE_SIZE=120480
+# Use this if you intend to use an apt-mirror as a source during bootstrap
+# server bring-up. Note this is an address, not url
+#export BOOTSTRAP_APT_MIRROR=10.0.100.2
 
 # Cluster VM Defaults
 CLUSTER_VM_MEM=2560


### PR DESCRIPTION
Leverage an existing apt mirror for a marginally faster build.