### PR TITLE
Clean up Chef run output

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -29,7 +29,7 @@ end
 
 def init_config
     if not Chef::DataBag.list.key?('configs')
-        puts "************ Creating data_bag \"configs\""
+        Chef::Log.info("************ Creating data_bag \"configs\"")
         bag = Chef::DataBag.new
         bag.name("configs")
         bag.save
@@ -37,14 +37,14 @@ def init_config
     begin
         $dbi = Chef::DataBagItem.load('configs', node.chef_environment)
         $edbi = Chef::EncryptedDataBagItem.load('configs', node.chef_environment) if node['bcpc']['enabled']['encrypt_data_bag']
-        puts "============ Loaded existing data_bag_item \"configs/#{node.chef_environment}\""
+        Chef::Log.info("============ Loaded existing data_bag_item \"configs/#{node.chef_environment}\"")
     rescue
         $dbi = Chef::DataBagItem.new
         $dbi.data_bag('configs')
         $dbi.raw_data = { 'id' => node.chef_environment }
         $dbi.save
         $edbi = Chef::EncryptedDataBagItem.load('configs', node.chef_environment) if node['bcpc']['enabled']['encrypt_data_bag']
-        puts "++++++++++++ Created new data_bag_item \"configs/#{node.chef_environment}\""
+        Chef::Log.info("++++++++++++ Created new data_bag_item \"configs/#{node.chef_environment}\"")
     end
 end
 
@@ -54,24 +54,24 @@ def make_config(key, value)
         $dbi[key] = (node['bcpc']['enabled']['encrypt_data_bag']) ? Chef::EncryptedDataBagItem.encrypt_value(value, Chef::EncryptedDataBagItem.load_secret) : value
         $dbi.save
         $edbi = Chef::EncryptedDataBagItem.load('configs', node.chef_environment) if node['bcpc']['enabled']['encrypt_data_bag']
-        puts "++++++++++++ Creating new item with key \"#{key}\""
+        Chef::Log.info("++++++++++++ Creating new item with key \"#{key}\"")
         return value
     else
-        puts "============ Loaded existing item with key \"#{key}\""
+        Chef::Log.info("============ Loaded existing item with key \"#{key}\"")
         return (node['bcpc']['enabled']['encrypt_data_bag']) ? $edbi[key] : $dbi[key]
     end
 end
 
 def config_defined(key)
     init_config if $dbi.nil?
-    puts "------------ Checking if key \"#{key}\" is defined"
+    Chef::Log.info("------------ Checking if key \"#{key}\" is defined")
     result = (node['bcpc']['enabled']['encrypt_data_bag']) ? $edbi[key] : $dbi[key]
     return !result.nil?
 end
 
 def get_config(key)
     init_config if $dbi.nil?
-    puts "------------ Fetching value for key \"#{key}\""
+    Chef::Log.info("------------ Fetching value for key \"#{key}\"")
     result = (node['bcpc']['enabled']['encrypt_data_bag']) ? $edbi[key] : $dbi[key]
     raise "No config found for get_config(#{key})!!!" if result.nil?
     return result

--- a/cookbooks/bcpc/providers/cpupower.rb
+++ b/cookbooks/bcpc/providers/cpupower.rb
@@ -29,7 +29,7 @@ action :set do
   ondemand_tunable_dir = ::File.join(base_cpu_dir, 'cpufreq', 'ondemand')
 
   unless ::File.exists?(cpu0_gov_file)
-    Chef::Log.warn("\nCurrent platform hardware/OS combination does not support CPU scaling governors")
+    Chef::Log.warn("Current platform hardware/OS combination does not support CPU scaling governors")
     next
   end
 
@@ -41,7 +41,7 @@ action :set do
     current_governor = ::File.read(cpu0_gov_file).chomp
     unconverged_resources.push('governor') if current_governor != @new_resource.governor
   rescue Errno::ENOENT
-    Chef::Log.warn("\nThis system is misconfigured and is missing a scaling governor at #{cpu0_gov_file}, please configure the power profile in the BIOS for OS control")
+    Chef::Log.warn("This system is misconfigured and is missing a scaling governor at #{cpu0_gov_file}, please configure the power profile in the BIOS for OS control")
   end
 
   sampling_rate_min_val = nil
@@ -60,7 +60,7 @@ action :set do
           current_tunable = ::File.read(tunable_path).chomp.to_i
           unconverged_resources.push(ondemand_tunable) if current_tunable != tunable
         rescue Error::ENOENT
