### PR TITLE
changing default domain for Test-Laptop to local.lan

### DIFF
--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -21,7 +21,7 @@
         "cpu_allocation_ratio": "20.0",
         "nova_single_cpu": true
       },
-      "domain_name" : "bcpc.example.com",
+      "domain_name" : "local.lan",
       "management": {
         "vip" : "10.0.100.5",
         "interface" : "eth0",


### PR DESCRIPTION
This is a trivial change and one I think we all agreed on making, but probably forgot to change in master because we had all edited our own environments locally.