### PR TITLE
In Kilo, glance settings must now be in a separate config section.

### DIFF
--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -105,8 +105,6 @@ novncproxy_host=<%=node['bcpc']['management']['ip']%>
 
 # Glance settings
 image_service=nova.image.glance.GlanceImageService
-glance_api_servers=<%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292
-glance_api_insecure=True
 
 # Cloudpipe
 vpn_image_id=<%=get_config('glance-cloudpipe-uuid')%>
@@ -165,3 +163,7 @@ signing_dir = /var/lib/nova
 
 [conductor]
 workers=<%=node['bcpc']['nova']['workers']%>
+
+[glance]
+api_servers=<%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292
+api_insecure=True


### PR DESCRIPTION
(Otherwise, VMs can't launch on worker nodes as cinder tries to talk to
glance on the local IP - which doesn't exist.)