### PR TITLE
Add support for custom flavors

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -392,7 +392,4 @@ default['bcpc']['rally']['user'] = 'ubuntu'
 ###########################################
 
 default['bcpc']['flavors']['deleted'] = []
-default['bcpc']['flavors']['enabled'] = { 
-  "b1.tiny" => { "vcpus" => 1,
-                 "disk_gb" => 0}
-}
+default['bcpc']['flavors']['enabled'] = {}

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -385,7 +385,6 @@ default['bcpc']['bootstrap']['mirror_path'] = "/ubuntu"
 # None needed at this time
 default['bcpc']['rally']['user'] = 'ubuntu'
 
-
 ###########################################
 #
 # Openstack Flavors
@@ -397,6 +396,3 @@ default['bcpc']['flavors']['enabled'] = {
   "b1.tiny" => { "vcpus" => 1,
                  "disk_gb" => 0}
 }
-                 
-                                         
-

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -391,7 +391,7 @@ default['bcpc']['rally']['user'] = 'ubuntu'
 #
 ###########################################
 
-default['bcpc']['flavors']['deleted'] = ["m1.tiny", "m1.small", "m1.medium", "m1.large", "m1.xlarge"]
+default['bcpc']['flavors']['deleted'] = []
 default['bcpc']['flavors']['enabled'] = { 
   "b1.tiny" => { "vcpus" => 1,
                  "disk_gb" => 0}

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -384,3 +384,19 @@ default['bcpc']['bootstrap']['mirror_path'] = "/ubuntu"
 # Package versions
 # None needed at this time
 default['bcpc']['rally']['user'] = 'ubuntu'
+
+
+###########################################
+#
+# Openstack Flavors
+#
+###########################################
+
+default['bcpc']['flavors']['deleted'] = ["m1.tiny", "m1.small", "m1.medium", "m1.large", "m1.xlarge"]
+default['bcpc']['flavors']['enabled'] = { 
+  "b1.tiny" => { "vcpus" => 1,
+                 "disk_gb" => 0}
+}
+                 
+                                         
+

--- a/cookbooks/bcpc/providers/osflavor.rb
+++ b/cookbooks/bcpc/providers/osflavor.rb
@@ -51,6 +51,7 @@ action :create do
                                       "--ephemeral=#{@new_resource.ephemeral_gb}",
                                       "--swap=#{@new_resource.swap_gb}",
                                       "--vcpus=#{@new_resource.vcpus}", 
+                                      "--id=#{@new_resource.flavor_id}",
                                       "#{ispub}"
                                       )
 

--- a/cookbooks/bcpc/providers/osflavor.rb
+++ b/cookbooks/bcpc/providers/osflavor.rb
@@ -1,0 +1,93 @@
+#
+# Cookbook Name:: bcpc
+# Provider:: osflavor
+#
+# Copyright 2013, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'open3'
+require 'json'
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  stdout, stderr, status = Open3.capture3("openstack",
+                                  "--os-tenant-name", node['bcpc']['admin_tenant'], 
+                                  "--os-username",  get_config('keystone-admin-user'),
+                                  "--os-auth-url",  
+                                  "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
+                                  "--os-region-name", node['bcpc']['region_name'],
+                                  "--os-password" , get_config('keystone-admin-password'),
+                                  "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
+                                  "flavor", "show", @new_resource.name , "-f", "json")
+  
+  if not status.success? 
+    converge_by("Creating #{new_resource.name}") do
+      ispub = @new_resource.is_public ? "--public" : "--private"
+      stdout, status = Open3.capture2("openstack",
+                                      "--os-tenant-name", node['bcpc']['admin_tenant'], 
+                                      "--os-username",  get_config('keystone-admin-user'),
+                                      "--os-auth-url",  
+                                      "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
+                                      "--os-region-name", node['bcpc']['region_name'],
+                                      "--os-password" , get_config('keystone-admin-password'),
+                                      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
+                                      "flavor", "create", @new_resource.name , "-f", "json",  
+                                      "--ram=#{@new_resource.memory_mb}", 
+                                      "--disk=#{@new_resource.disk_gb}",
+                                      "--ephemeral=#{@new_resource.ephemeral_gb}",
+                                      "--swap=#{@new_resource.swap_gb}",
+                                      "--vcpus=#{@new_resource.vcpus}", 
+                                      "#{ispub}"
+                                      )
+
+      if not status.success?
+        Chef::Log.error "Failed to create to flavor"
+      end
+    end
+  end   
+end
+
+action :delete do
+  stdout, stderr, status = Open3.capture3("openstack",
+                                          "--os-tenant-name", node['bcpc']['admin_tenant'], 
+                                          "--os-username",  get_config('keystone-admin-user'),
+                                          "--os-auth-url",  
+                                          "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
+                                          "--os-region-name", node['bcpc']['region_name'],
+                                          "--os-password" , get_config('keystone-admin-password'),
+                                          "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
+                                          "flavor", "show", @new_resource.name , "-f", "json")
+  if status.success? 
+    converge_by("deleting #{new_resource.name}") do
+      stdout, status = Open3.capture2("openstack",
+                                      "--os-tenant-name", node['bcpc']['admin_tenant'], 
+                                      "--os-username",  get_config('keystone-admin-user'),
+                                      "--os-auth-url",  
+                                      "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
+                                      "--os-region-name", node['bcpc']['region_name'],
+                                      "--os-password" , get_config('keystone-admin-password'),
+                                      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
+                                      "flavor", "delete", @new_resource.name )
+
+
+      if not status.success?
+        Chef::Log.error "Failed to delete to flavor"
+      end
+    end
+  end
+end
+

