### PR TITLE
Don't regenerate SOA timestamps on each Chef run

### DIFF
--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -24,6 +24,7 @@ if node['bcpc']['enabled']['dns'] then
     block do
       make_config('mysql-pdns-user', "pdns")
       make_config('mysql-pdns-password', secure_password)
+      make_config('powerdns-update-timestamp', Time.now.to_i)
     end
   end
 
@@ -204,7 +205,7 @@ end
       :floating_vip              => node['bcpc']['floating']['vip'],
       :management_vip            => node['bcpc']['management']['vip'],
       :management_monitoring_vip => node['bcpc']['management']['monitoring']['vip'],
-      :update_timestamp          => Time.now.to_i,
+      :update_timestamp          => get_config('powerdns-update-timestamp'),
       :reverse_fixed_zone        => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])),
       :reverse_float_zone        => (node['bcpc']['floating']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])),
     })

--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -205,7 +205,6 @@ end
       :floating_vip              => node['bcpc']['floating']['vip'],
       :management_vip            => node['bcpc']['management']['vip'],
       :management_monitoring_vip => node['bcpc']['management']['monitoring']['vip'],
-      :update_timestamp          => get_config('powerdns-update-timestamp'),
       :reverse_fixed_zone        => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])),
       :reverse_float_zone        => (node['bcpc']['floating']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])),
     })

--- a/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
@@ -8,19 +8,19 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
 -- so we must delete the old ones after these are inserted
 -- MySQL does not allow deleting from a table and selecting from that same table in a subquery, so ids of old SOA records are written to a temporary table, records are deleted,
 -- then the temporary table is cleaned up
-CREATE TEMPORARY TABLE soa_records_to_delete_<%=@update_timestamp%> (id int);
+CREATE TEMPORARY TABLE soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%> (id int);
 <% [@domain_name, @reverse_float_zone, @reverse_fixed_zone].each do |zone| %>
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
     ((SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), '<%=zone%>', 'NS', '<%=@management_vip%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), name='<%=zone%>', type='NS', content='<%=@management_vip%>', bcpc_record_type='STATIC';
 
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), '<%=zone%>', 'SOA', '<%=@domain_name%> root.<%=@domain_name%> <%=@update_timestamp%>', 'static')
-    ON DUPLICATE KEY UPDATE domain_id=(select id from <%=@database_name%>.domains where name='<%=zone%>'), name='<%=zone%>', type='soa', content='<%=@domain_name%> root.<%=@domain_name%> <%=@update_timestamp%>', bcpc_record_type='STATIC';
+    ((SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), '<%=zone%>', 'SOA', '<%=@domain_name%> root.<%=@domain_name%> <%=get_config('powerdns-update-timestamp')%>', 'static')
+    ON DUPLICATE KEY UPDATE domain_id=(select id from <%=@database_name%>.domains where name='<%=zone%>'), name='<%=zone%>', type='soa', content='<%=@domain_name%> root.<%=@domain_name%> <%=get_config('powerdns-update-timestamp')%>', bcpc_record_type='STATIC';
 
-INSERT INTO soa_records_to_delete_<%=@update_timestamp%> SELECT id FROM <%=@database_name%>.records WHERE type='SOA' AND name='<%=zone%>' AND id < (SELECT max(id) FROM <%=@database_name%>.records WHERE type='SOA' AND name='<%=zone%>');
+INSERT INTO soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%> SELECT id FROM <%=@database_name%>.records WHERE type='SOA' AND name='<%=zone%>' AND id < (SELECT max(id) FROM <%=@database_name%>.records WHERE type='SOA' AND name='<%=zone%>');
 <% end %>
-DELETE FROM <%=@database_name%>.records WHERE id IN (SELECT id FROM soa_records_to_delete_<%=@update_timestamp%>);
+DELETE FROM <%=@database_name%>.records WHERE id IN (SELECT id FROM soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%>);
 
 -- insert A records for all BCPC physical hosts
 <% @all_servers.each do |server| %>


### PR DESCRIPTION
This stops Chef from generating a new timestamp for SOA records in PowerDNS on every run by generating a one-time timestamp and storing it in the data bag. It is unlikely that these records will ever need to change once generated.