### PR TITLE
Updates rng-tools to work properly with Trusty

### DIFF
--- a/cookbooks/bcpc/templates/default/rng-tools.erb
+++ b/cookbooks/bcpc/templates/default/rng-tools.erb
@@ -15,4 +15,4 @@ HRNGDEVICE=/dev/null
 #RNGDOPTIONS="--hrng=intelfwh --fill-watermark=90% --feed-interval=1"
 #RNGDOPTIONS="--hrng=viakernel --fill-watermark=90% --feed-interval=1"
 #RNGDOPTIONS="--hrng=viapadlock --fill-watermark=90% --feed-interval=1"
-RNGDOPTIONS="--hrng=tpm --fill-watermark=90% --feed-interval=1"
+#RNGDOPTIONS="--hrng=tpm --fill-watermark=90% --feed-interval=1"


### PR DESCRIPTION
It was too much to hope that all the crypto stuff would _really_ be working correctly the first time through. This PR should fix everything for real this time by ensuring that the `tpm_rng` module is loaded into the kernel prior before doing anything, and adds it to `/etc/modules` so that `/dev/hwrng` is available on boot and **rng-tools** will start without grumpiness. (This also installs `linux-extra-image-virtual`, which is a virtual package that pulls in the appropriately versioned kernel extras, which is where `tpm_rng` comes from.)