### PR TITLE
Improve resilience if one of more memcached servers are down

### DIFF
--- a/cookbooks/bcpc/templates/default/keystone.conf.erb
+++ b/cookbooks/bcpc/templates/default/keystone.conf.erb
@@ -102,11 +102,11 @@ memcache_servers = <%=@servers.map{|x| x['bcpc']['management']['ip'] + ":11211"}
 <% else %>
 #memcache_servers =
 <% end %>
-#memcache_dead_retry = 300
-#memcache_socket_timeout = 3
+memcache_dead_retry = 60
+memcache_socket_timeout = 1
 #memcache_pool_maxsize = 10
 #memcache_pool_unused_timeout = 60
-#memcache_pool_connection_get_timeout = 10
+memcache_pool_connection_get_timeout = 1
 
 [catalog]
 #template_file = default_catalog.templates

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -154,6 +154,10 @@ admin_tenant_name = <%=node['bcpc']['admin_tenant']%>
 admin_user = <%=get_config('keystone-admin-user')%>
 admin_password = <%=get_config('keystone-admin-password')%>
 signing_dir = /var/lib/nova
+memcached_servers=<%=@servers.map{|x| x['bcpc']['management']['ip'] + ":11211"}.join(",")%>
+memcache_pool_conn_get_timeout=1
+memcache_pool_socket_timeout=1
+memcache_pool_dead_retry=60
 
 [conductor]
 workers=<%=node['bcpc']['nova']['workers']%>


### PR DESCRIPTION
This PR reduces the timeouts that Nova and Keystone will wait for a reply from memcached before marking that instance down. It also copies the memcached server list into another spot in nova.conf, since apparently it's supposed to be specified twice.

(Note: the option names in both keystone.conf and nova.conf are different, despite describing the same thing in both cases, because of course they are. I am pretty sure they are correct for each file, but if you would like to verify, the config file references are at http://docs.openstack.org/kilo/config-reference/content/section_keystone.conf.html and http://docs.openstack.org/kilo/config-reference/content/list-of-compute-config-options.html.)