### PR TITLE
Release 5 non vagrant

### DIFF
--- a/chefit.sh
+++ b/chefit.sh
@@ -24,19 +24,25 @@ if [[ -z "$CHEF" ]]; then
     $SCPCMD finish-head.sh    /home/ubuntu
 
     if [[ -n "$(source proxy_setup.sh >/dev/null; echo $PROXY)" ]]; then
-	PROXY=$(source proxy_setup.sh >/dev/null; echo $PROXY)
-	echo "setting up .wgetrc's to $PROXY"
-	$SSHCMD "echo \"http_proxy = http://$PROXY\" > .wgetrc"
+	    PROXY=$(source proxy_setup.sh >/dev/null; echo $PROXY)
+	    echo "setting up .wgetrc's to $PROXY"
+	    $SSHCMD "echo \"http_proxy = http://$PROXY\" > .wgetrc"
+
+        # possibly set up a proxy for apt too
+        if [[ -n "$APTPROXY" ]]; then
+	        echo "Acquire::http::Proxy \"http://${APTPROXY}\";" > /tmp/apt.conf
+	        $SCPCMD /tmp/apt.conf /tmp
+	        $SSHCMD "mv /tmp/apt.conf /etc/apt/apt.conf" sudo
+        fi
+
+        echo "setup chef"
+        $SSHCMD  "/home/ubuntu/install-chef.sh" sudo
+    else
+        echo "Chef is installed as $CHEF"
     fi
 
-    echo "setup chef"
-    $SSHCMD  "/home/ubuntu/install-chef.sh" sudo
-else
-    echo "Chef is installed as $CHEF"
-fi
-
-echo "zap disks"
-$SSHCMD "/home/ubuntu/zap-ceph-disks.sh" sudo
+    echo "zap disks"
+    $SSHCMD "/home/ubuntu/zap-ceph-disks.sh" sudo
 
 echo "temporarily adjust system time to avoid time skew related failures"
 GOODDATE=`date`

--- a/chefit.sh
+++ b/chefit.sh
@@ -24,25 +24,26 @@ if [[ -z "$CHEF" ]]; then
     $SCPCMD finish-head.sh    /home/ubuntu
 
     if [[ -n "$(source proxy_setup.sh >/dev/null; echo $PROXY)" ]]; then
-	    PROXY=$(source proxy_setup.sh >/dev/null; echo $PROXY)
-	    echo "setting up .wgetrc's to $PROXY"
-	    $SSHCMD "echo \"http_proxy = http://$PROXY\" > .wgetrc"
+        PROXY=$(source proxy_setup.sh >/dev/null; echo $PROXY)
+        echo "setting up .wgetrc's to $PROXY"
+        $SSHCMD "echo \"http_proxy = http://$PROXY\" > .wgetrc"
 
         # possibly set up a proxy for apt too
         if [[ -n "$APTPROXY" ]]; then
-	        echo "Acquire::http::Proxy \"http://${APTPROXY}\";" > /tmp/apt.conf
-	        $SCPCMD /tmp/apt.conf /tmp
-	        $SSHCMD "mv /tmp/apt.conf /etc/apt/apt.conf" sudo
+            echo "Acquire::http::Proxy \"http://${APTPROXY}\";" > /tmp/apt.conf
+            $SCPCMD /tmp/apt.conf /tmp
+            $SSHCMD "mv /tmp/apt.conf /etc/apt/apt.conf" sudo
         fi
-
-        echo "setup chef"
-        $SSHCMD  "/home/ubuntu/install-chef.sh" sudo
-    else
-        echo "Chef is installed as $CHEF"
     fi
 
-    echo "zap disks"
-    $SSHCMD "/home/ubuntu/zap-ceph-disks.sh" sudo
+    echo "setup chef"
+    $SSHCMD  "/home/ubuntu/install-chef.sh" sudo
+else
+    echo "Chef is installed as $CHEF"
+fi
+
+echo "zap disks"
+$SSHCMD "/home/ubuntu/zap-ceph-disks.sh" sudo
 
 echo "temporarily adjust system time to avoid time skew related failures"
 GOODDATE=`date`

