### PR TITLE
New host aggregates LWRP

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -536,7 +536,8 @@ default['bcpc']['nova']['live_migration_patch'] = false
 # Nova debug toggle
 default['bcpc']['nova']['debug'] = false
 # Nova scheduler default filters
-default['bcpc']['nova']['scheduler_default_filters'] = ['AggregateInstanceExtraSpecsFilter', 'AvailabilityZoneFilter', 'RamFilter', 'ComputeFilter', 'DifferentHostFilter', 'SameHostFilter']
+default['bcpc']['nova']['scheduler_default_filters'] = ['AggregateInstanceExtraSpecsFilter', 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter']
+
 default['bcpc']['nova']['quota'] = {
   "cores" => 4,
   "floating_ips" => 10,
@@ -1313,8 +1314,38 @@ default['bcpc']['rally']['user'] = 'ubuntu'
 #
 ###########################################
 
-default['bcpc']['flavors']['deleted'] = []
-default['bcpc']['flavors']['enabled'] = {}
+default['bcpc']['flavors'] = {
+    "m1.tiny"  => {
+      "extra_specs" => { "aggregate_instance_extra_specs:general_compute" => "yes"}
+    },
+    "m1.small"  => {
+      "extra_specs" => { "aggregate_instance_extra_specs:general_compute" => "yes"}
+    },
+    "m1.medium"  => { 
+      "extra_specs" => { "aggregate_instance_extra_specs:general_compute" => "yes"}
+    },
+    "m1.large"  => {
+      "extra_specs" => { "aggregate_instance_extra_specs:general_compute" => "yes"}
+    },
+    "m1.xlarge"  => {
+      "extra_specs" => { "aggregate_instance_extra_specs:general_compute" => "yes"} 
+    }
+}
+
+###########################################
+#
+# Openstack Host Aggregates
+#
+###########################################
+
+default['bcpc']['host_aggregates'] = {
+    "general_compute" => {
+      "general_compute" => "yes"
+    }
+}
+
+default['bcpc']['aggregate_membership'] = []
+
 ###########################################
 #
 # Zabbix settings

--- a/cookbooks/bcpc/providers/host_aggregate.rb
+++ b/cookbooks/bcpc/providers/host_aggregate.rb
@@ -1,0 +1,82 @@
+#
+# Cookbook Name:: bcpc
+# Provider:: host_aggregate
+#
+# Copyright 2013, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'open3'
+require 'json'
+
+def whyrun_supported?
+  true
+end
+
+def openstack_cli
+  args =  ["openstack", 
+           "--os-tenant-name", node['bcpc']['admin_tenant'], 
+           "--os-username", get_config('keystone-admin-user'),
+           "--os-auth-url", "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
+           "--os-region-name", node['bcpc']['region_name'],
+           "--os-password" , get_config('keystone-admin-password'),
+           "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem"]
+end
+
+action :create do
+  stdout, stderr, status = Open3.capture3(*(openstack_cli + 
+  	                                    ["aggregate", "show",
+                                             @new_resource.name, "-f", "json" ]))
+  
+  if not status.success? 
+    converge_by("Creating host aggregate #{new_resource.name}") do
+      args = ["aggregate", "create", @new_resource.name , "-f", "json"]
+      args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil? 
+      stdout, status = Open3.capture2( *(openstack_cli + args +  
+     		                         @new_resource.metadata.collect {|k , v| ["--property", k.to_s + "=" + v.to_s ] }.flatten ))	         
+      Chef::Log.error "Failed to create to host aggregate" unless status.success?
+    end
+  else  	
+    ha_fields = JSON.parse(stdout)
+    current_properties = ha_fields.select {|x| x['Field'] == "properties"}[0]["Value"]
+    
+    # update metadata if needed
+    new_properties = current_properties.clone
+    @new_resource.metadata.each { |k,v| new_properties[k.to_s] = v.to_s }
+    if new_properties != current_properties
+      converge_by ("Update properties") do
+	args = ["aggregate", "set", @new_resource.name]
+	args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil? 
+	stdout, status = Open3.capture2( *(openstack_cli + 
+    	 		 	           args + new_properties.collect {|k , v| ["--property", k + "=" + v ] }.flatten ))
+	Chef::Log.error "Failed to update to host aggregate" unless status.success?
+      end			
+    end	
+  end
+end
+
+action :member do
+  # Adds the current host to the host aggregate 
+  stdout, stderr, status = Open3.capture3(*(openstack_cli + 
+  	                                    ["aggregate", "show", @new_resource.name, "-f", "json" ]))
+  raise "Unable to find host aggreate #{@new_resource.name}" unless status.success? 
+  
+  ha_fields = JSON.parse(stdout)
+  current_hosts = ha_fields.select {|x| x['Field'] == "hosts"}[0]["Value"]	
+  if not current_hosts.include?(node['hostname'])
+    converge_by ("Adding host") do
+      stdout, stderr, status = Open3.capture3(*(openstack_cli + 
+  			                        ["aggregate", "add", "host", @new_resource.name, node['hostname'] ]))
+    end
+  end
+end

--- a/cookbooks/bcpc/providers/osflavor.rb
+++ b/cookbooks/bcpc/providers/osflavor.rb
@@ -23,71 +23,81 @@ def whyrun_supported?
   true
 end
 
+def openstack_cli
+  args =  ["openstack", 
+      "--os-tenant-name", node['bcpc']['admin_tenant'], 
+      "--os-username", get_config('keystone-admin-user'),
+      "--os-auth-url", "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
+      "--os-region-name", node['bcpc']['region_name'],
+      "--os-password" , get_config('keystone-admin-password'),
+      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem"]
+end
+
+def nova_cli
+  # Note the amazing lack of consistency between openstack CLI and nova CLI when it 
+  # comes to args e.g. "--os-user-name" vs "--os-username".  
+  args =  ["nova", 
+      "--os-project-name", node['bcpc']['admin_tenant'], 
+      "--os-user-name", get_config('keystone-admin-user'),
+      "--os-auth-url", "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
+      "--os-region-name", node['bcpc']['region_name'],
+      "--os-password" , get_config('keystone-admin-password'),
+      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem"]
+end 
+
 action :create do
-  stdout, stderr, status = Open3.capture3("openstack",
-                                  "--os-tenant-name", node['bcpc']['admin_tenant'], 
-                                  "--os-username",  get_config('keystone-admin-user'),
-                                  "--os-auth-url",  
-                                  "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
-                                  "--os-region-name", node['bcpc']['region_name'],
-                                  "--os-password" , get_config('keystone-admin-password'),
-                                  "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
-                                  "flavor", "show", @new_resource.name , "-f", "json")
-  
+  args = openstack_cli
+  stdout, stderr, status = Open3.capture3(*(args+ ["flavor", "show", @new_resource.name, "-f", "json"] ))
   if not status.success? 
     converge_by("Creating #{new_resource.name}") do
       ispub = @new_resource.is_public ? "--public" : "--private"
-      stdout, status = Open3.capture2("openstack",
-                                      "--os-tenant-name", node['bcpc']['admin_tenant'], 
-                                      "--os-username",  get_config('keystone-admin-user'),
-                                      "--os-auth-url",  
-                                      "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
-                                      "--os-region-name", node['bcpc']['region_name'],
-                                      "--os-password" , get_config('keystone-admin-password'),
-                                      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
-                                      "flavor", "create", @new_resource.name , "-f", "json",  
-                                      "--ram=#{@new_resource.memory_mb}", 
-                                      "--disk=#{@new_resource.disk_gb}",
-                                      "--ephemeral=#{@new_resource.ephemeral_gb}",
-                                      "--swap=#{@new_resource.swap_gb}",
-                                      "--vcpus=#{@new_resource.vcpus}", 
-                                      "--id=#{@new_resource.flavor_id}",
-                                      "#{ispub}"
-                                      )
-
-      if not status.success?
-        Chef::Log.error "Failed to create to flavor"
-      end
+      stdout, status = Open3.capture2( *(args + ["flavor", "create", @new_resource.name , "-f", "json",  
+                                                 "--ram=#{@new_resource.memory_mb}", 
+                                                 "--disk=#{@new_resource.disk_gb}",
+                                                 "--ephemeral=#{@new_resource.ephemeral_gb}",
+                                                 "--swap=#{@new_resource.swap_gb}",
+                                                 "--vcpus=#{@new_resource.vcpus}", 
+                                                 "--id=#{@new_resource.flavor_id}",
+                                                 "#{ispub}"]
+                                        ) )
+      Chef::Log.error "Failed to create to flavor" unless status.success?
     end
-  end   
+  end
+
+  # The openstack CLI doesn't have a way today (kilo) to get the extra_specs
+  # so fall back to nova CLI. 
+  stdout, stderr, status = Open3.capture3(*(nova_cli + ["flavor-show",  @new_resource.name] ))
+  if not status.success?
+    Chef::Log.error "Failed to get flavor info"  
+    raise("Unable to get flavor info.")
+  end
+  
+  line = stdout.split("\n").select { |x| x.include? " extra_specs "}
+  if line.nil? or line.empty?
+    raise("No extra_specs line in 'nova flavor-show'")
+  end 
+  
+  current_specs = JSON.parse(line[0].split("|")[2])
+  new_specs = current_specs.clone 
+  @new_resource.extra_specs.each { |k, v| new_specs[k.to_s] = v.to_s }
+  
+  if current_specs != new_specs
+    converge_by("Update flavor extra_specs") do
+      kvp = new_specs.collect { |k,v| k + "=" + v}
+      stdout, status = Open3.capture2(*(nova_cli + ["flavor-key",  @new_resource.name, "set"] + kvp ))
+      Chef::Log.error "Failed to update flavor extra_specs" unless status.success?
+    end
+  end
 end
 
 action :delete do
-  stdout, stderr, status = Open3.capture3("openstack",
-                                          "--os-tenant-name", node['bcpc']['admin_tenant'], 
-                                          "--os-username",  get_config('keystone-admin-user'),
-                                          "--os-auth-url",  
-                                          "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
-                                          "--os-region-name", node['bcpc']['region_name'],
-                                          "--os-password" , get_config('keystone-admin-password'),
-                                          "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
-                                          "flavor", "show", @new_resource.name , "-f", "json")
+  stdout, stderr, status = Open3.capture3(*(openstack_cli + 
+                                            ["flavor", "show", @new_resource.name]))
   if status.success? 
     converge_by("deleting #{new_resource.name}") do
-      stdout, status = Open3.capture2("openstack",
-                                      "--os-tenant-name", node['bcpc']['admin_tenant'], 
-                                      "--os-username",  get_config('keystone-admin-user'),
-                                      "--os-auth-url",  
-                                      "#{node['bcpc']['protocol']['keystone']}://#{node['bcpc']['management']['vip']}:5000/v2.0/",
-                                      "--os-region-name", node['bcpc']['region_name'],
-                                      "--os-password" , get_config('keystone-admin-password'),
-                                      "--os-cacert" , "/etc/ssl/certs/ssl-bcpc.pem",
-                                      "flavor", "delete", @new_resource.name )
-
-
-      if not status.success?
-        Chef::Log.error "Failed to delete to flavor"
-      end
+      stdout, status = Open3.capture2(*(openstack_cli + 
+                                        ["flavor", "delete", @new_resource.name ] ))
+      Chef::Log.error "Failed to delete to flavor" unless status.success?
     end
   end
 end

--- a/cookbooks/bcpc/recipes/host-aggregates.rb
+++ b/cookbooks/bcpc/recipes/host-aggregates.rb
@@ -1,5 +1,5 @@
 # Cookbook Name:: bcpc
-# Recipe:: flavors
+# Recipe:: host-aggregates
 #
 # Copyright 2013, Bloomberg Finance L.P.
 #
@@ -16,15 +16,16 @@
 # limitations under the License.
 #
 
-node['bcpc']['flavors'].each do |name, flavor| 
-  bcpc_osflavor name do
-    memory_mb flavor['memory_mb'] 
-    disk_gb   flavor['disk_gb'] 
-    vcpus  flavor['vcpus'] 
-    ephemeral_gb flavor['ephemeral_gb']
-    swap_gb flavor['swap_gb']
-    is_public flavor['is_public'] or true
-    flavor_id flavor['id'] or "auto"
-    extra_specs flavor["extra_specs"]
+node['bcpc']['host_aggregates'].each do |name, properties| 
+  bcpc_host_aggregate name do
+    metadata properties
   end
 end 
+
+node['bcpc']['aggregate_membership'].each do |name| 
+    bcpc_host_aggregate name do
+        action :member 
+        zone  node['bcpc']['region_name']
+    end
+end 
+

--- a/cookbooks/bcpc/resources/host_aggregate.rb
+++ b/cookbooks/bcpc/resources/host_aggregate.rb
@@ -1,5 +1,6 @@
+#
 # Cookbook Name:: bcpc
-# Recipe:: flavors
+# Resource:: host_aggregate
 #
 # Copyright 2013, Bloomberg Finance L.P.
 #
@@ -16,15 +17,10 @@
 # limitations under the License.
 #
 
-node['bcpc']['flavors'].each do |name, flavor| 
-  bcpc_osflavor name do
-    memory_mb flavor['memory_mb'] 
-    disk_gb   flavor['disk_gb'] 
-    vcpus  flavor['vcpus'] 
-    ephemeral_gb flavor['ephemeral_gb']
-    swap_gb flavor['swap_gb']
-    is_public flavor['is_public'] or true
-    flavor_id flavor['id'] or "auto"
-    extra_specs flavor["extra_specs"]
-  end
-end 
+
+actions :create, :member
+default_action :create
+
+attribute :name, :name_attribute => true, :kind_of => String, :required => true
+attribute :zone, :kind_of => String, :required => false
+attribute :metadata, :kind_of => Hash, :required => false, :default => {}

--- a/cookbooks/bcpc/resources/osflavor.rb
+++ b/cookbooks/bcpc/resources/osflavor.rb
@@ -29,3 +29,6 @@ attribute :ephemeral_gb, :kind_of => Fixnum, :required => false, :default => 0
 attribute :swap_gb, :kind_of => Fixnum, :required => false, :default => 0
 attribute :vcpus, :kind_of => Fixnum, :required => false, :default => 1
 attribute :is_public, :kind_of => [ TrueClass, FalseClass ], :required => false, :default => true
+# extra_specs are used for things like host aggregates. Set to
+# restrict flavors to particular compute nodes. 
+attribute :extra_specs, :kind_of => Hash, :required => false, :default => {}

--- a/roles/BCPC-Compute.json
+++ b/roles/BCPC-Compute.json
@@ -1,0 +1,28 @@
+{
+    "name": "BCPC-Compute",
+    "json_class": "Chef::Role",
+    "run_list": [
+      "role[Basic]",
+      "recipe[bcpc]",
+      "recipe[bcpc::system]",
+      "recipe[bcpc::networking]",
+      "recipe[bcpc::networking-link-test]",
+      "recipe[bcpc::networking-gw-test]",
+      "recipe[bcpc::networking-route-test]",
+      "recipe[bcpc::ceph-work]",
+      "role[BCPC-Rgwnode]",
+      "recipe[bcpc::nova-work]",
+      "recipe[bcpc::diamond]",
+      "recipe[bcpc::fluentd]",
+      "recipe[bcpc::tpm]",
+      "recipe[bcpc::flavors]",
+      "recipe[bcpc::host-aggregates]",
+      "recipe[bcpc::checks-work]",
+      "recipe[bcpc::zabbix-agent]"
+    ],
+    "description": "Run list for a general compute function. Building block, not designed as an applied role.",
+    "chef_type": "role"
+}
+
+
+

--- a/roles/BCPC-Headnode.json
+++ b/roles/BCPC-Headnode.json
@@ -27,13 +27,15 @@
       "recipe[bcpc::powerdns-nova]",
       "recipe[bcpc::heat]",
       "recipe[bcpc::horizon]",
-      "role[BCPC-Worknode]",
+      "role[BCPC-Compute]",
       "recipe[bcpc::checks-head]",
-      "recipe[bcpc::rally-keystone-populate]",
-      "recipe[bcpc::flavors]"
+      "recipe[bcpc::rally-keystone-populate]"
     ],
     "description": "A highly-available head node in a BCPC cluster",
     "chef_type": "role",
     "override_attributes": {
+      "bcpc" : {
+            "aggregate_membership" : [ ]
+      }
     }
 }

--- a/roles/BCPC-Worknode.json
+++ b/roles/BCPC-Worknode.json
@@ -4,24 +4,13 @@
     },
     "json_class": "Chef::Role",
     "run_list": [
-      "role[Basic]",
-      "recipe[bcpc]",
-      "recipe[bcpc::system]",
-      "recipe[bcpc::networking]",
-      "recipe[bcpc::networking-link-test]",
-      "recipe[bcpc::networking-gw-test]",
-      "recipe[bcpc::networking-route-test]",
-      "recipe[bcpc::ceph-work]",
-      "role[BCPC-Rgwnode]",
-      "recipe[bcpc::nova-work]",
-      "recipe[bcpc::diamond]",
-      "recipe[bcpc::fluentd]",
-      "recipe[bcpc::tpm]",
-      "recipe[bcpc::checks-work]",
-      "recipe[bcpc::zabbix-agent]"
+      "role[BCPC-Compute]"
     ],
     "description": "A functional compute node in a BCPC cluster",
     "chef_type": "role",
     "override_attributes": {
+      "bcpc" : {
+            "aggregate_membership" : ["general_compute"]
+      }
     }
 }


### PR DESCRIPTION
Create a general_compute host aggregate, which *does not* include headnodes. 

This PR lays the ground work for a several things:
* Clearer way to have ephemeral nodes, with their own flavors 
* Creating an AZ per failure domain, rather than one whooping lump of compute
* The ability to have ring fenced resources for some tenants 

Also I noted that the filters were way out of date, so updated them.

I had to create a new role which is designed to be a base role. Chef uses addition for merging attributes, so if BCPC-Headnode is a derivative of BCPC-Worknode, there is no way to clobber the aggregate membership array. This is a tad ugly, but on balance I think the overall ugliness is less.
  