### PR TITLE
Extending Keystone wait timeout and making it an attribute

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -260,6 +260,10 @@ default['bcpc']['keystone']['enable_caching'] = true
 default['bcpc']['keystone']['debug'] = false
 # Enable verbose logging.
 default['bcpc']['keystone']['verbose'] = false
+# Set the timeout for how long we will wait for Keystone to become operational
+# before failing (configures timeout on the wait-for-keystone-to-be-operational
+# spinlock guard).
+default['bcpc']['keystone']['wait_for_keystone_timeout'] = 120
 # This can be either 'sql' or 'ldap' to either store identities
 # in the mysql DB or the LDAP server
 default['bcpc']['keystone']['backend'] = 'sql'

--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -153,7 +153,7 @@ end
 # if something above has restarted Apache and Keystone isn't ready to play yet
 bash "wait-for-keystone-to-become-operational" do
   code ". /root/keystonerc; until keystone user-list >/dev/null 2>&1; do sleep 1; done"
-  timeout 30
+  timeout node['bcpc']['keystone']['wait_for_keystone_timeout']
 end
 
 


### PR DESCRIPTION
Apparently 30 seconds isn't always enough time to wait for Keystone to get ready. :water_buffalo: 