### PR TITLE
Make monitoring hostnames work and provide overrides

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -990,6 +990,9 @@ default['bcpc']['cpupower']['ondemand_up_threshold'] = nil
 #
 ###########################################
 #
+# Graphite Server FQDN
+default['bcpc']['graphite']['fqdn'] = "graphite.#{node['bcpc']['domain_name']}"
+#
 # Default retention rates
 # http://graphite.readthedocs.org/en/latest/config-carbon.html#storage-schemas-conf
 default['bcpc']['graphite']['retention'] = '60s:1d'
@@ -1023,6 +1026,7 @@ default['bcpc']['bootstrap']['mirror_path'] = "/ubuntu"
 # Default retention rates
 # http://graphite.readthedocs.org/en/latest/config-carbon.html#storage-schemas-conf
 default['bcpc']['graphite']['retention'] = '60s:1d'
+
 #
 ###########################################
 #
@@ -1070,4 +1074,12 @@ default['bcpc']['flavors']['enabled'] = {}
 #
 default['bcpc']['zabbix']['discovery']['delay'] = 600
 default['bcpc']['zabbix']['discovery']['ip_ranges'] = [node['bcpc']['management']['cidr']]
-
+default['bcpc']['zabbix']['fqdn'] = "zabbix.#{node['bcpc']['domain_name']}"
+###########################################
+#
+# Kibana settings
+#
+###########################################
+#
+# Kibana Server FQDN
+default['bcpc']['kibana']['fqdn'] = "kibana.#{node['bcpc']['domain_name']}"

--- a/cookbooks/bcpc/templates/default/apache-graphite-web.conf.erb
+++ b/cookbooks/bcpc/templates/default/apache-graphite-web.conf.erb
@@ -7,8 +7,6 @@
 Listen <%=node['bcpc']['management']['ip']%>:8888
 
 <VirtualHost <%=node['bcpc']['management']['ip']%>:8888>
-    ServerName "graphite.<%=node['bcpc']['domain_name']%>"
-
     DocumentRoot "/opt/graphite/webapp"
 
     # I've found that an equal number of processes & threads tends

--- a/cookbooks/bcpc/templates/default/apache-zabbix-web.conf.erb
+++ b/cookbooks/bcpc/templates/default/apache-zabbix-web.conf.erb
@@ -7,7 +7,6 @@
 Listen <%=node['bcpc']['management']['ip']%>:7777
 
 <VirtualHost <%=node['bcpc']['management']['ip']%>:7777>
-    ServerName zabbix.<%=node['bcpc']['domain_name']%>
     DocumentRoot "/usr/local/share/zabbix/php"
     <Directory /usr/local/share/zabbix/php>
         Require all granted

--- a/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
@@ -56,10 +56,16 @@ frontend https
   redirect code 301 prefix / append-slash if kibana_missing_slash
   acl url_kibana path_beg /kibana
   use_backend kibana-backend if url_kibana
+  acl host_kibana hdr_beg(Host) kibana.
+  use_backend kibana-backend if host_kibana
   acl url_elasticsearch path_beg /elasticsearch
   use_backend elasticsearch-backend if url_elasticsearch
   acl url_zabbix path_beg /zabbix
   use_backend zabbix-backend if url_zabbix
+  acl host_zabbix hdr_beg(Host) zabbix.
+  use_backend zabbix-backend if host_zabbix
+  acl host_graphite hdr_beg(Host) graphite.
+  use_backend graphite-web-backend if host_graphite
 
 backend graphite-web-backend
   balance source

--- a/cookbooks/bcpc/templates/default/index.html.erb
+++ b/cookbooks/bcpc/templates/default/index.html.erb
@@ -58,19 +58,19 @@
 				<label>Kibana</label>
 				<a href="https://<%=node['bcpc']['management']['monitoring']['vip']%>/kibana/">https://<%=node['bcpc']['management']['monitoring']['vip']%>/kibana/</a>
 				<br/><label>-</label>
-				<a href="https://kibana.<%=node['bcpc']['domain_name']%>">https://kibana.<%=node['bcpc']['domain_name']%></a>
+                <a href="https://<%=node['bcpc']['kibana']['fqdn']%>">https://<%=node['bcpc']['kibana']['fqdn']%></a>
 			</div>
 			<div class="block">
 				<label>Graphite</label>
 				<a href="https://<%=node['bcpc']['management']['monitoring']['vip']%>:8888">https://<%=node['bcpc']['management']['monitoring']['vip']%>:8888</a>
 				<br/><label>-</label>
-				<a href="https://graphite.<%=node['bcpc']['domain_name']%>">https://graphite.<%=node['bcpc']['domain_name']%></a>
+                <a href="https://<%=node['bcpc']['graphite']['fqdn']%>">https://<%=node['bcpc']['graphite']['fqdn']%></a>
 			</div>
 			<div class="block">
 				<label>Zabbix</label>
-				<a href="https://<%=node['bcpc']['management']['vip']%>/zabbix/">https://<%=node['bcpc']['management']['vip']%>/zabbix/</a>
+				<a href="https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/">https://<%=node['bcpc']['management']['monitoring']['vip']%>/zabbix/</a>
 				<br/><label>-</label>
-				<a href="https://zabbix.<%=node['bcpc']['domain_name']%>">https://zabbix.<%=node['bcpc']['domain_name']%></a>
+                <a href="https://<%=node['bcpc']['zabbix']['fqdn']%>">https://<%=node['bcpc']['zabbix']['fqdn']%></a>
 			</div>
 
 		<h3>API Endpoints</h3>

--- a/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
@@ -41,8 +41,8 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
     ((SELECT id FROM domains WHERE name='<%=@domain_name%>'), 'openstack.<%=@domain_name%>', 'A', '<%=@management_vip%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@domain_name%>'), name='openstack.<%=@domain_name%>', type='A', content='<%=@management_vip%>', bcpc_record_type='STATIC';
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM domains WHERE name='<%=@domain_name%>'), 'zabbix.<%=@domain_name%>', 'A', '<%=@management_vip%>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@domain_name%>'), name='zabbix.<%=@domain_name%>', type='A', content='<%=@management_vip%>', bcpc_record_type='STATIC';
+    ((SELECT id FROM domains WHERE name='<%=@domain_name%>'), 'zabbix.<%=@domain_name%>', 'A', '<%=@management_monitoring_vip%>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@domain_name%>'), name='zabbix.<%=@domain_name%>', type='A', content='<%=@management_monitoring_vip%>', bcpc_record_type='STATIC';
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
     ((SELECT id FROM domains WHERE name='<%=@domain_name%>'), 'graphite.<%=@domain_name%>', 'A', '<%=@management_monitoring_vip%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@domain_name%>'), name='graphite.<%=@domain_name%>', type='A', content='<%=@management_monitoring_vip%>', bcpc_record_type='STATIC';


### PR DESCRIPTION
Directing requests to monitoring sites based on host header never seemed functional, so this fixes it by implementing it on haproxy correctly. IP-based requests will continue to work as usual.

In addition, there may be occasions where monitoring functions are delegated to an external cluster. FQDN overrides are provided to at least maintain working hyperlinks in the landing page.