### PR TITLE
Fix Zabbix agent check errors

### DIFF
--- a/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
+++ b/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
@@ -23,9 +23,6 @@
                 <application>
                     <name>MySQL</name>
                 </application>
-                <application>
-                    <name>VIP</name>
-                </application>
             </applications>
             <items>
                 <item>
@@ -2292,48 +2289,6 @@
                     <applications>
                         <application>
                             <name>RGW</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                </item>
-                <item>
-                    <name>VIP Hostname</name>
-                    <type>7</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>system.run[whohasthevip]</key>
-                    <delay>90</delay>
-                    <history>3</history>
-                    <trends>30</trends>
-                    <status>0</status>
-                    <value_type>1</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>VIP</name>
                         </application>
                     </applications>
                     <valuemap/>
@@ -5012,16 +4967,6 @@
             <url/>
             <status>0</status>
             <priority>4</priority>
-            <description/>
-            <type>0</type>
-            <dependencies/>
-        </trigger>
-        <trigger>
-            <expression>{BCPC-Headnode:system.run[whohasthevip].diff(0)}=1</expression>
-            <name>VIP has changed host</name>
-            <url/>
-            <status>0</status>
-            <priority>2</priority>
             <description/>
             <type>0</type>
             <dependencies/>

--- a/cookbooks/bcpc/files/default/zabbix_discover_buckets
+++ b/cookbooks/bcpc/files/default/zabbix_discover_buckets
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 import subprocess
 import json
 

--- a/cookbooks/bcpc/recipes/zabbix-agent.rb
+++ b/cookbooks/bcpc/recipes/zabbix-agent.rb
@@ -51,6 +51,12 @@ if node['bcpc']['enabled']['monitoring'] then
       end
     end
 
+    group "adm" do
+        action :modify
+        append true
+        members "zabbix"
+    end
+
     template "/etc/zabbix/zabbix_agent.conf" do
         source "zabbix_agent.conf.erb"
         owner node['bcpc']['zabbix']['user']


### PR DESCRIPTION
First stab at fixing various errors reported in /var/log/zabbix/zabbix_agentd.log.

The removal of Zabbix configuration items is not automatic, as `deleteExisting` rule for Zabbix configuration import is only available from [2.4](https://www.zabbix.com/documentation/2.4/manual/api/reference/configuration/import).