### PR TITLE
Updates default security group mechanism for Kilo

### DIFF
--- a/cookbooks/bcpc/recipes/nova-setup.rb
+++ b/cookbooks/bcpc/recipes/nova-setup.rb
@@ -28,14 +28,14 @@ bash "wait-for-nova-to-become-operational" do
 end
 
 
-bash "nova-default-secgroup" do
+bash "nova-configure-default-secgroup-rules" do
     user "root"
     code <<-EOH
         . /root/adminrc
-        nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0
-        nova secgroup-add-rule default tcp 22 22 0.0.0.0/0
+        nova secgroup-add-default-rule icmp -1 -1 0.0.0.0/0
+        nova secgroup-add-default-rule tcp 22 22 0.0.0.0/0
     EOH
-    not_if ". /root/adminrc; nova secgroup-list-rules default | grep icmp"
+    not_if ". /root/adminrc; nova secgroup-list-default-rules | grep icmp"
 end
 
 bash "nova-floating-add" do


### PR DESCRIPTION
This was a major oversight on my part. In previous versions of OpenStack, a security group named **default** was treated as the default security group. At some point, the default security group mechanism was moved off to its own thing, but recipes were not updated appropriately. This updates our recipes to create the default security group rules in the expected format.