### PR TITLE
Making all Keystone backends configurable

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -306,9 +306,23 @@ default['bcpc']['keystone']['verbose'] = false
 # before failing (configures timeout on the wait-for-keystone-to-be-operational
 # spinlock guard).
 default['bcpc']['keystone']['wait_for_keystone_timeout'] = 120
-# This can be either 'sql' or 'ldap' to either store identities
-# in the mysql DB or the LDAP server
-default['bcpc']['keystone']['backend'] = 'sql'
+# The driver section below allows either 'sql' or 'ldap' (or 'templated' for catalog)
+# Note that not all drivers may support SQL/LDAP, only tinker if you know what you're getting into
+default['bcpc']['keystone']['drivers']['assignment'] = 'sql'
+default['bcpc']['keystone']['drivers']['catalog'] = 'templated'
+default['bcpc']['keystone']['drivers']['credential'] = 'sql'
+default['bcpc']['keystone']['drivers']['domain_config'] = 'sql'
+default['bcpc']['keystone']['drivers']['endpoint_filter'] = 'sql'
+default['bcpc']['keystone']['drivers']['endpoint_policy'] = 'sql'
+default['bcpc']['keystone']['drivers']['federation'] = 'sql'
+default['bcpc']['keystone']['drivers']['identity'] = 'sql'
+default['bcpc']['keystone']['drivers']['identity_mapping'] = 'sql'
+default['bcpc']['keystone']['drivers']['oauth1'] = 'sql'
+default['bcpc']['keystone']['drivers']['policy'] = 'sql'
+default['bcpc']['keystone']['drivers']['revoke'] = 'sql'
+default['bcpc']['keystone']['drivers']['role'] = 'sql'
+default['bcpc']['keystone']['drivers']['trust'] = 'sql'
+# LDAP credentials used by Keystone
 default['bcpc']['ldap']['admin_user'] = nil
 default['bcpc']['ldap']['admin_pass'] = nil
 default['bcpc']['ldap']['config'] = {}

--- a/cookbooks/bcpc/templates/default/keystone.conf.erb
+++ b/cookbooks/bcpc/templates/default/keystone.conf.erb
@@ -71,7 +71,7 @@ verbose = false
 #control_exchange = keystone
 
 [assignment]
-driver = keystone.assignment.backends.sql.Assignment
+driver = keystone.assignment.backends.<%= node['bcpc']['keystone']['drivers']['assignment'] %>.Assignment
 
 [auth]
 #methods = external,password,token,oauth1
@@ -110,7 +110,7 @@ memcache_pool_connection_get_timeout = 1
 
 [catalog]
 #template_file = default_catalog.templates
-driver = keystone.catalog.backends.templated.Catalog
+driver = keystone.catalog.backends.<%= node['bcpc']['keystone']['drivers']['catalog'] %>.Catalog
 <% if node['bcpc']['keystone']['enable_caching'] %>
 caching = true
 <% else %>
@@ -120,7 +120,7 @@ cache_time = 3600
 #list_limit = <None>
 
 [credential]
-#driver = keystone.credential.backends.sql.Credential
+driver = keystone.credential.backends.<%= node['bcpc']['keystone']['drivers']['credential'] %>.Credential
 
 [database]
 #sqlite_db = oslo.sqlite
@@ -145,7 +145,7 @@ connection = mysql://<%=get_config('mysql-keystone-user')%>:<%=get_config('mysql
 #db_max_retries = 20
 
 [domain_config]
-#driver = keystone.resource.config_backends.sql.DomainConfig
+driver = keystone.resource.config_backends.<%= node['bcpc']['keystone']['drivers']['domain_config'] %>.DomainConfig
 <% if node['bcpc']['keystone']['enable_caching'] %>
 caching = true
 <% else %>
@@ -154,11 +154,11 @@ caching = false
 cache_time = 300
 
 [endpoint_filter]
-#driver = keystone.contrib.endpoint_filter.backends.sql.EndpointFilter
+driver = keystone.contrib.endpoint_filter.backends.<%= node['bcpc']['keystone']['drivers']['endpoint_filter'] %>.EndpointFilter
 #return_all_endpoints_if_no_filter = true
 
 [endpoint_policy]