-          Chef::Log.warn("\nThis system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
+          Chef::Log.warn("This system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
         end
       end
     end
@@ -69,7 +69,7 @@ action :set do
     srm_file = ::File.join(ondemand_tunable_dir, 'sampling_rate_min')
     sampling_rate_min_val = ::File.read(srm_file).to_i if ::File.exists?(srm_file)
   else
-    Chef::Log.warn("\nThis system is misconfigured and is missing the directory for ondemand tunables (#{ondemand_tunable_dir})")
+    Chef::Log.warn("This system is misconfigured and is missing the directory for ondemand tunables (#{ondemand_tunable_dir})")
   end
 
   Chef::Log.debug("Converging #{unconverged_resources.join(', ')}")
@@ -96,7 +96,7 @@ action :set do
           governor.write @new_resource.governor
         end
       rescue Errno::ENOENT
-        Chef::Log.warn("\nThis system is misconfigured and is missing a scaling governor at #{cpu_governor_path}, please configure the power profile in the BIOS for OS control")
+        Chef::Log.warn("This system is misconfigured and is missing a scaling governor at #{cpu_governor_path}, please configure the power profile in the BIOS for OS control")
       end
     end
   end
@@ -128,7 +128,7 @@ action :set do
               f.write(tunable.to_s)
             end
           rescue Errno::ENOENT
-            Chef::Log.warn("\nThis system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
+            Chef::Log.warn("This system is misconfigured and is missing the ondemand scaling governor tunable #{tunable_file_name}")
           end # begin
         end # converge_by
       end # unless

--- a/cookbooks/bcpc/recipes/ceph-head.rb
+++ b/cookbooks/bcpc/recipes/ceph-head.rb
@@ -38,6 +38,11 @@ ruby_block "add-ceph-mon-hints" do
                 "add_bootstrap_peer_hint #{server['bcpc']['storage']['ip']}:6789"
         end
     end
+    # not_if checks to see if all head node IPs are in the mon list
+    not_if {
+      mon_list = %x[ceph mon stat]
+      get_head_nodes.collect{ |x| x['bcpc']['storage']['ip'] }.map{ |ip| mon_list.include? ip }.uniq == [true]
+    }
 end
 
 ruby_block "wait-for-mon-quorum" do

--- a/cookbooks/bcpc/recipes/cinder.rb
+++ b/cookbooks/bcpc/recipes/cinder.rb
@@ -58,17 +58,18 @@ end
 
 ruby_block "cinder-database-creation" do
     block do
-        if not system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['cinder']}\"'|grep \"#{node['bcpc']['dbname']['cinder']}\"" then
-            %x[ mysql -uroot -p#{get_config('mysql-root-password')} -e "CREATE DATABASE #{node['bcpc']['dbname']['cinder']};"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['cinder']}.* TO '#{get_config('mysql-cinder-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-cinder-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['cinder']}.* TO '#{get_config('mysql-cinder-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-cinder-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "FLUSH PRIVILEGES;"
-            ]
-            self.notifies :run, "bash[cinder-database-sync]", :immediately
-            self.resolve_notification_references
-        end
+        %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+            mysql -uroot -e "CREATE DATABASE #{node['bcpc']['dbname']['cinder']};"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['cinder']}.* TO '#{get_config('mysql-cinder-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-cinder-password')}';"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['cinder']}.* TO '#{get_config('mysql-cinder-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-cinder-password')}';"
+            mysql -uroot -e "FLUSH PRIVILEGES;"
+        ]
+        self.notifies :run, "bash[cinder-database-sync]", :immediately
+        self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['cinder']}\"'|grep \"#{node['bcpc']['dbname']['cinder']}\" >/dev/null" }
 end
+
 
 bash "cinder-database-sync" do
     action :nothing

--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -84,16 +84,16 @@ end
 
 ruby_block "glance-database-creation" do
     block do
-        if not system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['glance']}\"'|grep \"#{node['bcpc']['dbname']['glance']}\"" then
-            %x[ mysql -uroot -p#{get_config('mysql-root-password')} -e "CREATE DATABASE #{node['bcpc']['dbname']['glance']};"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['glance']}.* TO '#{get_config('mysql-glance-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-glance-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['glance']}.* TO '#{get_config('mysql-glance-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-glance-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "FLUSH PRIVILEGES;"
-            ]
-            self.notifies :run, "bash[glance-database-sync]", :immediately
-            self.resolve_notification_references
-        end
+        %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+            mysql -uroot -e "CREATE DATABASE #{node['bcpc']['dbname']['glance']};"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['glance']}.* TO '#{get_config('mysql-glance-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-glance-password')}';"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['glance']}.* TO '#{get_config('mysql-glance-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-glance-password')}';"
+            mysql -uroot -e "FLUSH PRIVILEGES;"
+        ]
+        self.notifies :run, "bash[glance-database-sync]", :immediately
+        self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['glance']}\"'|grep \"#{node['bcpc']['dbname']['glance']}\" >/dev/null" }
 end
 
 bash "glance-database-sync" do

--- a/cookbooks/bcpc/recipes/heat.rb
+++ b/cookbooks/bcpc/recipes/heat.rb
@@ -59,16 +59,16 @@ end
 
 ruby_block "heat-database-creation" do
     block do
