### PR TITLE
Avoid MySQL deadlocks with Zabbix

### DIFF
--- a/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
@@ -40,7 +40,7 @@ listen mysql-galera <%=node['bcpc']['management']['monitoring']['vip']%>:3306
   option tcpka
   option httpchk
 <% @servers.each do |server| -%>
-  <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:3306 check port 3307 inter 5s rise 1 fall 1 observe layer4" %>
+  <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:3306 check port 3307 inter 5s rise 1 fall 1 observe layer4 backup" %>
 <% end -%>
 
 frontend https


### PR DESCRIPTION
Make only one MySQL server operational at any one time to avoid MySQL deadlocks with Zabbix.