### PR TITLE
Reinstate nova and rgw functional checks

### DIFF
--- a/cookbooks/bcpc/files/default/checks/nova
+++ b/cookbooks/bcpc/files/default/checks/nova
@@ -57,15 +57,11 @@ class TestNovaCompute(object):
 
 
     def _delete_server(self, server):
-        """Nassty hack, current stack requires >1 delete"""
-        start = time.time()
-        while time.time() - start < self.config["timeout"]:
-            try:
-                server.delete()
-                time.sleep(2)
-            except novaclient.exceptions.NotFound:
-                return
-        raise Exception("unable to delete server")
+        try:
+            server.delete()
+        except novaclient.exceptions.NotFound:
+            raise Exception("unable to delete server")
+        return
 
     def run(self):
         import glob

--- a/cookbooks/bcpc/recipes/checks-common.rb
+++ b/cookbooks/bcpc/recipes/checks-common.rb
@@ -16,7 +16,7 @@ end
  template  "/usr/local/etc/checks/default.yml" do
    source "checks/default.yml.erb"
    owner "root"
-   group "root"
+   group "zabbix"
    mode 00640
  end
 
@@ -30,7 +30,7 @@ end
   template  "/usr/local/etc/checks/#{cc}.yml" do
     source "checks/#{cc}.yml.erb"
     owner "root"
-    group "root"
+    group "zabbix"
     mode 00640
   end
 

--- a/cookbooks/bcpc/recipes/checks-head.rb
+++ b/cookbooks/bcpc/recipes/checks-head.rb
@@ -1,17 +1,28 @@
 include_recipe "bcpc::checks-common"
 
- %w{ rgw mysql }.each do |cc|
-   template  "/usr/local/etc/checks/#{cc}.yml" do
-     source "checks/#{cc}.yml.erb"
-     owner "root"
-     group "root"
-     mode 00640
-   end
+%w{ rgw mysql }.each do |cc|
+    template  "/usr/local/etc/checks/#{cc}.yml" do
+        source "checks/#{cc}.yml.erb"
+        owner "root"
+        group "zabbix"
+        mode 00640
+    end
 
-   cookbook_file "/usr/local/bin/checks/#{cc}" do
-     source "checks/#{cc}"
-     owner "root"
-     mode "00755"
-   end
- end
+    cookbook_file "/usr/local/bin/checks/#{cc}" do
+        source "checks/#{cc}"
+        owner "root"
+        mode "00755"
+    end
+end
 
+if node['bcpc']['enabled']['monitoring'] then
+    %w{ nova rgw }.each do |cc|
+        cron "check-#{cc}" do
+            home "/var/lib/zabbix"
+            user "zabbix"
+            minute "*/10"
+            path "/usr/local/bin:/usr/bin:/bin"
+            command "zabbix_sender -c /etc/zabbix/zabbix_agentd.conf --key 'check.#{cc}' --value `check -f timeonly #{cc}` 2>&1 | /usr/bin/logger -p local0.notice"
+        end
+    end
+end


### PR DESCRIPTION
Reinstate Nova and RadosGW functional checks so we have a "service-oriented" view of the cluster health via Zabbix. The repetitive deletes invoked by nova check is removed as it should not be necessary for Kilo.

I have tested this on a fresh cluster. The crontab should run on the head node(s) like so:

Jul 15 16:00:01 vagrant-ubuntu-trusty-64 CRON[19824]: (zabbix) CMD (zabbix_sender -c /etc/zabbix/zabbix_agentd.conf --key 'check.nova' --value `check -f timeonly nova` 2>&1 | /usr/bin/logger -p local0.notice)
Jul 15 16:00:01 vagrant-ubuntu-trusty-64 CRON[19826]: (zabbix) CMD (zabbix_sender -c /etc/zabbix/zabbix_agentd.conf --key 'check.rgw' --value `check -f timeonly rgw` 2>&1 | /usr/bin/logger -p local0.notice)

Once the cron jobs run after the monitoring node is up, the results should be visible in Zabbix dashboard.