### PR TITLE
Prioritize Ceph OSD and monitor processes higher

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -121,6 +121,10 @@ default['bcpc']['ceph']['hdd']['ruleset'] = 2
 # See wiki for further details. 
 default['bcpc']['ceph']['rebalance'] = false
 
+# Set the default niceness of Ceph OSD and monitor processes
+default['bcpc']['ceph']['osd_niceness'] = -10
+default['bcpc']['ceph']['mon_niceness'] = -10
+
 ###########################################
 #
 # RabbitMQ settings

--- a/cookbooks/bcpc/recipes/ceph-head.rb
+++ b/cookbooks/bcpc/recipes/ceph-head.rb
@@ -27,6 +27,19 @@ bash 'ceph-mon-mkfs' do
     not_if "test -f /var/lib/ceph/mon/ceph-#{node['hostname']}/keyring"
 end
 
+template '/etc/init/ceph-mon-renice.conf' do
+  source 'ceph-upstart.ceph-mon-renice.conf.erb'
+  mode 00644
+  notifies :restart, "service[ceph-mon-renice]", :immediately
+end
+
+service 'ceph-mon-renice' do
+  provider Chef::Provider::Service::Upstart
+  action [:enable, :start]
+  restart_command 'service ceph-mon-renice restart'
+end
+
+
 execute "ceph-mon-start" do
     command "initctl emit ceph-mon id='#{node['hostname']}'"
 end

--- a/cookbooks/bcpc/recipes/ceph-work.rb
+++ b/cookbooks/bcpc/recipes/ceph-work.rb
@@ -80,6 +80,18 @@ ruby_block "reap-ceph-disks-from-dead-servers" do
     end
 end
 
+template '/etc/init/ceph-osd-renice.conf' do
+  source 'ceph-upstart.ceph-osd-renice.conf.erb'
+  mode 00644
+  notifies :restart, "service[ceph-osd-renice]", :immediately
+end
+
+service 'ceph-osd-renice' do
+  provider Chef::Provider::Service::Upstart
+  action [:enable, :start]
+  restart_command 'service ceph-osd-renice restart'
+end
+
 # this resource is to clean up leftovers from the CephFS resources that used to be here
 bash "clean-up-cephfs-mountpoint" do
   code "sed -i 's/^-- \\/mnt fuse\\.ceph-fuse rw,nosuid,nodev,noexec,noatime,noauto 0 2$//g' /etc/fstab"

--- a/cookbooks/bcpc/templates/default/ceph-upstart.ceph-mon-renice.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph-upstart.ceph-mon-renice.conf.erb
@@ -1,0 +1,8 @@
+description "Ceph monitor renicer"
+
+start on started ceph-mon-all
+
+post-start script
+  pgrep ceph-mon | xargs renice <%=node['bcpc']['ceph']['mon_niceness']%>
+end script
+

--- a/cookbooks/bcpc/templates/default/ceph-upstart.ceph-osd-renice.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph-upstart.ceph-osd-renice.conf.erb
@@ -1,0 +1,7 @@
+description "Ceph OSD renicer"
+
+start on started ceph-osd-all
+
+post-start script
+  pgrep ceph-osd | xargs renice <%=node['bcpc']['ceph']['osd_niceness']%>
+end script


### PR DESCRIPTION
This PR creates a simple upstart script that renices Ceph OSD processes to -10 after they have all been started. Some load pressure testing showed that re-nicing the OSDs kept responsiveness higher under high to extreme load conditions (hypervisor load averages of 10 or higher, tested up to 50).