### PR TITLE
Re-adding some hostname-related patches that were lost in the move to 5.x

### DIFF
--- a/cookbooks/bcpc/files/default/nova_api_metadata_base.patch
+++ b/cookbooks/bcpc/files/default/nova_api_metadata_base.patch
@@ -1,0 +1,55 @@
+diff --git a/nova/api/metadata/base.py b/nova/api/metadata/base.py
+index 382378f..369e2c9 100644
+--- a/nova/api/metadata/base.py
++++ b/nova/api/metadata/base.py
+@@ -14,6 +14,8 @@
+ #    License for the specific language governing permissions and limitations
+ #    under the License.
+ 
++# THIS FILE PATCHED BY BCPC
++
+ """Instance Metadata information."""
+ 
+ import base64
+@@ -223,6 +225,11 @@ class InstanceMetadata(object):
+         fixed_ips = self.ip_info['fixed_ips']
+         fixed_ip = fixed_ips and fixed_ips[0] or ''
+ 
++        if floating_ip != '':
++            public_hostname = self._get_public_hostname(floating_ip)
++        else:
++            public_hostname = ''
++
+         fmt_sgroups = [x['name'] for x in self.security_groups]
+ 
+         meta_data = {
+@@ -251,7 +258,7 @@ class InstanceMetadata(object):
+ 
+         if self._check_version('2007-01-19', version):
+             meta_data['local-hostname'] = hostname
+-            meta_data['public-hostname'] = hostname
++            meta_data['public-hostname'] = public_hostname
+             meta_data['public-ipv4'] = floating_ip
+ 
+         if False and self._check_version('2007-03-01', version):
+@@ -372,8 +379,19 @@ class InstanceMetadata(object):
+     def _check_os_version(self, required, requested):
+         return self._check_version(required, requested, OPENSTACK_VERSIONS)
+ 
++    def _aws_style_internal_hostname(self):
++        return 'ip-%s' % str(self.address).replace('.', '-')
++
++    def _aws_style_public_hostname(self, public_address):
++        return 'public-%s' % str(public_address).replace('.', '-')
++
+     def _get_hostname(self):
+-        return "%s%s%s" % (self.instance.hostname,
++        return "%s%s%s" % (self._aws_style_internal_hostname(),
++                           '.' if CONF.dhcp_domain else '',
++                           CONF.dhcp_domain)
++
++    def _get_public_hostname(self, public_address):
++        return "%s%s%s" % (self._aws_style_public_hostname(public_address),
+                            '.' if CONF.dhcp_domain else '',
+                            CONF.dhcp_domain)
+ 

--- a/cookbooks/bcpc/files/default/nova_network_linux_net.patch
+++ b/cookbooks/bcpc/files/default/nova_network_linux_net.patch
@@ -1,0 +1,23 @@
+diff --git a/nova/network/linux_net.py b/nova/network/linux_net.py
+index 430da17..465e7ca 100644
+--- a/nova/network/linux_net.py
++++ b/nova/network/linux_net.py
+@@ -15,6 +15,8 @@
+ #    License for the specific language governing permissions and limitations
+ #    under the License.
+ 
++# THIS FILE PATCHED BY BCPC
++
+ """Implements vlans, bridges, and iptables rules using linux utilities."""
+ 
+ import calendar
+@@ -1220,7 +1222,8 @@ def _host_dhcp(fixedip):
+     # NOTE(cfb): dnsmasq on linux only supports 64 characters in the hostname
+     #            field (LP #1238910). Since the . counts as a character we need
+     #            to truncate the hostname to only 63 characters.
+-    hostname = fixedip.instance.hostname
++    #hostname = fixedip.instance.hostname # EDITED BY BCPC
++    hostname = 'ip-%s' % str(fixedip.address).replace('.', '-')
+     if len(hostname) > 63:
+         LOG.warning(_LW('hostname %s too long, truncating.') % (hostname))
+         hostname = fixedip.instance.hostname[:2] + '-' +\


### PR DESCRIPTION
This PR re-adds some patches (modified) that were forgotten when we moved to 5.x. Specifically, this alters the behavior of nova-network and nova-api so that DHCP leases are provided with hostnames in the `ip-x-x-x-x` AWS style, and the metadata server will now return `ip-x-x-x-x.bcpc.example.com` for the internal hostname and `public-y-y-y-y.bcpc.example.com` for the external hostname.