### PR TITLE
Optionally bootstrap 1-3 monitoring nodes

### DIFF
--- a/bootstrap/config/bootstrap_config.sh.template
+++ b/bootstrap/config/bootstrap_config.sh.template
@@ -56,3 +56,7 @@
 # Sets the size of disks (in MB) given to cluster VMs.
 # export CLUSTER_VM_DRIVE_SIZE=20480
 
+# Sets the number of monitoring VMs to bootstrap. Please ensure you have
+# sufficient hardware resources to run these additional VMs.
+# Valid range is 0-3 (default 0).
+# export MONITORING_NODES=0

--- a/bootstrap/vagrant_scripts/BOOT_GO.sh
+++ b/bootstrap/vagrant_scripts/BOOT_GO.sh
@@ -50,6 +50,7 @@ export BOOTSTRAP_VM_DRIVE_SIZE=${BOOTSTRAP_VM_DRIVE_SIZE:-20480}
 export CLUSTER_VM_MEM=${CLUSTER_VM_MEM:-2560}
 export CLUSTER_VM_CPUS=${CLUSTER_VM_CPUS:-2}
 export CLUSTER_VM_DRIVE_SIZE=${CLUSTER_VM_DRIVE_SIZE:-20480}
+export MONITORING_NODES=${MONITORING_NODES:-0}
 
 # Perform preflight checks to validate environment sanity as much as possible.
 echo "Performing preflight environment validation..."

--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -16,6 +16,7 @@ $https_proxy_server = ENV["BOOTSTRAP_HTTPS_PROXY"]
 $additional_cacerts_dir = ENV["BOOTSTRAP_ADDITIONAL_CACERTS_DIR"]
 $box_url = "#{ENV['BOOTSTRAP_CACHE_DIR']}/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 $packages_to_remove = ['puppet', 'puppet-common']
+$monitoring_nodes = ENV["MONITORING_NODES"].to_i
 
 # if a directory with additional CA certs is provided, test each file in there to
 # verify that it's a certificate and then add it to a script to be run inside each VM
@@ -177,8 +178,17 @@ Vagrant.configure("2") do |config|
     end
   end # bootstrap node
   
+  $cluster_nodes = 3
+  unless $monitoring_nodes.nil? or $monitoring_nodes == 0
+    if (1..3).include?($monitoring_nodes)
+      $cluster_nodes += $monitoring_nodes
+    else
+      raise "Invalid number of monitoring nodes specified"
+    end
+  end
+
   # configure cluster nodes
-  (1..3).each do |i|
+  (1..$cluster_nodes).each do |i|
     config.vm.define "vm#{i}" do |machine|
       machine.vm.hostname = "bcpc-vm#{i}.#{$bootstrap_domain}"
 
@@ -201,7 +211,7 @@ Vagrant.configure("2") do |config|
         s.inline = $update_ca_certificates_script
       end
           
-    # configure proxy servers (do not run as root)
+      # configure proxy servers (do not run as root)
       machine.vm.provision "configure-proxy-servers", type: "shell" do |s|
         s.privileged = false
         s.inline = $proxy_configuration_script
@@ -266,7 +276,7 @@ Vagrant.configure("2") do |config|
             vb.customize ["storageattach", :id, "--storagectl", "SATAController", "--device", "0", "--port", "#{idx+1}", "--type", "hdd", "--medium", disk_file]
           end # File.exist
         end # b..e each
-      end # config.vimprovider
-    end
-  end
+      end # machine.vm.provider
+    end # config.vm.define
+  end # 1..$cluster_nodes each
 end

--- a/bootstrap/vagrant_scripts/vagrant_clean.sh
+++ b/bootstrap/vagrant_scripts/vagrant_clean.sh
@@ -2,4 +2,6 @@
 # Exit immediately if anything goes wrong, instead of making things worse.
 set -e
 
+# Set this to max value to ensure leftover mon VMs are destroyed
+MONITORING_NODES=3
 cd $REPO_ROOT/bootstrap/vagrant_scripts && vagrant destroy -f

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,6 +9,11 @@ Can I use VMware instead of VirtualBox for a local cluster?
 ---
 Not at present, but it is something we'd like to offer.
 
+Why can't I ssh to the monitoring VMs?
+---
+The short answer is, `vagrant` requires the presence of MONITORING_NODES environment variable to track the mon VMs that have been built. Use the following example command to ssh to your mon VM(s):
+ MONITORING_NODES=3 vagrant ssh vm6
+
 Why is it so slow when running locally?
 ---
 A couple of reasons:

