### PR TITLE
Guarantees update-ca-certificates will fire in the same block

### DIFF
--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -35,8 +35,6 @@ unless $additional_cacerts_dir.nil? or $additional_cacerts_dir.empty?
       raise "Certificate #{File.join($additional_cacerts_dir, f)} is not a valid PEM certificate, aborting."
     end
   end
-end
-unless $update_ca_certificates_script.empty?
   $update_ca_certificates_script << <<-EOH
     update-ca-certificates
   EOH


### PR DESCRIPTION
Having it separate was a bit of a premature optimization. This is related to issue #662.