### PR TITLE
Extend iptables for monitoring

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1251,7 +1251,14 @@ default['bcpc']['cpupower']['ondemand_powersave_bias'] = nil
 default['bcpc']['cpupower']['ondemand_sampling_down_factor'] = nil
 default['bcpc']['cpupower']['ondemand_sampling_rate'] = nil
 default['bcpc']['cpupower']['ondemand_up_threshold'] = nil
-
+###########################################
+#
+# General monitoring settings
+#
+###########################################
+#
+# List of monitoring clients external to cluster that we are monitoring
+default['bcpc']['monitoring']['external_clients'] = [] 
 ###########################################
 #
 # Graphite settings

--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -77,10 +77,22 @@ iptables-restore <<EOH
 ## powerdns 53
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p udp --dport 53 -j ACCEPT
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --dport 53 -j ACCEPT
+
+<% if node["roles"].include? "BCPC-Monitoring" -%>
 ## kibana 443
 ## graphite 8888
-<% if node["roles"].include? "BCPC-Monitoring" -%>
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["monitoring"]["vip"]%> -p tcp --match multiport --dports 443,8888 -j ACCEPT
+
+## carbon-relay 2013, 2014
+## elasticsearch 9200
+## zabbix-server 10051
+:INPUT-monitoring - [0:0]
+-A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["monitoring"]["vip"]%> -p tcp --match multiport --dports 2013,2014,9200,10051 -j INPUT-monitoring
+
+###########################
+# INPUT-monitoring chain
+###########################
+-A INPUT-monitoring -m set --match-set monitoring-clients src -j ACCEPT
 <% end -%>
 
 # Log and drop everything else

--- a/cookbooks/bcpc/templates/default/ipset-monitoring-clients.erb
+++ b/cookbooks/bcpc/templates/default/ipset-monitoring-clients.erb
@@ -1,0 +1,4 @@
+create monitoring-clients-staging hash:ip family inet hashsize 1024 maxelem 65536
+<% for @ipaddress in @clients %>
+add monitoring-clients-staging <%= @ipaddress %>
+<% end %>


### PR DESCRIPTION
On clusters that monitor (aka collect logs/metrics and alert on) clients outside of the cluster, current iptables rules are insufficient. As number of clients may be large, and if their IP addresses are not contiguous, `ipset` will be used here to prevent bloated iptables rulesets.