--- a/docs/building_with_vagrant.md
+++ b/docs/building_with_vagrant.md
@@ -5,8 +5,8 @@ Introduction
 ------------
 To get started with BCPC locally, we strongly recommend using the Vagrant mechanism. Vagrant is a tool that allows for easy provisioning of development environments that can be downloaded from [https://www.vagrantup.com](https://www.vagrantup.com).
 
-Prerequisites
--------------
+Minimum Prerequisites
+---------------------
 * OS X or Linux
 * Processor that supports VT-x virtualization extensions
 * 16 GB of memory
@@ -44,10 +44,10 @@ Glad you asked! Of course you may read all the scripts within to see exactly wha
 4. `BOOT_GO.sh` runs `bootstrap/common_scripts/bootstrap_prereqs.sh`, which downloads various files used by the bootstrap process (not all of them are used by the Vagrant method of bootstrapping, but this script is shared between the Vagrant and non-Vagrant bootstrap pathways). The script has a full and complete list of all files that are downloaded, and the total size of all downloaded files is around 1 GB.
 5. `BOOT_GO.sh` runs `bootstrap/vagrant_scripts/vagrant_clean.sh`, which is effectively a wrapper for `vagrant destroy -f` (delete any existing BCPC VMs). If you have BCPC VMs around that were built using the older bootstrap process, this will **not** recognize them and you will need to delete them from VirtualBox manually (you will get an error message when Vagrant tries to launch the new cluster).
 6. `BOOT_GO.sh` runs `bootstrap/vagrant_scripts/vagrant_create.sh`, which clears out existing VirtualBox DHCP server configurations and then calls `vagrant up`.
-7. `vagrant up` reads the `Vagrantfile` and launches 4 VMs: one bootstrap node and 3 BCPC cluster nodes. `Vagrantfile` performs some additional environment validations and then launches each VM in turn, provisioning it with some inline shell scripts in the Vagrantfile, creating networks and assigning network addresses, and creating extra disks for the BCPC cluster nodes.
+7. `vagrant up` reads the `Vagrantfile` and launches 4 VMs by default: one bootstrap node and 3 BCPC cluster nodes. `Vagrantfile` performs some additional environment validations and then launches each VM in turn, provisioning it with some inline shell scripts in the Vagrantfile, creating networks and assigning network addresses, and creating extra disks for the BCPC cluster nodes.
 8. `BOOT_GO.sh` runs `bootstrap/vagrant_scripts/vagrant_configure_chef.sh`, which is where the meat of the cluster setup happens.
-9. `vagrant_configure_chef.sh` installs Chef Server 12 on the bootstrap node and Chef Client 12 on all 4 nodes. On the bootstrap node, it configures credentials for the nodes to access Chef Server, executes `knife bootstrap` to link the nodes to the Chef Server installation (but does not immediately begin the provisioning process), and configures Chef client permissions so that the head node and bootstrap node can write items into a Chef data bag. It then copies the BCPC repository into the bootstrap VM via VirtualBox shared folders, executes `bootstrap/common_scripts/common_build_bins.sh` within the bootstrap VM to build various binary packages, uploads the `bcpc` cookbook and its dependencies to Chef Server, and selects the roles for each cluster node.
-10. If `$BOOTSTRAP_CHEF_DO_CONVERGE` is set to `1` (the default), `vagrant_configure_chef.sh` will execute Chef on each node in turn to converge it with the BCPC recipes, and then execute Chef on the head node one more time so that the head node can update itself based on the roles assigned to the other two nodes.
+9. `vagrant_configure_chef.sh` installs Chef Server 12 on the bootstrap node and Chef Client 12 on all nodes. On the bootstrap node, it configures credentials for the nodes to access Chef Server, executes `knife bootstrap` to link the nodes to the Chef Server installation (but does not immediately begin the provisioning process), and configures Chef client permissions so that the head, bootstrap and monitoring (if any) nodes can write items into a Chef data bag. It then copies the BCPC repository into the bootstrap VM via VirtualBox shared folders, executes `bootstrap/common_scripts/common_build_bins.sh` within the bootstrap VM to build various binary packages, uploads the `bcpc` cookbook and its dependencies to Chef Server, and selects the roles for each cluster node.
+10. If `$BOOTSTRAP_CHEF_DO_CONVERGE` is set to `1` (the default), `vagrant_configure_chef.sh` will execute Chef on each node in turn to converge it with the BCPC recipes, and then execute Chef on the head and monitoring nodes one more time so that they can update themselves based on the roles assigned to the other nodes.
 11. If you allowed `vagrant_configure_chef.sh` to converge the cluster nodes, `BOOT_GO.sh` runs `bootstrap/vagrant_scripts/vagrant_print_useful_info.sh`, which prints out the URL of the BCPC landing page and some passwords to get you going.
 
 Something didn't work!


### PR DESCRIPTION
As head nodes do not run monitoring, this updates the bootstrap process to optionally deploy additional VM(s) for the monitoring role. Monitoring bootstrapping is disabled by default, as anecdotally, a functional Openstack cluster is generally the requirement.