### PR TITLE
Fixes #573 - patches Nova networking to not use the same DHCP server

### DIFF
--- a/cookbooks/bcpc/files/default/nova-network-dhcp-server.patch
+++ b/cookbooks/bcpc/files/default/nova-network-dhcp-server.patch
@@ -1,0 +1,24 @@
+diff --git a/nova/network/manager.py b/nova/network/manager.py
+index 3e8e8b1..832fd1b 100644
+--- a/nova/network/manager.py
++++ b/nova/network/manager.py
+@@ -1351,13 +1351,15 @@ class NetworkManager(manager.Manager):
+                 else:
+                     net.gateway = current
+                     current += 1
+-                if not dhcp_server:
+-                    dhcp_server = net.gateway
++                if dhcp_server:
++                    subnet_dhcp_server = dhcp_server
++                else:
++                    subnet_dhcp_server = net.gateway
+                 net.dhcp_start = current
+                 current += 1
+-                if str(net.dhcp_start) == dhcp_server:
++                if str(net.dhcp_start) == subnet_dhcp_server:
+                     net.dhcp_start = current
+-                net.dhcp_server = dhcp_server
++                net.dhcp_server = subnet_dhcp_server
+                 extra_reserved.append(str(net.dhcp_server))
+                 extra_reserved.append(str(net.gateway))
+

--- a/cookbooks/bcpc/recipes/nova-setup.rb
+++ b/cookbooks/bcpc/recipes/nova-setup.rb
@@ -20,6 +20,37 @@
 include_recipe "bcpc::keystone"
 include_recipe "bcpc::nova-head"
 
+#  _   _  ____ _  __   __  ____   _  _____ ____ _   _
+# | | | |/ ___| | \ \ / / |  _ \ / \|_   _/ ___| | | |
+# | | | | |  _| |  \ V /  | |_) / _ \ | || |   | |_| |
+# | |_| | |_| | |___| |   |  __/ ___ \| || |___|  _  |
+#  \___/ \____|_____|_|   |_| /_/   \_\_| \____|_| |_|
+# this patch resolves OpenStack issue #1456321 and BCPC issue #573 -
+# fixes DHCP server assignment so that each fixed IP subnet gets its gateway
+# address as its DHCP server by default instead of all subnets getting the
+# gateway of the lowest subnet
+cookbook_file "/tmp/nova-network-dhcp-server.patch" do
+    source "nova-network-dhcp-server.patch"
+    owner "root"
+    mode 00644
+end
+
+bash "patch-for-nova-network-dhcp-server" do
+    user "root"
+    code <<-EOH
+       cd /usr/lib/python2.7/dist-packages
+       patch -p1 < /tmp/nova-network-dhcp-server.patch
+       rv=$?
+       if [ $rv -ne 0 ]; then
+         echo "Error applying patch ($rv) - aborting!"
+         exit $rv
+       fi
+       cp /tmp/nova-network-dhcp-server.patch .
+    EOH
+    not_if "test -f /usr/lib/python2.7/dist-packages/nova-network-dhcp-server.patch"
+    notifies :restart, "service[nova-api]", :immediately
+end
+
 bash "nova-default-secgroup" do
     user "root"
     code <<-EOH


### PR DESCRIPTION
This fixes bug #573, where when creating multiple subnets via nova-manage, the DHCP server for all of them would be the gateway IP for the first subnet in the range.