### PR TITLE
Fixes #599 - allows uploading images to Glance via Horizon

### DIFF
--- a/cookbooks/bcpc/files/default/horizon_glance_image_upload.patch
+++ b/cookbooks/bcpc/files/default/horizon_glance_image_upload.patch
@@ -1,0 +1,54 @@
+diff --git a/openstack_dashboard/api/glance.py b/openstack_dashboard/api/glance.py
+index 91fa883..363423d 100644
+--- a/openstack_dashboard/api/glance.py
++++ b/openstack_dashboard/api/glance.py
+@@ -16,6 +16,8 @@
+ #    License for the specific language governing permissions and limitations
+ #    under the License.
+ 
++# THIS FILE PATCHED BY BCPC
++
+ from __future__ import absolute_import
+ 
+ import collections
+@@ -26,6 +28,10 @@ import os
+ 
+ 
+ from django.conf import settings
++from django.core.files.uploadedfile import InMemoryUploadedFile
++from django.core.files.uploadedfile import SimpleUploadedFile
++from django.core.files.uploadedfile import TemporaryUploadedFile
++
+ 
+ import glanceclient as glance_client
+ from six.moves import _thread as thread
+@@ -115,9 +121,12 @@ def image_update(request, image_id, **kwargs):
+             try:
+                 os.remove(image_data.file.name)
+             except Exception as e:
++                filename = str(image_data.file)
++                if hasattr(image_data.file, 'name'):
++                    filename = image_data.file.name
+                 msg = (('Failed to remove temporary image file '
+                         '%(file)s (%(e)s)') %
+-                       dict(file=image_data.file.name, e=str(e)))
++                       dict(file=filename, e=str(e)))
+                 LOG.warn(msg)
+     return image
+ 
+@@ -130,6 +139,15 @@ def image_create(request, **kwargs):
+     image = glanceclient(request).images.create(**kwargs)
+ 
+     if data:
++        if isinstance(data, TemporaryUploadedFile):
++            # Hack to fool Django, so we can keep file open in the new thread.
++            data.file.close_called = True
++        if isinstance(data, InMemoryUploadedFile):
++            # Clone a new file for InMemeoryUploadedFile.
++            # Because the old one will be closed by Django.
++            data = SimpleUploadedFile(data.name,
++                                      data.read(),
++                                      data.content_type)
+         thread.start_new_thread(image_update,
+                                 (request, image.id),
+                                 {'data': data,


### PR DESCRIPTION
What the topic says. Can be cheffed into an existing cluster.