### PR TITLE
Add support for flavor extra specs

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1313,8 +1313,7 @@ default['bcpc']['rally']['user'] = 'ubuntu'
 #
 ###########################################
 
-default['bcpc']['flavors']['deleted'] = []
-default['bcpc']['flavors']['enabled'] = {}
+default['bcpc']['flavors'] = {}
 ###########################################
 #
 # Zabbix settings

--- a/cookbooks/bcpc/providers/osflavor.rb
+++ b/cookbooks/bcpc/providers/osflavor.rb
@@ -23,43 +23,69 @@ def whyrun_supported?
   true
 end
 
+def openstack_cli
+  args =  ["openstack", 
+      "--os-tenant-name", node['bcpc']['admin_tenant'], 
+      "--os-username", get_config('keystone-admin-user'),
+      "--os-auth-url", "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
+      "--os-region-name", node['bcpc']['region_name'],
+      "--os-password" , get_config('keystone-admin-password'),
+      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem"]
+end
+
+def nova_cli
+  # Note the amazing lack of consistency between openstack CLI and nova CLI when it 
+  # comes to args e.g. "--os-user-name" vs "--os-username".  
+  args =  ["nova", 
+      "--os-project-name", node['bcpc']['admin_tenant'], 
+      "--os-user-name", get_config('keystone-admin-user'),
+      "--os-auth-url", "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
+      "--os-region-name", node['bcpc']['region_name'],
+      "--os-password" , get_config('keystone-admin-password'),
+      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem"]
+end 
+
 action :create do
-  stdout, stderr, status = Open3.capture3("openstack",
-                                  "--os-tenant-name", node['bcpc']['admin_tenant'], 
-                                  "--os-username",  get_config('keystone-admin-user'),
-                                  "--os-auth-url",  
-                                  "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
-                                  "--os-region-name", node['bcpc']['region_name'],
-                                  "--os-password" , get_config('keystone-admin-password'),
-                                  "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
-                                  "flavor", "show", @new_resource.name , "-f", "json")
-  
+  args = openstack_cli
+  stdout, stderr, status = Open3.capture3(*(args+ ["flavor", "show", @new_resource.name, "-f", "json"] ))
   if not status.success? 
     converge_by("Creating #{new_resource.name}") do
       ispub = @new_resource.is_public ? "--public" : "--private"
-      stdout, status = Open3.capture2("openstack",
-                                      "--os-tenant-name", node['bcpc']['admin_tenant'], 
-                                      "--os-username",  get_config('keystone-admin-user'),
-                                      "--os-auth-url",  
-                                      "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
-                                      "--os-region-name", node['bcpc']['region_name'],
-                                      "--os-password" , get_config('keystone-admin-password'),
-                                      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
-                                      "flavor", "create", @new_resource.name , "-f", "json",  
+      stdout, status = Open3.capture2( *(args + ["flavor", "create", @new_resource.name , "-f", "json",  
                                       "--ram=#{@new_resource.memory_mb}", 
                                       "--disk=#{@new_resource.disk_gb}",
                                       "--ephemeral=#{@new_resource.ephemeral_gb}",
                                       "--swap=#{@new_resource.swap_gb}",
                                       "--vcpus=#{@new_resource.vcpus}", 
                                       "--id=#{@new_resource.flavor_id}",
-                                      "#{ispub}"
-                                      )
-
-      if not status.success?
-        Chef::Log.error "Failed to create to flavor"
-      end
+                                      "#{ispub}"]
+                                      ) )
+      Chef::Log.error "Failed to create to flavor" unless status.success?
     end
-  end   
+  end
+
+  # The openstack CLI doesn't have a way today (kilo) to get the extra_specs
+  # so fall back to nova CLI. 
+  stdout, stderr, status = Open3.capture3(*(nova_cli + ["flavor-show",  @new_resource.name] ))
+  if not status.success?
+    Chef::Log.error "Failed to get flavor info"  
+    raise("Unable to get flavor info.")
+  end
+
+  line = stdout.split("\n").select { |x| x.include? " extra_specs "}
+  if line.nil? or line.empty?
+    raise("No extra_specs line in 'nova flavor-show'")
+  end 
+
+  current_specs = JSON.parse(line[0].split("|")[2])
+  new_specs = current_specs.merge(@new_resource.extra_specs.map { |k, v| [k.to_s, v.to_s ]} )
+  if current_specs != new_specs
+    converge_by("Update flavor extra_specs") do
+      kvp = new_specs.collect { |k,v| k + "=" + v}
+      stdout, status = Open3.capture2(*(nova_cli + ["flavor-key",  @new_resource.name, "set"] + kvp ))
+      Chef::Log.error "Failed to update flavor extra_specs" unless status.success?
+    end
+  end
 end
 
 action :delete do
@@ -85,9 +111,7 @@ action :delete do
                                       "flavor", "delete", @new_resource.name )
 
 
-      if not status.success?
-        Chef::Log.error "Failed to delete to flavor"
-      end
+      Chef::Log.error "Failed to delete to flavor" unless status.success?
     end
   end
 end

--- a/cookbooks/bcpc/providers/osflavor.rb
+++ b/cookbooks/bcpc/providers/osflavor.rb
@@ -89,28 +89,12 @@ action :create do
 end
 
 action :delete do
-  stdout, stderr, status = Open3.capture3("openstack",
-                                          "--os-tenant-name", node['bcpc']['admin_tenant'], 
-                                          "--os-username",  get_config('keystone-admin-user'),
-                                          "--os-auth-url",  
-                                          "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
-                                          "--os-region-name", node['bcpc']['region_name'],
-                                          "--os-password" , get_config('keystone-admin-password'),
-                                          "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
-                                          "flavor", "show", @new_resource.name , "-f", "json")
+  stdout, stderr, status = Open3.capture3(*(openstack_cli + 
+                                          ["flavor", "show", @new_resource.name]))
   if status.success? 
     converge_by("deleting #{new_resource.name}") do
-      stdout, status = Open3.capture2("openstack",
-                                      "--os-tenant-name", node['bcpc']['admin_tenant'], 
-                                      "--os-username",  get_config('keystone-admin-user'),
-                                      "--os-auth-url",  
-                                      "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
-                                      "--os-region-name", node['bcpc']['region_name'],
-                                      "--os-password" , get_config('keystone-admin-password'),
-                                      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
-                                      "flavor", "delete", @new_resource.name )
-
-
+      stdout, status = Open3.capture2(*(openstack_cli + 
+        ["flavor", "delete", @new_resource.name ] ))
       Chef::Log.error "Failed to delete to flavor" unless status.success?
     end
   end

--- a/cookbooks/bcpc/recipes/flavors.rb
+++ b/cookbooks/bcpc/recipes/flavors.rb
@@ -25,5 +25,6 @@ node['bcpc']['flavors'].each do |name, flavor|
     swap_gb flavor['swap_gb']
     is_public flavor['is_public']
     flavor_id flavor['id']
+    extra_specs flavor["extra_specs"]
   end
 end 

--- a/cookbooks/bcpc/recipes/flavors.rb
+++ b/cookbooks/bcpc/recipes/flavors.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-node['bcpc']['flavors']['enabled'].each do |name, flavor| 
+node['bcpc']['flavors'].each do |name, flavor| 
   bcpc_osflavor name do
     memory_mb flavor['memory_mb'] 
     disk_gb   flavor['disk_gb'] 
@@ -27,9 +27,3 @@ node['bcpc']['flavors']['enabled'].each do |name, flavor|
     flavor_id flavor['id']
   end
 end 
-
-node['bcpc']['flavors']['deleted'].each do |name| 
-  bcpc_osflavor name do
-    action :delete
-  end
-end

--- a/cookbooks/bcpc/resources/osflavor.rb
+++ b/cookbooks/bcpc/resources/osflavor.rb
@@ -1,4 +1,4 @@
-#
+ #
 # Cookbook Name:: bcpc
 # Resource:: osflavor
 #
@@ -29,3 +29,4 @@ attribute :ephemeral_gb, :kind_of => Fixnum, :required => false, :default => 0
 attribute :swap_gb, :kind_of => Fixnum, :required => false, :default => 0
 attribute :vcpus, :kind_of => Fixnum, :required => false, :default => 1
 attribute :is_public, :kind_of => [ TrueClass, FalseClass ], :required => false, :default => true
+attribute :extra_specs, :kind_of => Hash, :required => false, :default => {}

--- a/cookbooks/bcpc/resources/osflavor.rb
+++ b/cookbooks/bcpc/resources/osflavor.rb
@@ -1,4 +1,4 @@
- #
+#
 # Cookbook Name:: bcpc
 # Resource:: osflavor
 #
@@ -29,4 +29,6 @@ attribute :ephemeral_gb, :kind_of => Fixnum, :required => false, :default => 0
 attribute :swap_gb, :kind_of => Fixnum, :required => false, :default => 0
 attribute :vcpus, :kind_of => Fixnum, :required => false, :default => 1
 attribute :is_public, :kind_of => [ TrueClass, FalseClass ], :required => false, :default => true
+# extra_specs are used for things like host aggregates. Set to
+# restrict flavors to particular compute nodes. 
 attribute :extra_specs, :kind_of => Hash, :required => false, :default => {}


### PR DESCRIPTION
Use these to limit flavors to compute nodes.

Should be a no-op unless you add flavors to your env file. If you have flavors in your env this change should be a trivial extra field "extra_specs" and a rechef. 

e.g. env file
```
override_attributes": {
    "bcpc": {
      "flavors" : {
        "m1.small" : { 
          "vcpus" : 1,
          "memory_mb" : 2048,
          "disk_gb" : 20,
          "extra_specs" : {"type" : "ephemeral"}
          } 
      },     ...
```   