-        if not system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['heat']}\"'|grep \"#{node['bcpc']['dbname']['heat']}\"" then
-            %x[ mysql -uroot -p#{get_config('mysql-root-password')} -e "CREATE DATABASE #{node['bcpc']['dbname']['heat']};"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['heat']}.* TO '#{get_config('mysql-heat-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-heat-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['heat']}.* TO '#{get_config('mysql-heat-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-heat-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "FLUSH PRIVILEGES;"
-            ]
-            self.notifies :run, "bash[heat-database-sync]", :immediately
-            self.resolve_notification_references
-        end
+        %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+            mysql -uroot -e "CREATE DATABASE #{node['bcpc']['dbname']['heat']};"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['heat']}.* TO '#{get_config('mysql-heat-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-heat-password')}';"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['heat']}.* TO '#{get_config('mysql-heat-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-heat-password')}';"
+            mysql -uroot -e "FLUSH PRIVILEGES;"
+        ]
+        self.notifies :run, "bash[heat-database-sync]", :immediately
+        self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['heat']}\"'|grep \"#{node['bcpc']['dbname']['heat']}\" >/dev/null" }
 end
 
 bash "heat-database-sync" do

--- a/cookbooks/bcpc/recipes/horizon.rb
+++ b/cookbooks/bcpc/recipes/horizon.rb
@@ -112,16 +112,16 @@ end
 
 ruby_block "horizon-database-creation" do
     block do
-        if not system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['horizon']}\"'|grep \"#{node['bcpc']['dbname']['horizon']}\"" then
-            %x[ mysql -uroot -p#{get_config('mysql-root-password')} -e "CREATE DATABASE #{node['bcpc']['dbname']['horizon']};"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['horizon']}.* TO '#{get_config('mysql-horizon-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-horizon-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['horizon']}.* TO '#{get_config('mysql-horizon-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-horizon-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "FLUSH PRIVILEGES;"
-            ]
-            self.notifies :run, "bash[horizon-database-sync]", :immediately
-            self.resolve_notification_references
-        end
+        %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+            mysql -uroot -e "CREATE DATABASE #{node['bcpc']['dbname']['horizon']};"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['horizon']}.* TO '#{get_config('mysql-horizon-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-horizon-password')}';"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['horizon']}.* TO '#{get_config('mysql-horizon-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-horizon-password')}';"
+            mysql -uroot -e "FLUSH PRIVILEGES;"
+        ]
+        self.notifies :run, "bash[horizon-database-sync]", :immediately
+        self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['horizon']}\"'|grep \"#{node['bcpc']['dbname']['horizon']}\" >/dev/nul" }
 end
 
 bash "horizon-database-sync" do

--- a/cookbooks/bcpc/recipes/mysql-head.rb
+++ b/cookbooks/bcpc/recipes/mysql-head.rb
@@ -32,17 +32,17 @@ end
 
 ruby_block "initial-mysql-config" do
     block do
-        if not system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT user from mysql.user where User=\"haproxy\"'" then
-            %x[ mysql -u root -e "DELETE FROM mysql.user WHERE user='';"
-                mysql -u root -e "UPDATE mysql.user SET password=PASSWORD('#{get_config('mysql-root-password')}') WHERE user='root'; FLUSH PRIVILEGES;"
-                mysql -u root -p#{get_config('mysql-root-password')} -e "UPDATE mysql.user SET host='%' WHERE user='root' and host='localhost'; FLUSH PRIVILEGES;"
-                mysql -u root -p#{get_config('mysql-root-password')} -e "GRANT USAGE ON *.* to #{get_config('mysql-galera-user')}@'%' IDENTIFIED BY '#{get_config('mysql-galera-password')}';"
-                mysql -u root -p#{get_config('mysql-root-password')} -e "GRANT ALL PRIVILEGES on *.* TO #{get_config('mysql-galera-user')}@'%' IDENTIFIED BY '#{get_config('mysql-galera-password')}';"
-                mysql -u root -p#{get_config('mysql-root-password')} -e "GRANT PROCESS ON *.* to '#{get_config('mysql-check-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-check-password')}';"
-                mysql -u root -p#{get_config('mysql-root-password')} -e "FLUSH PRIVILEGES;"
-            ]
-        end
+        %x[ mysql -u root -e "DELETE FROM mysql.user WHERE user='';"
+            mysql -u root -e "UPDATE mysql.user SET password=PASSWORD('#{get_config('mysql-root-password')}') WHERE user='root'; FLUSH PRIVILEGES;"
+            export MYSQL_PWD=#{get_config('mysql-root-password')};
+            mysql -u root -e "UPDATE mysql.user SET host='%' WHERE user='root' and host='localhost'; FLUSH PRIVILEGES;"
+            mysql -u root -e "GRANT USAGE ON *.* to #{get_config('mysql-galera-user')}@'%' IDENTIFIED BY '#{get_config('mysql-galera-password')}';"
+            mysql -u root -e "GRANT ALL PRIVILEGES on *.* TO #{get_config('mysql-galera-user')}@'%' IDENTIFIED BY '#{get_config('mysql-galera-password')}';"
+            mysql -u root -e "GRANT PROCESS ON *.* to '#{get_config('mysql-check-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-check-password')}';"
+            mysql -u root -e "FLUSH PRIVILEGES;"
+        ]
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT user from mysql.user where User=\"haproxy\"' >/dev/null" }
 end
 
 include_recipe "bcpc::mysql-common"