--- a/cluster-check.sh
+++ b/cluster-check.sh
@@ -139,6 +139,13 @@ if [[ -f cluster.txt ]]; then
             vtrace "Root fileystem size = $ROOTSIZE ($ROOTGIGS GB) "
         fi
         
+        if [[ -z `$SSH "ip route show table main | grep default"` ]]; then
+            echo "$HOST no default route in table main !!WARNING!!"
+            BADHOSTS="$BADHOSTS $HOST"
+        else
+            vtrace "$HOST has a default (main) route"
+            MA=$[MA + 1]
+        fi
         if [[ -z `$SSH "ip route show table mgmt | grep default"` ]]; then
             echo "$HOST no mgmt default route !!WARNING!!"
             BADHOSTS="$BADHOSTS $HOST"
@@ -222,7 +229,7 @@ if [[ -f cluster.txt ]]; then
         vftrace "$HOST %20s %s\n" "$SERVICE" "$STAT"
         
         # Finally, check well-known BCPC services run out of upstart
-        for SERVICE in glance-api glance-registry cinder-scheduler cinder-volume cinder-api nova-api nova-novncproxy nova-scheduler nova-consoleauth nova-cert nova-conductor nova-compute nova-network haproxy apache2 routemon tpm; do
+        for SERVICE in keystone glance-api glance-registry cinder-scheduler cinder-volume cinder-api nova-api nova-novncproxy nova-scheduler nova-consoleauth nova-cert nova-conductor nova-compute nova-network haproxy apache2 routemon tpm; do
             STAT=`$SSH "service $SERVICE status 2>&1"`
             if [[ ! "$STAT" =~ "unrecognized" ]]; then
                 
@@ -270,7 +277,7 @@ if [[ -f cluster.txt ]]; then
 else
     echo "Warning 'cluster.txt' not found"
 fi
-echo "$ENVIRONMENT cluster summary: $UP hosts up. $MG hosts with default mgmt route. $SG hosts with default storage route"
+echo "$ENVIRONMENT cluster summary: $UP hosts up. $MA hosts with default main route. $MG hosts with default mgmt route. $SG hosts with default storage route"
 BADHOSTS=`echo $BADHOSTS | uniq | sort`
 if [[ ! -z "$BADHOSTS" ]]; then
     echo "Bad hosts $BADHOSTS - definite issues on these"

--- a/cluster-nuke.sh
+++ b/cluster-nuke.sh
@@ -59,12 +59,12 @@ knife data bag show configs "${ENVIRONMENT}" >> "${DATABAG_BACKUP}"
 echo "Databag configs for ${ENVIRONMENT} dumped to ${DATABAG_BACKUP}"
 
 echo "Deleting data bag configs..."
-knife data bag delete configs
+knife data bag delete --yes configs
 
 echo "Removing clients and nodes..."
 for CLIENT in $CLUSTER_MEMBERS; do
-    knife client delete "${CLIENT}.${BOOTSTRAP_DOMAIN}"
-    knife node   delete "${CLIENT}.${BOOTSTRAP_DOMAIN}"
+    knife client delete --yes "${CLIENT}.${BOOTSTRAP_DOMAIN}"
+    knife node   delete --yes "${CLIENT}.${BOOTSTRAP_DOMAIN}"
 done
 
 echo "reload knife data..."

--- a/cluster-rechef.sh
+++ b/cluster-rechef.sh
@@ -6,7 +6,15 @@
 # This script uses cluster.txt to find cluster node definitions, see
 # cluster-readme.txt for details
 #
-#set -x
+
+myping() {
+    if  hash fping 2>/dev/null; then
+        RES=`fping -aq $1`
+    else
+        RES=`ping -c 1 $1 | grep ttl`
+    fi
+    echo $RES
+}
 if [[ -z "$1" ]]; then
     echo "Usage: $0 environment (role)"
     exit
