### PR TITLE
Parameterize Java options for Elasticsearch

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1320,3 +1320,13 @@ default['bcpc']['zabbix']['fqdn'] = "zabbix.#{node['bcpc']['domain_name']}"
 #
 # Kibana Server FQDN
 default['bcpc']['kibana']['fqdn'] = "kibana.#{node['bcpc']['domain_name']}"
+###########################################
+#
+# Elasticsearch settings
+#
+###########################################
+#
+# Heap memory size
+default['bcpc']['elasticsearch']['heap_size'] = '256m'
+# Additional Java options
+default['bcpc']['elasticsearch']['java_opts'] = '-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -verbose:gc -Xloggc:/var/log/elasticsearch/gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10m'

--- a/cookbooks/bcpc/recipes/elasticsearch.rb
+++ b/cookbooks/bcpc/recipes/elasticsearch.rb
@@ -41,6 +41,18 @@ if node['bcpc']['enabled']['logging'] then
         action :install
     end
 
+    template "/etc/default/elasticsearch" do
+        source "elasticsearch-default.erb"
+        owner "root"
+        group "root"
+        mode 00644
+        variables(
+            :es_heap_size => node['bcpc']['elasticsearch']['heap_size'],
+            :es_java_opts => node['bcpc']['elasticsearch']['java_opts']
+        )
+        notifies :restart, "service[elasticsearch]", :delayed
+    end
+
     service "elasticsearch" do
         action [:enable, :start]
     end

--- a/cookbooks/bcpc/templates/default/elasticsearch-default.erb
+++ b/cookbooks/bcpc/templates/default/elasticsearch-default.erb
@@ -1,0 +1,44 @@
+# Run Elasticsearch as this user ID and group ID
+#ES_USER=elasticsearch
+#ES_GROUP=elasticsearch
+
+# Heap Size (defaults to 256m min, 1g max)
+ES_HEAP_SIZE=<%= @es_heap_size %>
+
+# Heap new generation
+#ES_HEAP_NEWSIZE=
+
+# max direct memory
+#ES_DIRECT_SIZE=
+
+# Maximum number of open files, defaults to 65535.
+#MAX_OPEN_FILES=65535
+
+# Maximum locked memory size. Set to "unlimited" if you use the
+# bootstrap.mlockall option in elasticsearch.yml. You must also set
+# ES_HEAP_SIZE.
+#MAX_LOCKED_MEMORY=unlimited
+
+# Maximum number of VMA (Virtual Memory Areas) a process can own
+#MAX_MAP_COUNT=262144
+
+# Elasticsearch log directory
+#LOG_DIR=/var/log/elasticsearch
+
+# Elasticsearch data directory
+#DATA_DIR=/var/lib/elasticsearch
+
+# Elasticsearch work directory
+#WORK_DIR=/tmp/elasticsearch
+
+# Elasticsearch configuration directory
+#CONF_DIR=/etc/elasticsearch
+
+# Elasticsearch configuration file (elasticsearch.yml)
+#CONF_FILE=/etc/elasticsearch/elasticsearch.yml
+
+# Additional Java OPTS
+ES_JAVA_OPTS="<%= @es_java_opts %>"
+
+# Configure restart on package upgrade (true, every other setting will lead to not restarting)
+#RESTART_ON_UPGRADE=true


### PR DESCRIPTION
Garbage collection logging will be enabled by default. No change to default heap size (256m).