--- a/cookbooks/bcpc/recipes/mysql-monitoring.rb
+++ b/cookbooks/bcpc/recipes/mysql-monitoring.rb
@@ -32,17 +32,17 @@ end
 
 ruby_block "initial-mysql-monitoring-config" do
     block do
-        if not system "mysql -uroot -p#{get_config('mysql-monitoring-root-password')} -e 'SELECT user from mysql.user where User=\"haproxy\"'" then
-            %x[ mysql -u root -e "DELETE FROM mysql.user WHERE user='';"
-                mysql -u root -e "UPDATE mysql.user SET password=PASSWORD('#{get_config('mysql-monitoring-root-password')}') WHERE user='root'; FLUSH PRIVILEGES;"
-                mysql -u root -p#{get_config('mysql-monitoring-root-password')} -e "UPDATE mysql.user SET host='%' WHERE user='root' and host='localhost'; FLUSH PRIVILEGES;"
-                mysql -u root -p#{get_config('mysql-monitoring-root-password')} -e "GRANT USAGE ON *.* to #{get_config('mysql-monitoring-galera-user')}@'%' IDENTIFIED BY '#{get_config('mysql-monitoring-galera-password')}';"
-                mysql -u root -p#{get_config('mysql-monitoring-root-password')} -e "GRANT ALL PRIVILEGES on *.* TO #{get_config('mysql-monitoring-galera-user')}@'%' IDENTIFIED BY '#{get_config('mysql-monitoring-galera-password')}';"
-                mysql -u root -p#{get_config('mysql-monitoring-root-password')} -e "GRANT PROCESS ON *.* to '#{get_config('mysql-check-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-check-password')}';"
-                mysql -u root -p#{get_config('mysql-monitoring-root-password')} -e "FLUSH PRIVILEGES;"
-            ]
-        end
+        %x[ mysql -u root -e "DELETE FROM mysql.user WHERE user='';"
+            mysql -u root -e "UPDATE mysql.user SET password=PASSWORD('#{get_config('mysql-monitoring-root-password')}') WHERE user='root'; FLUSH PRIVILEGES;"
+            export MYSQL_PWD=#{get_config('mysql-monitoring-root-password')};
+            mysql -u root -e "UPDATE mysql.user SET host='%' WHERE user='root' and host='localhost'; FLUSH PRIVILEGES;"
+            mysql -u root -e "GRANT USAGE ON *.* to #{get_config('mysql-monitoring-galera-user')}@'%' IDENTIFIED BY '#{get_config('mysql-monitoring-galera-password')}';"
+            mysql -u root -e "GRANT ALL PRIVILEGES on *.* TO #{get_config('mysql-monitoring-galera-user')}@'%' IDENTIFIED BY '#{get_config('mysql-monitoring-galera-password')}';"
+            mysql -u root -e "GRANT PROCESS ON *.* to '#{get_config('mysql-check-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-check-password')}';"
+            mysql -u root -e "FLUSH PRIVILEGES;"
+        ]
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-monitoring-root-password')} mysql -uroot -e 'SELECT user from mysql.user where User=\"haproxy\"' >/dev/null" }
 end
 
 include_recipe "bcpc::mysql-common"

--- a/cookbooks/bcpc/recipes/nova-head.rb
+++ b/cookbooks/bcpc/recipes/nova-head.rb
@@ -58,7 +58,7 @@ end
 ruby_block "reap-dead-servers-from-nova" do
     block do
         all_hosts = search_nodes("recipe", "nova-work").collect { |x| x['hostname'] }
-        nova_hosts = %x[nova-manage service list | awk '{print $2}' | grep -ve "^Host$" | uniq].split
+        nova_hosts = %x[nova-manage service list 2>/dev/null | awk '{print $2}' | grep -ve "^Host$" | uniq].split
         nova_hosts.each do |host|
             if not all_hosts.include?(host)
                 %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};

--- a/cookbooks/bcpc/recipes/nova-head.rb
+++ b/cookbooks/bcpc/recipes/nova-head.rb
@@ -33,16 +33,16 @@ end
 
 ruby_block "nova-database-creation" do
     block do
-        if not system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['nova']}\"'|grep \"#{node['bcpc']['dbname']['nova']}\"" then
-            %x[ mysql -uroot -p#{get_config('mysql-root-password')} -e "CREATE DATABASE #{node['bcpc']['dbname']['nova']};"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['nova']}.* TO '#{get_config('mysql-nova-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-nova-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['nova']}.* TO '#{get_config('mysql-nova-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-nova-password')}';"
-                mysql -uroot -p#{get_config('mysql-root-password')} -e "FLUSH PRIVILEGES;"
-            ]
-            self.notifies :run, "bash[nova-database-sync]", :immediately
-            self.resolve_notification_references
-        end
+        %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+            mysql -uroot -e "CREATE DATABASE #{node['bcpc']['dbname']['nova']};"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['nova']}.* TO '#{get_config('mysql-nova-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-nova-password')}';"
+            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['nova']}.* TO '#{get_config('mysql-nova-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-nova-password')}';"
+            mysql -uroot -e "FLUSH PRIVILEGES;"
+        ]
+        self.notifies :run, "bash[nova-database-sync]", :immediately
+        self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['nova']}\"'|grep \"#{node['bcpc']['dbname']['nova']}\" >/dev/null" }
 end
 
 bash "nova-database-sync" do