@@ -16,23 +24,24 @@ fi
 ROLE_REQUESTED="$2"
 if [[ -f cluster.txt ]]; then
     while read HOSTNAME MACADDR IPADDR ILOIPADDR DOMAIN ROLE; do
-	if [[ $HOSTNAME = "end" ]]; then
-	    continue
-	fi
-	if [[ -z "$ROLE_REQUESTED" || "$ROLE" = "$ROLE_REQUESTED"  ]]; then
-	    HOSTS="$HOSTS $HOSTNAME"
-	    IPS="$IPS $IPADDR"
-	fi
+        if [[ $HOSTNAME = "end" ]]; then
+            continue
+        fi
+        if [[ -z "$ROLE_REQUESTED" || "$ROLE" = "$ROLE_REQUESTED"  ]]; then
+            HOSTS="$HOSTS $HOSTNAME"
+            IPS="$IPS $IPADDR"
+        fi
     done < cluster.txt
     echo "HOSTS = $HOSTS"
     for HOST in $IPS; do
-	if [[ -z `fping -aq $HOST` ]]; then
-	    echo $HOST is down
-	    continue
-	else
-	    echo $HOST is up
-	fi
-	./nodessh.sh $ENVIRONMENT $HOST "chef-client" sudo
+        RES=`myping $HOST`
+        if [[ -z $RES ]]; then
+            echo $HOST is down
+            continue
+        else
+            echo $HOST is up
+        fi
+        ./nodessh.sh $ENVIRONMENT $HOST "chef-client" sudo
     done
 fi
 

--- a/cookbooks/bcpc/files/default/build_bins.sh
+++ b/cookbooks/bcpc/files/default/build_bins.sh
@@ -66,7 +66,12 @@ VER_ESPLUGIN=9c032b7c628d8da7745fbb1939dcd2db52629943
 PROXY_INFO_FILE="/home/vagrant/proxy_info.sh"
 if [[ -f $PROXY_INFO_FILE ]]; then
   . $PROXY_INFO_FILE
+elif [[ -f $HOME/chef-bcpc/proxy_setup.sh ]]
+then
+  . $HOME/chef-bcpc/proxy_setup.sh
 fi
+
+
 
 # define calling gem with a proxy if necessary
 if [[ -z $http_proxy ]]; then

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -81,13 +81,13 @@ def search_nodes(key, value)
     if key == "recipe"
         results = search(:node, "recipes:bcpc\\:\\:#{value} AND chef_environment:#{node.chef_environment}")
         results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-        if not results.include?(node) and node.run_list.expand.recipes.include?("bcpc::#{value}")
+        if not results.include?(node) and node.run_list.expand(node.chef_environment).recipes.include?("bcpc::#{value}")
             results.push(node)
         end
     elsif key == "role"
         results = search(:node, "#{key}:#{value} AND chef_environment:#{node.chef_environment}")
         results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
-        if not results.include?(node) and node.run_list.expand.roles.include?(value)
+        if not results.include?(node) and node.run_list.expand(node.chef_environment).roles.include?(value)
             results.push(node)
         end
     else

--- a/finish-worker.sh
+++ b/finish-worker.sh
@@ -7,4 +7,4 @@
 #
 #service glance-api       restart
 #service glance-registry  restart
-#chef-client
+chef-client

--- a/proxy_setup.sh
+++ b/proxy_setup.sh
@@ -8,6 +8,10 @@
 # hypervisor. Change to reflect your real proxy info
 #export PROXY="10.0.100.2:3128"
 
+# define APTPROXY if your apt mirror is accessed via the proxy
+# do not define if it's local (e.g. on the bootstrap node as per the apache-mirror recipe).
+#export APTPROXY=$PROXY
+
 export CURL='curl'
 if [ -n "$PROXY" ]; then
     


### PR DESCRIPTION
Fix up the non-vagrant build path following the move to Trusty/Kilo. 

Also add another check to cluster-check.sh to spot a nasty issue that cropped up in such a build where default routes in table main disappeared and led to very odd behavior.