### PR TITLE
Stuck carbon-relay fix

### DIFF
--- a/cookbooks/bcpc/files/default/graphite-carbon-client.patch
+++ b/cookbooks/bcpc/files/default/graphite-carbon-client.patch
@@ -1,0 +1,18 @@
+--- graphite/lib/carbon/client.py.orig	2014-12-31 16:49:45.000000000 +0000
++++ graphite/lib/carbon/client.py	2015-07-07 15:07:50.844870514 +0000
+@@ -1,3 +1,5 @@
++# THIS FILE PATCHED BY BCPC
++
+ from twisted.application.service import Service
+ from twisted.internet import reactor
+ from twisted.internet.defer import Deferred, DeferredList
+@@ -76,7 +78,8 @@
+       queueSize = self.factory.queueSize
+       if (self.factory.queueFull.called and
+           queueSize < SEND_QUEUE_LOW_WATERMARK):
+-        self.factory.queueHasSpace.callback(queueSize)
++        if not self.factory.queueHasSpace.called:
++          self.factory.queueHasSpace.callback(queueSize)
+
+   def __str__(self):
+     return 'CarbonClientProtocol(%s:%d:%s)' % (self.factory.destination)

--- a/cookbooks/bcpc/recipes/graphite.rb
+++ b/cookbooks/bcpc/recipes/graphite.rb
@@ -69,6 +69,37 @@ if node['bcpc']['enabled']['metrics'] then
         end
     end
 
+    #  _   _  ____ _  __   __  ____   _  _____ ____ _   _
+    # | | | |/ ___| | \ \ / / |  _ \ / \|_   _/ ___| | | |
+    # | | | | |  _| |  \ V /  | |_) / _ \ | || |   | |_| |
+    # | |_| | |_| | |___| |   |  __/ ___ \| || |___|  _  |
+    #  \___/ \____|_____|_|   |_| /_/   \_\_| \____|_| |_|
+    # carbon-relay sometimes remain stuck even when destinations have
+    # (i.e, carbon-cache) recovered from lag/unresponsiveness. This patch
+    # applies Graphite Carbon PR #400 which fixes a race condition in carbon
+    # client queue signalling.
+    cookbook_file "/tmp/graphite-carbon-client.patch" do
+        source "graphite-carbon-client.patch"
+        owner "root"
+        mode 00644
+    end
+
+    bash "patch-for-graphite-carbon-client" do
+        user "root"
+        code <<-EOH
+           cd /opt/graphite
+           patch -p1 < /tmp/graphite-carbon-client.patch
+           rv=$?
+           if [ $rv -ne 0 ]; then
+             echo "Error applying patch ($rv) - aborting!"
+             exit $rv
+           fi
+           cp /tmp/graphite-carbon-client.patch .
+        EOH
+        not_if "grep -q 'THIS FILE PATCHED BY BCPC' /opt/graphite/lib/carbon/client.py"
+        notifies :restart, "service[carbon-relay]", :delayed
+    end
+
     template "/opt/graphite/conf/carbon.conf" do
         source "carbon.conf.erb"
         owner "root"


### PR DESCRIPTION
carbon-relay sometimes remain stuck even when destinations (i.e, carbon-cache) have recovered from lag/unresponsiveness. This patch applies Graphite Carbon PR 400 which fixes a race condition in carbon client queue signalling.