### PR TITLE
Upgrading Cirros to 0.3.4 to stay current

### DIFF
--- a/cookbooks/bcpc/files/default/build_bins.sh
+++ b/cookbooks/bcpc/files/default/build_bins.sh
@@ -161,10 +161,10 @@ for i in elasticsearch tail-multiline tail-ex record-reformer rewrite; do
 done
 
 # Fetch the cirros image for testing
-if [ ! -f cirros-0.3.2-x86_64-disk.img ]; then
-    ccurl http://download.cirros-cloud.net/0.3.2/cirros-0.3.2-x86_64-disk.img
+if [ ! -f cirros-0.3.4-x86_64-disk.img ]; then
+    ccurl http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img
 fi
-FILES="cirros-0.3.2-x86_64-disk.img $FILES"
+FILES="cirros-0.3.4-x86_64-disk.img $FILES"
 
 # Grab the Ubuntu 14.04 installer image
 if [ ! -f ubuntu-14.04-mini.iso ]; then

--- a/cookbooks/bcpc/files/default/checks/nova
+++ b/cookbooks/bcpc/files/default/checks/nova
@@ -76,7 +76,7 @@ class TestNovaCompute(object):
             if server.name == self.instance_name:
                 self._delete_server(server)
 
-        image_name = self.config.get("image_name", "Cirros 0.3.2*")
+        image_name = self.config.get("image_name", "Cirros 0.3.4*")
         images = [ i for i in self.client.images.list() if i.name is not None and glob.fnmatch.fnmatch(i.name, image_name) ]
         if len(images)==0:
             raise Exception("Found %d images called %s"  %(len(images), image_name))

--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -136,8 +136,8 @@ end
     end
 end
 
-cookbook_file "/tmp/cirros-0.3.2-x86_64-disk.img" do
-    source "bins/cirros-0.3.2-x86_64-disk.img"
+cookbook_file "/tmp/cirros-0.3.4-x86_64-disk.img" do
+    source "bins/cirros-0.3.4-x86_64-disk.img"
     owner "root"
     mode 00444
 end
@@ -150,8 +150,8 @@ bash "glance-cirros-image" do
     user "root"
     code <<-EOH
         . /root/adminrc
-        qemu-img convert -f qcow2 -O raw /tmp/cirros-0.3.2-x86_64-disk.img /tmp/cirros-0.3.2-x86_64-disk.raw
-        glance image-create --name='Cirros 0.3.2 x86_64' --is-public=True --container-format=bare --disk-format=raw --file /tmp/cirros-0.3.2-x86_64-disk.raw
+        qemu-img convert -f qcow2 -O raw /tmp/cirros-0.3.4-x86_64-disk.img /tmp/cirros-0.3.4-x86_64-disk.raw
+        glance image-create --name='Cirros 0.3.4 x86_64' --is-public=True --container-format=bare --disk-format=raw --file /tmp/cirros-0.3.4-x86_64-disk.raw
     EOH
-    not_if ". /root/adminrc; glance image-list | grep 'Cirros 0.3.2 x86_64'"
+    not_if ". /root/adminrc; glance image-list | grep 'Cirros 0.3.4 x86_64'"
 end

--- a/cookbooks/bcpc/templates/default/rally.conf.erb
+++ b/cookbooks/bcpc/templates/default/rally.conf.erb
@@ -548,14 +548,14 @@ connection = sqlite:////var/lib/rally/database/rally.sqlite
 # From rally
 #
 
-cirros_version = 0.3.2
-cirros_image = cirros-0.3.2-x86_64-disk.img
+cirros_version = 0.3.4
+cirros_image = cirros-0.3.4-x86_64-disk.img
 
 # Version of cirros image (string value)
-#cirros_version = 0.3.2
+#cirros_version = 0.3.4
 
 # Cirros image name (string value)
-#cirros_image = cirros-0.3.2-x86_64-disk.img
+#cirros_image = cirros-0.3.4-x86_64-disk.img
 
 
 [users_context]

--- a/tests/run_tempest.sh
+++ b/tests/run_tempest.sh
@@ -128,7 +128,7 @@ configDir = {
               "admin_tenant_name": "AdminTenant",
               "admin_password": "${keystone_admin_pass}"},
  "image": {"region": "$ENVIRONMENT",
-           "http_image": "http://${BOOTSTRAP}:8080/cirros-0.3.0-x86_64-disk.img"},
+           "http_image": "http://${BOOTSTRAP}:8080/cirros-0.3.4-x86_64-disk.img"},
  "input-scenario": {"image_regex": '[["^[Cc]irros.*$","^[Uu]buntu.*"]]',
                     "flavor_regex": "^m1.tiny",
                     "ssh_user_regex": '[["^.*[Cc]irros.*$", "ubuntu"]]'},


### PR DESCRIPTION
This PR upgrades Cirros to the most current version, 0.3.4. I deployed it on test hardware and everything seems fine. Checks pass, can launch instances from image or volume with it, assign IP, inject keys, everything you'd expect.

To deploy to an existing cluster, rerun `cookbooks/bcpc/files/default/build_bins.sh` and then upload the cookbook.