### PR TITLE
Upgrading RabbitMQ to 3.5.3

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -33,7 +33,7 @@ default['bcpc']['ceph']['version'] = '0.80.9-0ubuntu0.14.04.2'
 default['bcpc']['erlang']['version'] = '1:17.5.3'
 default['bcpc']['haproxy']['version'] = '1.5.12-1ppa1~trusty'
 default['bcpc']['kibana']['version'] = '4.0.2'
-default['bcpc']['rabbitmq']['version'] = '3.5.2-1'
+default['bcpc']['rabbitmq']['version'] = '3.5.3-1'
 
 ###########################################
 #


### PR DESCRIPTION
Unfortunately, RabbitMQ has revved again and the RabbitMQ upstream repository prunes all but the newest patch release. We need to revisit the package version pinning decision, but for now, here's this PR to upgrade the default version.