### PR TITLE
Make Graphite webapp work properly with SSL termination

### DIFF
--- a/cookbooks/bcpc/templates/default/graphite.local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/graphite.local_settings.py.erb
@@ -180,3 +180,4 @@ CARBONLINK_HOSTS = [ "<%=node['bcpc']['management']['ip']%>:7002" ]
 from graphite.app_settings import *
 SECRET_KEY = '<%= get_config('graphite-secret-key') %>'
 ALLOWED_HOSTS = ['*']
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
@@ -51,7 +51,7 @@ frontend https
   stats hide-version
   stats realm Haproxy\ Statistics
   stats auth <%=get_config('haproxy-stats-user')%>:<%=get_config('haproxy-stats-password')%>
-  reqadd X-Forwarded-Protocol:\ https
+  reqadd X-Forwarded-Proto:\ https
   acl kibana_missing_slash path_reg ^/kibana[^/]*$
   redirect code 301 prefix / append-slash if kibana_missing_slash
   acl url_kibana path_beg /kibana
@@ -107,6 +107,7 @@ backend zabbix-backend
 frontend graphite-web
   bind <%="#{node['bcpc']['management']['monitoring']['vip']}:8888"%> ssl crt /etc/haproxy/haproxy.pem
   option tcplog
+  reqadd X-Forwarded-Proto:\ https
   default_backend graphite-web-backend
 
 listen graphite-carbon-relay-line <%=node['bcpc']['management']['monitoring']['vip']%>:2013


### PR DESCRIPTION
The URL produced by "short URL" button in Graphite web composer does not load as the request is redirecting to HTTP instead of HTTPS. This PR makes Django behave correctly behind SSL terminating proxy and updates the header name to comply with the Forwarded HTTP extension guidelines.