### PR TITLE
Fixes a failure that would occur on the initial Chef of a node

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -81,13 +81,13 @@ def search_nodes(key, value)
     if key == "recipe"
         results = search(:node, "recipes:bcpc\\:\\:#{value} AND chef_environment:#{node.chef_environment}")
         results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-        if not results.include?(node) and node.run_list.expand.recipes.include?("bcpc::#{value}")
+        if not results.include?(node) and node.run_list.expand(node.chef_environment).recipes.include?("bcpc::#{value}")
             results.push(node)
         end
     elsif key == "role"
         results = search(:node, "#{key}:#{value} AND chef_environment:#{node.chef_environment}")
         results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-        if not results.include?(node) and node.run_list.expand.roles.include?(value)
+        if not results.include?(node) and node.run_list.expand(node.chef_environment).roles.include?(value)
             results.push(node)
         end
     else


### PR DESCRIPTION
This fixes a problem that was introduced by a change to `search_nodes` in #591. On the first Chef run on a node, the call to `results.include?(node)` would not short-circuit the entire comparison and Chef would evaluate `node.run_list.expand.recipes.include?("bcpc::#{value}")`. `expand` requires at least one parameter (the Chef environment), and so compilation would fail. However, the Chef server would then be updated with the run list and any subsequent Chef runs would short circuit on the comparison and never reach the call to the `expand` method.