### PR TITLE
Fixes #596 - pre-creates .rgw.buckets.extra for RADOSgw

### DIFF
--- a/cookbooks/bcpc/recipes/ceph-rgw.rb
+++ b/cookbooks/bcpc/recipes/ceph-rgw.rb
@@ -62,7 +62,7 @@ rgw_optimal_pg = power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_
 
 rgw_crush_ruleset = (node['bcpc']['ceph']['rgw']['type'] == "ssd") ? node['bcpc']['ceph']['ssd']['ruleset'] : node['bcpc']['ceph']['hdd']['ruleset']
 
-%w{.rgw .rgw.control .rgw.gc .rgw.root .users.uid .users.email .users .usage .log .intent-log .rgw.buckets .rgw.buckets.index}.each do |pool|
+%w{.rgw .rgw.control .rgw.gc .rgw.root .users.uid .users.email .users .usage .log .intent-log .rgw.buckets .rgw.buckets.index .rgw.buckets.extra}.each do |pool|
     bash "create-rados-pool-#{pool}" do
         code <<-EOH
             ceph osd pool create #{pool} #{rgw_optimal_pg}


### PR DESCRIPTION
RADOSgw uses .rgw.buckets.extra to store metadata when accepting multipart file uploads. If this pool is not already created, it tries to create it with crush_ruleset 0, size 3, min_size 2, and so the PGs will never go active because crush_ruleset 0 is not one that exists in our setup. This adds that pool to the list of pools to be pre-created.