### PR TITLE
Adding a way to hide Horizon panels via the Chef environment

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -245,6 +245,17 @@ default['bcpc']['protocol']['nova'] = "https"
 default['bcpc']['protocol']['cinder'] = "https"
 default['bcpc']['protocol']['heat'] = "https"
 
+
+###########################################
+#
+#  Horizon Settings
+#
+###########################################
+#
+# List panels to remove from the Horizon interface here
+# (if the last panel in a group is removed, the group will also be removed)
+default['bcpc']['horizon']['disable_panels'] = ['containers']
+
 ###########################################
 #
 #  Keystone Settings

--- a/cookbooks/bcpc/recipes/horizon.rb
+++ b/cookbooks/bcpc/recipes/horizon.rb
@@ -65,6 +65,22 @@ bash "patch-for-horizon-swift-content-length" do
     notifies :restart, "service[apache2]", :delayed
 end
 
+# this adds a way to override and customize Horizon's behavior
+horizon_customize_dir = ::File.join('/', 'usr', 'local', 'bcpc-horizon', 'bcpc')
+directory horizon_customize_dir do
+  action    :create
+  recursive true
+end
+
+file ::File.join(horizon_customize_dir, '__init__.py') do
+  action :create
+end
+
+template ::File.join(horizon_customize_dir, 'overrides.py') do
+  source   'horizon.overrides.py.erb'
+  notifies :restart, "service[apache2]", :delayed
+end
+
 package "cobalt-horizon" do
     only_if { not node["bcpc"]["vms_key"].nil? }
     action :upgrade
@@ -76,7 +92,7 @@ package "openstack-dashboard-ubuntu-theme" do
     notifies :run, "bash[dpkg-reconfigure-openstack-dashboard]", :delayed
 end
 
-# This maybe better served by a2disconf
+# This may be better served by a2disconf
 file "/etc/apache2/conf-enabled/openstack-dashboard.conf" do
     action :delete
     notifies :restart, "service[apache2]", :delayed

--- a/cookbooks/bcpc/templates/default/apache-openstack-dashboard.conf.erb
+++ b/cookbooks/bcpc/templates/default/apache-openstack-dashboard.conf.erb
@@ -10,7 +10,7 @@ Listen <%=node['bcpc']['management']['ip']%>:9999
     ServerName "openstack.<%=node['bcpc']['domain_name']%>"
 
     WSGIScriptAlias /horizon /usr/share/openstack-dashboard/openstack_dashboard/wsgi/django.wsgi
-    WSGIDaemonProcess horizon user=www-data group=www-data processes=3 threads=10
+    WSGIDaemonProcess horizon user=www-data group=www-data processes=3 threads=10 python-path=/usr/local/bcpc-horizon
     WSGIProcessGroup horizon
     Alias /static /usr/share/openstack-dashboard/openstack_dashboard/static/
     <Directory /usr/share/openstack-dashboard/openstack_dashboard/wsgi>

--- a/cookbooks/bcpc/templates/default/horizon.local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/horizon.local_settings.py.erb
@@ -76,6 +76,8 @@ DATABASES = {
 
 # Default OpenStack Dashboard configuration.
 HORIZON_CONFIG = {
+    # overrides module is in /usr/local/bcpc-horizon
+    'customization_module': 'bcpc.overrides',
     'simple_ip_management' : False,	
     'user_home': 'openstack_dashboard.views.get_user_home',
     'ajax_queue_limit': 10,

--- a/cookbooks/bcpc/templates/default/horizon.overrides.py.erb
+++ b/cookbooks/bcpc/templates/default/horizon.overrides.py.erb
@@ -1,0 +1,14 @@
+from django.utils.translation import ugettext_lazy as _
+
+import horizon
+
+<% if node['bcpc']['horizon'] and node['bcpc']['horizon']['disable_panels'] %>
+# edit bcpc.horizon.disable_panels in the Chef env to add/remove panels
+panels_to_remove = <%=node['bcpc']['horizon']['disable_panels']%>
+
+projects_dashboard = horizon.get_dashboard('project')
+for panel in panels_to_remove:
+    removed_panel = projects_dashboard.get_panel(panel)
+    projects_dashboard.unregister(removed_panel.__class__)
+# end for panel in panels_to_remove
+<% end %>


### PR DESCRIPTION
This PR adds a mechanism via attributes for disabling panels in Horizon via the Django slug (see `openstack_dashboard/dashboards/project/dashboard.py` for the full list), and disables the Object Store panel, because the feature doesn't work for us.