### PR TITLE
Upgrade HAProxy to 1.5.13

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -34,7 +34,7 @@ default['bcpc']['ceph']['version_number'] = '0.94.2'
 # Ceph.com version number '0.94.2-1trusty'
 # Ubuntu cloud version number '0.94.1-0ubuntu1~cloud0'
 default['bcpc']['erlang']['version'] = '1:17.5.3'
-default['bcpc']['haproxy']['version'] = '1.5.12-1ppa1~trusty'
+default['bcpc']['haproxy']['version'] = '1.5.13-1ppa1~trusty'
 default['bcpc']['kibana']['version'] = '4.0.2'
 default['bcpc']['rabbitmq']['version'] = '3.5.3-1'
 


### PR DESCRIPTION
HAProxy in the PPA was upgraded to 1.5.13 and previous versions were removed.