--- a/cookbooks/bcpc/recipes/flavors.rb
+++ b/cookbooks/bcpc/recipes/flavors.rb
@@ -24,7 +24,7 @@ node['bcpc']['flavors']['enabled'].each do |name, flavor|
     ephemeral_gb flavor['ephemeral_gb']
     swap_gb flavor['swap_gb']
     is_public flavor['is_public']
-    
+    flavor_id flavor['id']
   end
 end 
 

--- a/cookbooks/bcpc/recipes/flavors.rb
+++ b/cookbooks/bcpc/recipes/flavors.rb
@@ -1,3 +1,20 @@
+# Cookbook Name:: bcpc
+# Recipe:: flavors
+#
+# Copyright 2013, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 node['bcpc']['flavors']['enabled'].each do |name, flavor| 
   bcpc_osflavor name do

--- a/cookbooks/bcpc/recipes/flavors.rb
+++ b/cookbooks/bcpc/recipes/flavors.rb
@@ -1,0 +1,18 @@
+
+node['bcpc']['flavors']['enabled'].each do |name, flavor| 
+  bcpc_osflavor name do
+    memory_mb flavor['memory_mb'] 
+    disk_gb   flavor['disk_gb'] 
+    vcpus  flavor['vcpus'] 
+    ephemeral_gb flavor['ephemeral_gb']
+    swap_gb flavor['swap_gb']
+    is_public flavor['is_public']
+    
+  end
+end 
+
+node['bcpc']['flavors']['deleted'].each do |name| 
+  bcpc_osflavor name do
+    action :delete
+  end
+end

--- a/cookbooks/bcpc/resources/osflavor.rb
+++ b/cookbooks/bcpc/resources/osflavor.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: bcpc
+# Resource:: cephconfig
+#
+# Copyright 2013, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+actions :create, :delete
+default_action :create
+
+attribute :name, :name_attribute => true, :kind_of => String, :required => true
+attribute :id, :kind_of => Fixnum, :required => false
+attribute :memory_mb, :kind_of => Fixnum, :required => false, :default => 512
+attribute :disk_gb, :kind_of => Fixnum, :required => false, :default => 5
+attribute :ephemeral_gb, :kind_of => Fixnum, :required => false, :default => 0
+attribute :swap_gb, :kind_of => Fixnum, :required => false, :default => 0
+attribute :vcpus, :kind_of => Fixnum, :required => false, :default => 1
+attribute :is_public, :kind_of => [ TrueClass, FalseClass ], :required => false, :default => true
+
+
+
+
+
+

--- a/cookbooks/bcpc/resources/osflavor.rb
+++ b/cookbooks/bcpc/resources/osflavor.rb
@@ -22,7 +22,7 @@ actions :create, :delete
 default_action :create
 
 attribute :name, :name_attribute => true, :kind_of => String, :required => true
-attribute :id, :kind_of => Fixnum, :required => false
+attribute :flavor_id, :kind_of => String, :required => false, :default => "auto"
 attribute :memory_mb, :kind_of => Fixnum, :required => false, :default => 512
 attribute :disk_gb, :kind_of => Fixnum, :required => false, :default => 5
 attribute :ephemeral_gb, :kind_of => Fixnum, :required => false, :default => 0

--- a/cookbooks/bcpc/resources/osflavor.rb
+++ b/cookbooks/bcpc/resources/osflavor.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: bcpc
-# Resource:: cephconfig
+# Resource:: osflavor
 #
 # Copyright 2013, Bloomberg Finance L.P.
 #
@@ -29,9 +29,3 @@ attribute :ephemeral_gb, :kind_of => Fixnum, :required => false, :default => 0
 attribute :swap_gb, :kind_of => Fixnum, :required => false, :default => 0
 attribute :vcpus, :kind_of => Fixnum, :required => false, :default => 1
 attribute :is_public, :kind_of => [ TrueClass, FalseClass ], :required => false, :default => true
-
-
-
-
-
-

--- a/roles/BCPC-Headnode.json
+++ b/roles/BCPC-Headnode.json
@@ -30,7 +30,8 @@
       "recipe[bcpc::horizon]",
       "role[BCPC-Worknode]",
       "recipe[bcpc::checks-head]",
-      "recipe[bcpc::rally-keystone-populate]"
+      "recipe[bcpc::rally-keystone-populate]",
+      "recipe[bcpc::flavors]"
     ],
     "description": "A highly-available head node in a BCPC cluster",
     "chef_type": "role",


### PR DESCRIPTION
Ad configured this will delete all flavors installed by default (if present) and create a single new one `b1.tiny`. It is expected that any real cluster would add its own flavors in.