### PR TITLE
Moving the dhcp-server patch from nova-setup.rb to nova-work.rb

### DIFF
--- a/cookbooks/bcpc/recipes/nova-setup.rb
+++ b/cookbooks/bcpc/recipes/nova-setup.rb
@@ -20,37 +20,6 @@
 include_recipe "bcpc::keystone"
 include_recipe "bcpc::nova-head"
 
-#  _   _  ____ _  __   __  ____   _  _____ ____ _   _
-# | | | |/ ___| | \ \ / / |  _ \ / \|_   _/ ___| | | |
-# | | | | |  _| |  \ V /  | |_) / _ \ | || |   | |_| |
-# | |_| | |_| | |___| |   |  __/ ___ \| || |___|  _  |
-#  \___/ \____|_____|_|   |_| /_/   \_\_| \____|_| |_|
-# this patch resolves OpenStack issue #1456321 and BCPC issue #573 -
-# fixes DHCP server assignment so that each fixed IP subnet gets its gateway
-# address as its DHCP server by default instead of all subnets getting the
-# gateway of the lowest subnet
-cookbook_file "/tmp/nova-network-dhcp-server.patch" do
-    source "nova-network-dhcp-server.patch"
-    owner "root"
-    mode 00644
-end
-
-bash "patch-for-nova-network-dhcp-server" do
-    user "root"
-    code <<-EOH
-       cd /usr/lib/python2.7/dist-packages
-       patch -p1 < /tmp/nova-network-dhcp-server.patch
-       rv=$?
-       if [ $rv -ne 0 ]; then
-         echo "Error applying patch ($rv) - aborting!"
-         exit $rv
-       fi
-       cp /tmp/nova-network-dhcp-server.patch .
-    EOH
-    not_if "test -f /usr/lib/python2.7/dist-packages/nova-network-dhcp-server.patch"
-    notifies :restart, "service[nova-api]", :immediately
-end
-
 # spin until nova starts to respond, avoids blowing up on an HTTP 503
 # if Apache was restarted recently and is not yet ready
 bash "wait-for-nova-to-become-operational" do

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -40,6 +40,37 @@ service "nova-api" do
     restart_command "service nova-api restart; sleep 5"
 end
 
+#  _   _  ____ _  __   __  ____   _  _____ ____ _   _
+# | | | |/ ___| | \ \ / / |  _ \ / \|_   _/ ___| | | |
+# | | | | |  _| |  \ V /  | |_) / _ \ | || |   | |_| |
+# | |_| | |_| | |___| |   |  __/ ___ \| || |___|  _  |
+#  \___/ \____|_____|_|   |_| /_/   \_\_| \____|_| |_|
+# this patch resolves OpenStack issue #1456321 and BCPC issue #573 -
+# fixes DHCP server assignment so that each fixed IP subnet gets its gateway
+# address as its DHCP server by default instead of all subnets getting the
+# gateway of the lowest subnet
+cookbook_file "/tmp/nova-network-dhcp-server.patch" do
+    source "nova-network-dhcp-server.patch"
+    owner "root"
+    mode 00644
+end
+
+bash "patch-for-nova-network-dhcp-server" do
+    user "root"
+    code <<-EOH
+       cd /usr/lib/python2.7/dist-packages
+       patch -p1 < /tmp/nova-network-dhcp-server.patch
+       rv=$?
+       if [ $rv -ne 0 ]; then
+         echo "Error applying patch ($rv) - aborting!"
+         exit $rv
+       fi
+       cp /tmp/nova-network-dhcp-server.patch .
+    EOH
+    not_if "test -f /usr/lib/python2.7/dist-packages/nova-network-dhcp-server.patch"
+    notifies :restart, "service[nova-api]", :immediately
+end
+
 %w{novnc pm-utils memcached sysfsutils}.each do |pkg|
     package pkg do
         action :upgrade


### PR DESCRIPTION
This is a minor change to move this DHCP server patch that was originally created to fix #573 from `nova-setup.rb` to `nova-work.rb`, so that it applies to all compute hosts and not just head nodes.