### PR TITLE
Require minimum Vagrant version of 1.7.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,8 @@
 # Chef server.
 # See http://www.vagrantup.com/ for info on Vagrant.
 
+Vagrant.require_version ">= 1.7.0"
+
 $local_environment = "Test-Laptop"
 $local_mirror = ENV["BOOTSTRAP_APT_MIRROR"]
 

--- a/vbox_create.sh
+++ b/vbox_create.sh
@@ -219,7 +219,7 @@ function create_bootstrap_VM {
                 $VBM createvm --name $vm --ostype Ubuntu_64 --basefolder $P --register
                 $VBM modifyvm $vm --memory $BOOTSTRAP_VM_MEM
                 $VBM modifyvm $vm --cpus $BOOTSTRAP_VM_CPUS
-                $VBM modifyvm $vm --vram $BOOTSTRAP_VM_VRAM
+                $VBM modifyvm $vm --vram 16
                 $VBM storagectl $vm --name "SATA Controller" --add sata
                 $VBM storagectl $vm --name "IDE Controller" --add ide
                 # Create a number of hard disks


### PR DESCRIPTION
A syntax change to the Vagrantfile now requires at least Vagrant 1.7.0 (found out when I tried to use Vagrant 1.6.5 to build, which is the default version installed from vivid upstream).

This PR also fixes an unrelated issue where the `BOOTSTRAP_VM_VRAM` environment variable was still referenced but no longer being set, so bootstrap would fail.