@@ -61,8 +61,9 @@ ruby_block "reap-dead-servers-from-nova" do
         nova_hosts = %x[nova-manage service list | awk '{print $2}' | grep -ve "^Host$" | uniq].split
         nova_hosts.each do |host|
             if not all_hosts.include?(host)
-                %x[ mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['nova']} -e "DELETE FROM services WHERE host=\\"#{host}\\";"
-                    mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['nova']} -e "DELETE FROM compute_nodes WHERE hypervisor_hostname=\\"#{host}\\";"
+                %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+                    mysql -uroot #{node['bcpc']['dbname']['nova']} -e "DELETE FROM services WHERE host=\\"#{host}\\";"
+                    mysql -uroot #{node['bcpc']['dbname']['nova']} -e "DELETE FROM compute_nodes WHERE hypervisor_hostname=\\"#{host}\\";"
                 ]
             end
         end

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -166,14 +166,12 @@ end
 
 ruby_block 'load-virsh-keys' do
     block do
-        if not system "virsh secret-list | grep -i #{get_config('libvirt-secret-uuid')}" then
-            %x[ ADMIN_KEY=`ceph --name mon. --keyring /etc/ceph/ceph.mon.keyring auth get-or-create-key client.admin`
-                virsh secret-define --file /etc/nova/virsh-secret.xml
-                virsh secret-set-value --secret #{get_config('libvirt-secret-uuid')} \
-                    --base64 "$ADMIN_KEY"
-            ]
-        end
+        %x[ ADMIN_KEY=`ceph --name mon. --keyring /etc/ceph/ceph.mon.keyring auth get-or-create-key client.admin`
+            virsh secret-define --file /etc/nova/virsh-secret.xml
+            virsh secret-set-value --secret #{get_config('libvirt-secret-uuid')} --base64 "$ADMIN_KEY"
+        ]
     end
+    not_if { system "virsh secret-list | grep -i #{get_config('libvirt-secret-uuid')} >/dev/null" }
 end
 
 bash "remove-default-virsh-net" do

--- a/cookbooks/bcpc/recipes/powerdns-nova.rb
+++ b/cookbooks/bcpc/recipes/powerdns-nova.rb
@@ -36,7 +36,7 @@ if node['bcpc']['enabled']['dns']
 
   ruby_block "powerdns-load-fixed-records" do
     block do
-      system "mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['pdns']} < #{fixed_records_file}"
+      system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot #{node['bcpc']['dbname']['pdns']} < #{fixed_records_file}"
     end
   end
 

--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -48,37 +48,35 @@ if node['bcpc']['enabled']['dns'] then
 
   ruby_block "powerdns-database-creation" do
     block do
-      system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['pdns']}\"' | grep -q \"#{node['bcpc']['dbname']['pdns']}\""
-      if not $?.success? then
-        %x[ mysql -uroot -p#{get_config('mysql-root-password')} -e "CREATE DATABASE #{node['bcpc']['dbname']['pdns']} CHARACTER SET utf8 COLLATE utf8_general_ci;"
-            mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['pdns']}.* TO '#{get_config('mysql-pdns-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-pdns-password')}';"
-            mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['pdns']}.* TO '#{get_config('mysql-pdns-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-pdns-password')}';"
-            mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['nova']}.* TO '#{get_config('mysql-pdns-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-pdns-password')}';"
-            mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['nova']}.* TO '#{get_config('mysql-pdns-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-pdns-password')}';"
-            mysql -uroot -p#{get_config('mysql-root-password')} -e "FLUSH PRIVILEGES;"
-        ]
-        self.notifies :restart, resources(:service => "pdns"), :delayed
-        self.resolve_notification_references
-      end
+      %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+          mysql -uroot -e "CREATE DATABASE #{node['bcpc']['dbname']['pdns']} CHARACTER SET utf8 COLLATE utf8_general_ci;"
+          mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['pdns']}.* TO '#{get_config('mysql-pdns-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-pdns-password')}';"
+          mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['pdns']}.* TO '#{get_config('mysql-pdns-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-pdns-password')}';"
+          mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['nova']}.* TO '#{get_config('mysql-pdns-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-pdns-password')}';"
+          mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['nova']}.* TO '#{get_config('mysql-pdns-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-pdns-password')}';"
+          mysql -uroot -e "FLUSH PRIVILEGES;"
+      ]
+      self.notifies :restart, resources(:service => "pdns"), :delayed
+      self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['pdns']}\"' | grep -q \"#{node['bcpc']['dbname']['pdns']}\" >/dev/null" }
   end
 
   ruby_block "powerdns-table-keystone_project" do
     block do