-#driver = keystone.contrib.endpoint_policy.backends.sql.EndpointPolicy
+driver = keystone.contrib.endpoint_policy.backends.<%= node['bcpc']['keystone']['drivers']['endpoint_policy'] %>.EndpointPolicy
 
 
 [eventlet_server]
@@ -184,7 +184,7 @@ admin_bind_host = <%=node['bcpc']['management']['ip']%>
 #cert_required = false
 
 [federation]
-#driver = keystone.contrib.federation.backends.sql.Federation
+driver = keystone.contrib.federation.backends.<%= node['bcpc']['keystone']['drivers']['federation'] %>.Federation
 #assertion_prefix =
 #remote_id_attribute = <None>
 #federated_domain_name = Federated
@@ -200,7 +200,7 @@ admin_bind_host = <%=node['bcpc']['management']['ip']%>
 #domain_specific_drivers_enabled = false
 #domain_configurations_from_database = false
 #domain_config_dir = /etc/keystone/domains
-driver = keystone.identity.backends.<%=node['bcpc']['keystone']['backend']%>.Identity
+driver = keystone.identity.backends.<%=node['bcpc']['keystone']['drivers']['identity']%>.Identity
 <% if node['bcpc']['keystone']['enable_caching'] %>
 caching = true
 <% else %>
@@ -211,7 +211,7 @@ cache_time = 600
 #list_limit = <None>
 
 [identity_mapping]
-#driver = keystone.identity.mapping_backends.sql.Mapping
+driver = keystone.identity.mapping_backends.<%= node['bcpc']['keystone']['drivers']['identity_mapping'] %>.Mapping
 #generator = keystone.identity.id_generators.sha256.Generator
 #backward_compatible_ids = true
 
@@ -251,7 +251,7 @@ servers = <%=@servers.map{|x| x['bcpc']['management']['ip'] + ":11211"}.join(','
 #pool_connection_get_timeout = 10
 
 [oauth1]
-#driver = keystone.contrib.oauth1.backends.sql.OAuth1
+driver = keystone.contrib.oauth1.backends.<%= node['bcpc']['keystone']['drivers']['oauth1'] %>.OAuth1
 #request_token_duration = 28800
 #access_token_duration = 86400
 
@@ -324,7 +324,7 @@ servers = <%=@servers.map{|x| x['bcpc']['management']['ip'] + ":11211"}.join(','
 #config_file = keystone-paste.ini
 
 [policy]
-#driver = keystone.policy.backends.sql.Policy
+driver = keystone.policy.backends.<%= node['bcpc']['keystone']['drivers']['policy'] %>.Policy
 #list_limit = <None>
 
 [resource]
@@ -338,7 +338,7 @@ caching = false
 #list_limit = <None>
 
 [revoke]
-#driver = keystone.contrib.revoke.backends.sql.Revoke
+driver = keystone.contrib.revoke.backends.<%= node['bcpc']['keystone']['drivers']['revoke'] %>.Revoke
 #expiration_buffer = 1800
 <% if node['bcpc']['keystone']['enable_caching'] %>
 caching = true
@@ -348,7 +348,7 @@ caching = false
 #cache_time = 3600
 
 [role]
-driver =  keystone.assignment.role_backends.sql.Role
+driver = keystone.assignment.role_backends.<%= node['bcpc']['keystone']['drivers']['role'] %>.Role
 <% if node['bcpc']['keystone']['enable_caching'] %>
 caching = true
 <% else %>
@@ -412,4 +412,4 @@ caching = false
 #enabled = true
 #allow_redelegation = false
 #max_redelegation_count = 3
-#driver = keystone.trust.backends.sql.Trust
+driver = keystone.trust.backends.<%= node['bcpc']['keystone']['drivers']['trust'] %>.Trust


### PR DESCRIPTION
This PR is to make it easy to swap Keystone backend drivers out (mainly to swap between SQL and LDAP for specific drivers).