### PR TITLE
Check to see if ['bcpc']['vagrant'] exists first before sub-indexing

### DIFF
--- a/cookbooks/bcpc/templates/default/sshd_config.erb
+++ b/cookbooks/bcpc/templates/default/sshd_config.erb
@@ -8,7 +8,7 @@
 Port 22
 # Use these options to restrict which interfaces/protocols sshd will bind to
 #ListenAddress ::
-<% if node['bcpc']['vagrant']['nat_ip'] %>
+<% if node['bcpc']['vagrant'] and node['bcpc']['vagrant']['nat_ip'] %>
 ListenAddress <%= node['bcpc']['vagrant']['nat_ip'] %>
 <% end %>
 ListenAddress <%= node['bcpc']['management']['ip'] %>


### PR DESCRIPTION
This fixes #641, which was my fault.