-      system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = \"#{node['bcpc']['dbname']['pdns']}\" AND TABLE_NAME=\"keystone_project\"' | grep -q \"keystone_project\""
-      if not $?.success? then
-        %x[ mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['pdns']} <<-EOH
-            CREATE TABLE IF NOT EXISTS keystone_project (
-                id VARCHAR(255) NOT NULL,
-                name VARCHAR(255) NOT NULL
-            );
-            CREATE UNIQUE INDEX keystone_project_name ON keystone_project(name);
-            CREATE UNIQUE INDEX keystone_project_id on keystone_project(id);
-        ]
-        self.notifies :restart, resources(:service => "pdns"), :delayed
-        self.resolve_notification_references
-      end
+      %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+          mysql -uroot #{node['bcpc']['dbname']['pdns']} <<-EOH
+          CREATE TABLE IF NOT EXISTS keystone_project (
+              id VARCHAR(255) NOT NULL,
+              name VARCHAR(255) NOT NULL
+          );
+          CREATE UNIQUE INDEX keystone_project_name ON keystone_project(name);
+          CREATE UNIQUE INDEX keystone_project_id on keystone_project(id);
+      ]
+      self.notifies :restart, resources(:service => "pdns"), :delayed
+      self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = \"#{node['bcpc']['dbname']['pdns']}\" AND TABLE_NAME=\"keystone_project\"' | grep -q \"keystone_project\" >/dev/null" }
   end
 
   ruby_block "powerdns-table-domains" do
@@ -86,104 +84,100 @@ if node['bcpc']['enabled']['dns'] then
       reverse_fixed_zone = node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])
       reverse_float_zone = node['bcpc']['floating']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])
 
-      system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = \"#{node['bcpc']['dbname']['pdns']}\" AND TABLE_NAME=\"domains\"' | grep -q \"domains\""
-      if not $?.success? then
-        %x[ mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['pdns']} <<-EOH
-            CREATE TABLE IF NOT EXISTS domains (
-                id INT auto_increment,
-                name VARCHAR(255) NOT NULL,
-                master VARCHAR(128) DEFAULT NULL,
-                last_check INT DEFAULT NULL,
-                type VARCHAR(6) NOT NULL,
-                notified_serial INT DEFAULT NULL,
-                account VARCHAR(40) DEFAULT NULL,
-                primary key (id)
-            );
-            INSERT INTO domains (name, type) values ('#{node['bcpc']['domain_name']}', 'NATIVE');
-            INSERT INTO domains (name, type) values ('#{reverse_float_zone}', 'NATIVE');
-            INSERT INTO domains (name, type) values ('#{reverse_fixed_zone}', 'NATIVE');
-            CREATE UNIQUE INDEX dom_name_index ON domains(name);
-        ]
-        self.notifies :restart, resources(:service => "pdns"), :delayed
-        self.resolve_notification_references
-      end
+      %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+          mysql -uroot #{node['bcpc']['dbname']['pdns']} <<-EOH
+          CREATE TABLE IF NOT EXISTS domains (
+              id INT auto_increment,
+              name VARCHAR(255) NOT NULL,
+              master VARCHAR(128) DEFAULT NULL,
+              last_check INT DEFAULT NULL,
+              type VARCHAR(6) NOT NULL,
+              notified_serial INT DEFAULT NULL,
+              account VARCHAR(40) DEFAULT NULL,
+              primary key (id)
+          );
+          INSERT INTO domains (name, type) values ('#{node['bcpc']['domain_name']}', 'NATIVE');
+          INSERT INTO domains (name, type) values ('#{reverse_float_zone}', 'NATIVE');
+          INSERT INTO domains (name, type) values ('#{reverse_fixed_zone}', 'NATIVE');
+          CREATE UNIQUE INDEX dom_name_index ON domains(name);
+      ]
+      self.notifies :restart, resources(:service => "pdns"), :delayed
+      self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = \"#{node['bcpc']['dbname']['pdns']}\" AND TABLE_NAME=\"domains\"' | grep -q \"domains\" >/dev/null" }
   end
 
 ruby_block "powerdns-function-ip4_to_ptr_name" do
   block do
