### PR TITLE
Fixes monitoring role requiring two runs to set up

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -119,6 +119,15 @@ def get_head_nodes
     return results.sort! { |a, b| a['hostname'] <=> b['hostname'] }
 end
 
+def get_monitoring_nodes
+    results = search(:node, "role:BCPC-Monitoring AND chef_environment:#{node.chef_environment}")
+    results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
+    if not results.include?(node) and node.run_list.roles.include?('BCPC-Monitoring')
+        results.push(node)
+    end
+    return results.sort! { |a, b| a['hostname'] <=> b['hostname'] }
+end
+
 def get_bootstrap_node
     results = search(:node, "role:BCPC-Bootstrap AND chef_environment:#{node.chef_environment}")
     raise 'There is not exactly one bootstrap node found.' if results.size != 1

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -80,13 +80,20 @@ end
 def search_nodes(key, value)
     if key == "recipe"
         results = search(:node, "recipes:bcpc\\:\\:#{value} AND chef_environment:#{node.chef_environment}")
+        results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
+        if not results.include?(node) and node.run_list.expand.recipes.include?("bcpc::#{value}")
+            results.push(node)
+        end
     elsif key == "role"
-        results = search(:node, "roles:#{value} AND chef_environment:#{node.chef_environment}")
+        results = search(:node, "#{key}:#{value} AND chef_environment:#{node.chef_environment}")
+        results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
+        if not results.include?(node) and node.run_list.expand.roles.include?(value)
+            results.push(node)
+        end
     else
         raise("Invalid search key: #{key}")
     end
 
-    results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
     return results.sort! { |a, b| a['hostname'] <=> b['hostname'] }
 end
 
@@ -114,15 +121,6 @@ def get_head_nodes
     results = search(:node, "role:BCPC-Headnode AND chef_environment:#{node.chef_environment}")
     results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
     if not results.include?(node) and node.run_list.roles.include?('BCPC-Headnode')
-        results.push(node)
-    end
-    return results.sort! { |a, b| a['hostname'] <=> b['hostname'] }
-end
-
-def get_monitoring_nodes
-    results = search(:node, "role:BCPC-Monitoring AND chef_environment:#{node.chef_environment}")
-    results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-    if not results.include?(node) and node.run_list.roles.include?('BCPC-Monitoring')
         results.push(node)
     end
     return results.sort! { |a, b| a['hostname'] <=> b['hostname'] }

--- a/cookbooks/bcpc/recipes/haproxy-monitoring.rb
+++ b/cookbooks/bcpc/recipes/haproxy-monitoring.rb
@@ -24,7 +24,7 @@ template "/etc/haproxy/haproxy.cfg" do
     source "haproxy-monitoring.cfg.erb"
     mode 00644
     variables(
-        :servers => search_nodes("role", "BCPC-Monitoring")
+        :servers => get_monitoring_nodes
     )
     notifies :restart, "service[haproxy]", :immediately
 end

--- a/cookbooks/bcpc/recipes/haproxy-monitoring.rb
+++ b/cookbooks/bcpc/recipes/haproxy-monitoring.rb
@@ -24,7 +24,7 @@ template "/etc/haproxy/haproxy.cfg" do
     source "haproxy-monitoring.cfg.erb"
     mode 00644
     variables(
-        :servers => get_monitoring_nodes
+        :servers => search_nodes("role", "BCPC-Monitoring")
     )
     notifies :restart, "service[haproxy]", :immediately
 end


### PR DESCRIPTION
This moves the lookup of monitoring nodes from compile time to runtime. The first time you run the monitoring recipe, the node is not registered with the Chef server as actually being of the **BCPC-Monitoring** role until after everything is compiled and convergence begins (note that this is different from setting the run list of the node to include `role[BCPC-Monitoring]`), and so the call to `search_nodes` would return an empty list, which would cause HAProxy to not have any backends configured for MySQL, which caused Graphite database setup to explode. Moving the node lookup to a utility function means that it's looked up at runtime after convergence has begun, and so the node will be able to find itself on the first run and configure HAProxy appropriately.