### PR TITLE
Don't collect RabbitMQ queue metrics by default

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -340,6 +340,17 @@ default['bcpc']['graphite']['retention'] = '60s:1d'
 #
 ###########################################
 #
+# Diamond settings
+#
+###########################################
+#
+# List of queue names separated by whitespace to report on. If nil, report all.
+default['bcpc']['diamond']['collectors']['rabbitmq']['queues'] = nil
+# Regular expression or list of queues to not report on.
+# If not nil, this overrides "queues".
+default['bcpc']['diamond']['collectors']['rabbitmq']['queues_ignored'] = '.*'
+###########################################
+#
 # defaults for the bcpc.bootstrap settings
 #
 ###########################################

--- a/cookbooks/bcpc/files/default/build_bins.sh
+++ b/cookbooks/bcpc/files/default/build_bins.sh
@@ -59,8 +59,7 @@ filecheck() {
 
 # Define the appropriate version of each binary to grab/build
 VER_KIBANA=4.0.2
-# newer versions of Diamond depend upon dh-python which isn't in precise/12.04
-VER_DIAMOND=f33aa2f75c6ea2dfbbc659766fe581e5bfe2476d
+VER_DIAMOND=2c0de81281a6750cf06fac760c081f89a088bca4
 VER_ESPLUGIN=9c032b7c628d8da7745fbb1939dcd2db52629943
 
 PROXY_INFO_FILE="/home/vagrant/proxy_info.sh"
@@ -185,7 +184,7 @@ FILES="ubuntu-14.04-mini.iso $FILES"
 
 # Make the diamond package
 if [ ! -f diamond.deb ]; then
-    git clone https://github.com/BrightcoveOS/Diamond.git
+    git clone https://github.com/python-diamond/Diamond.git
     cd Diamond
     git checkout $VER_DIAMOND
     make builddeb

--- a/cookbooks/bcpc/templates/default/diamond.conf.erb
+++ b/cookbooks/bcpc/templates/default/diamond.conf.erb
@@ -234,7 +234,15 @@ innodb = True
 enabled = True
 host=<%=node['bcpc']['management']['ip']%>:55672
 password=<%=get_config('rabbitmq-password')%>
-
+<% if @servers.length > 1 -%>
+cluster = True
+<% end -%>
+<% if not node['bcpc']['diamond']['collectors']['rabbitmq']['queues_ignored'].nil? -%>
+queues_ignored = <%=node['bcpc']['diamond']['collectors']['rabbitmq']['queues_ignored']%>
+<% end -%>
+<% if not node['bcpc']['diamond']['collectors']['rabbitmq']['queues'].nil? -%>
+queues = <%=node['bcpc']['diamond']['collectors']['rabbitmq']['queues']%>
+<% end -%>
 <% end -%>
 
 ################################################################################

--- a/cookbooks/bcpc/templates/default/diamond.conf.erb
+++ b/cookbooks/bcpc/templates/default/diamond.conf.erb
@@ -163,6 +163,24 @@ batch = 100
 # Default Poll Interval (seconds)
 interval = 10
 
+[[CPUCollector]]
+enabled = True
+
+[[DiskSpaceCollector]]
+enabled = True
+
+[[DiskUsageCollector]]
+enabled = True
+
+[[LoadAverageCollector]]
+enabled = True
+
+[[MemoryCollector]]
+enabled = True
+
+[[VMStatCollector]]
+enabled = True
+
 [[KSMCollector]]
 enabled = True
 


### PR DESCRIPTION
On larger Openstack installations, number of RabbitMQ queues can get large and therefore generate a massive amount of metrics that go unused. Ignore these queues until we ascertain what queues/metrics are of interest.

Collect RabbitMQ cluster-level metrics as well if there is more than 1 head node.

This PR depends on a newer version of Diamond as proposed in #614 