-    system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT name FROM mysql.proc WHERE name = \"ip4_to_ptr_name\" AND db = \"#{node['bcpc']['dbname']['pdns']}\";' \"#{node['bcpc']['dbname']['pdns']}\" | grep -q \"ip4_to_ptr_name\""
-    if not $?.success?
-      %x[ mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['pdns']} <<-EOH
-          delimiter //
-          CREATE FUNCTION ip4_to_ptr_name(ip4 VARCHAR(64) CHARACTER SET latin1) RETURNS VARCHAR(64)
-          COMMENT 'Returns the reversed IP with .in-addr.arpa appended, suitable for use in the name column of PTR records.'
-          DETERMINISTIC
-          BEGIN
-          return concat_ws( '.',  SUBSTRING_INDEX( SUBSTRING_INDEX(ip4, '.', 4), '.', -1),
-                                  SUBSTRING_INDEX( SUBSTRING_INDEX(ip4, '.', 3), '.', -1),
-                                  SUBSTRING_INDEX( SUBSTRING_INDEX(ip4, '.', 2), '.', -1),
-                                  SUBSTRING_INDEX( SUBSTRING_INDEX(ip4, '.', 1), '.', -1), 'in-addr.arpa');
-          END//
-      ]
-      self.notifies :restart, resources(:service => "pdns"), :delayed
-    end
+    %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+        mysql -uroot #{node['bcpc']['dbname']['pdns']} <<-EOH
+        delimiter //
+        CREATE FUNCTION ip4_to_ptr_name(ip4 VARCHAR(64) CHARACTER SET latin1) RETURNS VARCHAR(64)
+        COMMENT 'Returns the reversed IP with .in-addr.arpa appended, suitable for use in the name column of PTR records.'
+        DETERMINISTIC
+        BEGIN
+        return concat_ws( '.',  SUBSTRING_INDEX( SUBSTRING_INDEX(ip4, '.', 4), '.', -1),
+                                SUBSTRING_INDEX( SUBSTRING_INDEX(ip4, '.', 3), '.', -1),
+                                SUBSTRING_INDEX( SUBSTRING_INDEX(ip4, '.', 2), '.', -1),
+                                SUBSTRING_INDEX( SUBSTRING_INDEX(ip4, '.', 1), '.', -1), 'in-addr.arpa');
+        END//
+    ]
+    self.notifies :restart, resources(:service => "pdns"), :delayed
   end
+  not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT name FROM mysql.proc WHERE name = \"ip4_to_ptr_name\" AND db = \"#{node['bcpc']['dbname']['pdns']}\";' \"#{node['bcpc']['dbname']['pdns']}\" | grep -q \"ip4_to_ptr_name\" >/dev/null" }
 end
 
   ruby_block "powerdns-function-dns-name" do
     block do
-      system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT name FROM mysql.proc WHERE name = \"dns_name\" AND db = \"#{node['bcpc']['dbname']['pdns']}\";' \"#{node['bcpc']['dbname']['pdns']}\" | grep -q \"dns_name\""
-      if not $?.success? then
-        %x[ mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['pdns']} <<-EOH
-            delimiter //
-            CREATE FUNCTION dns_name (tenant VARCHAR(64) CHARACTER SET latin1) RETURNS VARCHAR(64)
-            COMMENT 'Returns the project name in a DNS acceptable format. Roughly RFC 1035.'
-            DETERMINISTIC
-            BEGIN
-              SELECT LOWER(tenant) INTO tenant;
-              SELECT REPLACE(tenant, '&', 'and') INTO tenant;
-              SELECT REPLACE(tenant, '_', '-') INTO tenant;
-              SELECT REPLACE(tenant, ' ', '-') INTO tenant;
-              SELECT REPLACE(tenant, '.', '-') INTO tenant;
-              RETURN tenant;
-            END//
-        ]
-        self.notifies :restart, resources(:service => "pdns"), :delayed
-        self.resolve_notification_references
-      end
+      %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+          mysql -uroot #{node['bcpc']['dbname']['pdns']} <<-EOH
+          delimiter //
+          CREATE FUNCTION dns_name (tenant VARCHAR(64) CHARACTER SET latin1) RETURNS VARCHAR(64)
+          COMMENT 'Returns the project name in a DNS acceptable format. Roughly RFC 1035.'
+          DETERMINISTIC
+          BEGIN
+            SELECT LOWER(tenant) INTO tenant;
+            SELECT REPLACE(tenant, '&', 'and') INTO tenant;
+            SELECT REPLACE(tenant, '_', '-') INTO tenant;
+            SELECT REPLACE(tenant, ' ', '-') INTO tenant;
+            SELECT REPLACE(tenant, '.', '-') INTO tenant;
+            RETURN tenant;
+          END//
+      ]
+      self.notifies :restart, resources(:service => "pdns"), :delayed
+      self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT name FROM mysql.proc WHERE name = \"dns_name\" AND db = \"#{node['bcpc']['dbname']['pdns']}\";' \"#{node['bcpc']['dbname']['pdns']}\" | grep -q \"dns_name\" >/dev/null" }
   end
 
   ruby_block "powerdns-table-records" do
     block do
-      system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = \"#{node['bcpc']['dbname']['pdns']}\" AND TABLE_NAME=\"records\"' | grep -q \"records\""
-      if not $?.success? then
-        %x[ mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['pdns']} <<-EOH
-            CREATE TABLE IF NOT EXISTS records (
-                id INT auto_increment,
-                domain_id INT DEFAULT NULL,
-                name VARCHAR(255) DEFAULT NULL,
-                type VARCHAR(6) DEFAULT NULL,
-                content VARCHAR(255) DEFAULT NULL,
-                ttl INT DEFAULT 300,
-                prio INT DEFAULT NULL,
-                change_date INT DEFAULT NULL,
-                bcpc_record_type VARCHAR(32),
-                primary key(id)
-            );
-            CREATE INDEX rec_name_index ON records(name);
-            CREATE INDEX nametype_index ON records(name,type);
-            CREATE INDEX domain_id ON records(domain_id);
-            -- this unique index exists in order to facilitate the use of INSERT INTO ON DUPLICATE KEY UPDATE for doing non-destructive inserts/updates
-            -- change_date is intentionally not included so that it will not be considered as part of the record itself when determining uniqueness
-            -- prio is also not included because it is NULL in all cases for us and this apparently confuses MySQL into thinking that the INSERT is always unique when it's not
-            CREATE UNIQUE INDEX idx_records_all_fields ON records (domain_id, name, type, content, ttl, bcpc_record_type);
-        ]
-        self.notifies :restart, resources(:service => "pdns"), :delayed
-        self.resolve_notification_references
-      end
+      %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+          mysql -uroot #{node['bcpc']['dbname']['pdns']} <<-EOH
+          CREATE TABLE IF NOT EXISTS records (
+              id INT auto_increment,
+              domain_id INT DEFAULT NULL,
+              name VARCHAR(255) DEFAULT NULL,
+              type VARCHAR(6) DEFAULT NULL,
+              content VARCHAR(255) DEFAULT NULL,
+              ttl INT DEFAULT 300,
+              prio INT DEFAULT NULL,
+              change_date INT DEFAULT NULL,
+              bcpc_record_type VARCHAR(32),
+              primary key(id)
+          );
+          CREATE INDEX rec_name_index ON records(name);
+          CREATE INDEX nametype_index ON records(name,type);
+          CREATE INDEX domain_id ON records(domain_id);
+          -- this unique index exists in order to facilitate the use of INSERT INTO ON DUPLICATE KEY UPDATE for doing non-destructive inserts/updates
+          -- change_date is intentionally not included so that it will not be considered as part of the record itself when determining uniqueness
+          -- prio is also not included because it is NULL in all cases for us and this apparently confuses MySQL into thinking that the INSERT is always unique when it's not
+          CREATE UNIQUE INDEX idx_records_all_fields ON records (domain_id, name, type, content, ttl, bcpc_record_type);
+      ]
+      self.notifies :restart, resources(:service => "pdns"), :delayed
+      self.resolve_notification_references
     end
+    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = \"#{node['bcpc']['dbname']['pdns']}\" AND TABLE_NAME=\"records\"' | grep -q \"records\" >/dev/null" }
   end
 
   # this template replaces several old ruby_block resources and pre-seeds static and float entries into a template file to be loaded into MySQL
@@ -212,7 +206,7 @@ end
 
   ruby_block "powerdns-load-float-records" do
     block do
-      system "mysql -uroot -p#{get_config('mysql-root-password')} #{node['bcpc']['dbname']['pdns']} < #{float_records_file}"
+      system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot #{node['bcpc']['dbname']['pdns']} < #{float_records_file}"
     end
   end
 

--- a/cookbooks/bcpc/recipes/zabbix-head.rb
+++ b/cookbooks/bcpc/recipes/zabbix-head.rb
@@ -79,7 +79,7 @@ if node['bcpc']['enabled']['monitoring'] then
     ruby_block "zabbix-database-creation" do
         block do
             if not system "mysql -uroot -p#{get_config('mysql-root-password')} -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['zabbix']}\"'|grep \"#{node['bcpc']['dbname']['zabbix']}\"" then
-                puts %x[ mysql -uroot -p#{get_config('mysql-root-password')} -e "CREATE DATABASE #{node['bcpc']['dbname']['zabbix']} CHARACTER SET UTF8;"
+                %x[ mysql -uroot -p#{get_config('mysql-root-password')} -e "CREATE DATABASE #{node['bcpc']['dbname']['zabbix']} CHARACTER SET UTF8;"
                     mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['zabbix']}.* TO '#{get_config('mysql-zabbix-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-zabbix-password')}';"
                     mysql -uroot -p#{get_config('mysql-root-password')} -e "GRANT ALL ON #{node['bcpc']['dbname']['zabbix']}.* TO '#{get_config('mysql-zabbix-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-zabbix-password')}';"
                     mysql -uroot -p#{get_config('mysql-root-password')} -e "FLUSH PRIVILEGES;"


### PR DESCRIPTION
This PR eliminates a lot of extraneous noise during Chef runs:
* anywhere `puts` was used has been replaced by a call to `Chef::Log` and an appropriate log level (usually **info**)
* invocations of `mysql` now receive their password via the `MYSQL_PWD` environment variable rather than the `-p` switch, which suppresses the warning about using a password on the command line
* guards that were created as `if` or `if not` statements inside a `ruby_block` resource type have been moved out of the main block into an `only_if` or `not_if` guard
* command stdout and/or stderr was redirected to `/dev/null` in certain cases where the command is known to always output something that isn't needed (mostly used in cases where `nova-manage` is invoked to suppress the complaint about `oslo_config.log`)
* added a guard on `load-virsh-keys`
* rewrote `wait-for-mon-quorum` to have a timeout (`ruby_block` resources do not have a `:timeout` attribute of their own)