### PR TITLE
Switch to using fqdn endpoints

### DIFF
--- a/cookbooks/bcpc/templates/default/hosts.erb
+++ b/cookbooks/bcpc/templates/default/hosts.erb
@@ -13,8 +13,9 @@ ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
 
+<%=node['bcpc']['management']['vip']%> openstack.<%=node['bcpc']['cluster_domain']%>
 <% @servers.each do |server| -%>
-<%= "#{server['bcpc']['management']['ip']}\t#{server['hostname']}.#{node['bcpc']['domain_name']} #{server['fqdn']} #{server['hostname']}" %>
+<%= "#{server['bcpc']['management']['ip']}\t#{server['hostname']}.#{node['bcpc']['hypervisor_domain']} #{server['fqdn']} #{server['hostname']}" %>
 <% end -%>
 <%=
     if @bootstrap_node

--- a/cookbooks/bcpc/templates/default/keystone-default_catalog.templates.erb
+++ b/cookbooks/bcpc/templates/default/keystone-default_catalog.templates.erb
@@ -4,57 +4,57 @@
 #
 ################################################
 
-catalog.<%=node['bcpc']['region_name']%>.identity.publicURL = <%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['management']['vip']%>:5000/v2.0
-catalog.<%=node['bcpc']['region_name']%>.identity.adminURL = <%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['management']['vip']%>:35357/v2.0
-catalog.<%=node['bcpc']['region_name']%>.identity.internalURL = <%=node['bcpc']['protocol']['keystone']%>://<%=node['bcpc']['management']['vip']%>:5000/v2.0
+catalog.<%=node['bcpc']['region_name']%>.identity.publicURL = <%=node['bcpc']['protocol']['keystone']%>://openstack.<%=node['bcpc']['cluster_domain']%>:5000/v2.0
+catalog.<%=node['bcpc']['region_name']%>.identity.adminURL = <%=node['bcpc']['protocol']['keystone']%>://openstack.<%=node['bcpc']['cluster_domain']%>:35357/v2.0
+catalog.<%=node['bcpc']['region_name']%>.identity.internalURL = <%=node['bcpc']['protocol']['keystone']%>://openstack.<%=node['bcpc']['cluster_domain']%>:5000/v2.0
 catalog.<%=node['bcpc']['region_name']%>.identity.name = Identity Service
 
-catalog.<%=node['bcpc']['region_name']%>.object-store.publicURL = http://<%=node['bcpc']['floating']['vip']%>/swift/v1
-catalog.<%=node['bcpc']['region_name']%>.object-store.adminURL = http://<%=node['bcpc']['floating']['vip']%>/swift/v1
-catalog.<%=node['bcpc']['region_name']%>.object-store.internalURL = http://<%=node['bcpc']['floating']['vip']%>/swift/v1
+catalog.<%=node['bcpc']['region_name']%>.object-store.publicURL = http://openstack.<%=node['bcpc']['cluster_domain']%>/swift/v1
+catalog.<%=node['bcpc']['region_name']%>.object-store.adminURL = http://openstack.<%=node['bcpc']['cluster_domain']%>/swift/v1
+catalog.<%=node['bcpc']['region_name']%>.object-store.internalURL = http://openstack.<%=node['bcpc']['cluster_domain']%>/swift/v1
 catalog.<%=node['bcpc']['region_name']%>.object-store.name = Object Store Service
 
-catalog.<%=node['bcpc']['region_name']%>.image.publicURL = <%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1
-catalog.<%=node['bcpc']['region_name']%>.image.adminURL = <%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1
-catalog.<%=node['bcpc']['region_name']%>.image.internalURL = <%=node['bcpc']['protocol']['glance']%>://<%=node['bcpc']['management']['vip']%>:9292/v1
+catalog.<%=node['bcpc']['region_name']%>.image.publicURL = <%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292/v1
+catalog.<%=node['bcpc']['region_name']%>.image.adminURL = <%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292/v1
+catalog.<%=node['bcpc']['region_name']%>.image.internalURL = <%=node['bcpc']['protocol']['glance']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9292/v1
 catalog.<%=node['bcpc']['region_name']%>.image.name = Image Service
 
-catalog.<%=node['bcpc']['region_name']%>.compute.publicURL = <%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8774/v1.1/$(tenant_id)s
-catalog.<%=node['bcpc']['region_name']%>.compute.adminURL = <%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8774/v1.1/$(tenant_id)s
-catalog.<%=node['bcpc']['region_name']%>.compute.internalURL = <%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8774/v1.1/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.compute.publicURL = <%=node['bcpc']['protocol']['nova']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8774/v1.1/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.compute.adminURL = <%=node['bcpc']['protocol']['nova']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8774/v1.1/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.compute.internalURL = <%=node['bcpc']['protocol']['nova']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8774/v1.1/$(tenant_id)s
 catalog.<%=node['bcpc']['region_name']%>.compute.name = Compute Service
 
-catalog.<%=node['bcpc']['region_name']%>.volume.publicURL = <%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['management']['vip']%>:8776/v1/$(tenant_id)s
-catalog.<%=node['bcpc']['region_name']%>.volume.adminURL = <%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['management']['vip']%>:8776/v1/$(tenant_id)s
-catalog.<%=node['bcpc']['region_name']%>.volume.internalURL = <%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['management']['vip']%>:8776/v1/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.volume.publicURL = <%=node['bcpc']['protocol']['cinder']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8776/v1/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.volume.adminURL = <%=node['bcpc']['protocol']['cinder']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8776/v1/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.volume.internalURL = <%=node['bcpc']['protocol']['cinder']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8776/v1/$(tenant_id)s
 catalog.<%=node['bcpc']['region_name']%>.volume.name = Volume Service
 
-catalog.<%=node['bcpc']['region_name']%>.volumev2.publicURL = <%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['management']['vip']%>:8776/v2/$(tenant_id)s
-catalog.<%=node['bcpc']['region_name']%>.volumev2.adminURL = <%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['management']['vip']%>:8776/v2/$(tenant_id)s
-catalog.<%=node['bcpc']['region_name']%>.volumev2.internalURL = <%=node['bcpc']['protocol']['cinder']%>://<%=node['bcpc']['management']['vip']%>:8776/v2/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.volumev2.publicURL = <%=node['bcpc']['protocol']['cinder']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8776/v2/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.volumev2.adminURL = <%=node['bcpc']['protocol']['cinder']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8776/v2/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.volumev2.internalURL = <%=node['bcpc']['protocol']['cinder']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8776/v2/$(tenant_id)s
 catalog.<%=node['bcpc']['region_name']%>.volumev2.name = cinderv2
 
-catalog.<%=node['bcpc']['region_name']%>.ec2.publicURL = <%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8773/services/Cloud
-catalog.<%=node['bcpc']['region_name']%>.ec2.adminURL = <%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8773/services/Admin
-catalog.<%=node['bcpc']['region_name']%>.ec2.internalURL = <%=node['bcpc']['protocol']['nova']%>://<%=node['bcpc']['management']['vip']%>:8773/services/Cloud
+catalog.<%=node['bcpc']['region_name']%>.ec2.publicURL = <%=node['bcpc']['protocol']['nova']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8773/services/Cloud
+catalog.<%=node['bcpc']['region_name']%>.ec2.adminURL = <%=node['bcpc']['protocol']['nova']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8773/services/Admin
+catalog.<%=node['bcpc']['region_name']%>.ec2.internalURL = <%=node['bcpc']['protocol']['nova']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8773/services/Cloud
 catalog.<%=node['bcpc']['region_name']%>.ec2.name = EC2 Service
 
-catalog.<%=node['bcpc']['region_name']%>.orchestration.publicURL = <%=node['bcpc']['protocol']['heat']%>://<%=node['bcpc']['management']['vip']%>:8004/v1/$(tenant_id)s
-catalog.<%=node['bcpc']['region_name']%>.orchestration.adminURL = <%=node['bcpc']['protocol']['heat']%>://<%=node['bcpc']['management']['vip']%>:8004/v1/$(tenant_id)s
-catalog.<%=node['bcpc']['region_name']%>.orchestration.internalURL = <%=node['bcpc']['protocol']['heat']%>://<%=node['bcpc']['management']['vip']%>:8004/v1/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.orchestration.publicURL = <%=node['bcpc']['protocol']['heat']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8004/v1/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.orchestration.adminURL = <%=node['bcpc']['protocol']['heat']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8004/v1/$(tenant_id)s
+catalog.<%=node['bcpc']['region_name']%>.orchestration.internalURL = <%=node['bcpc']['protocol']['heat']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8004/v1/$(tenant_id)s
 catalog.<%=node['bcpc']['region_name']%>.orchestration.name = Orchestration Service
 
-catalog.<%=node['bcpc']['region_name']%>.cloudformation.publicURL = <%=node['bcpc']['protocol']['heat']%>://<%=node['bcpc']['management']['vip']%>:8000/v1
-catalog.<%=node['bcpc']['region_name']%>.cloudformation.adminURL = <%=node['bcpc']['protocol']['heat']%>://<%=node['bcpc']['management']['vip']%>:8000/v1
-catalog.<%=node['bcpc']['region_name']%>.cloudformation.internalURL = <%=node['bcpc']['protocol']['heat']%>://<%=node['bcpc']['management']['vip']%>:8000/v1
+catalog.<%=node['bcpc']['region_name']%>.cloudformation.publicURL = <%=node['bcpc']['protocol']['heat']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8000/v1
+catalog.<%=node['bcpc']['region_name']%>.cloudformation.adminURL = <%=node['bcpc']['protocol']['heat']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8000/v1
+catalog.<%=node['bcpc']['region_name']%>.cloudformation.internalURL = <%=node['bcpc']['protocol']['heat']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8000/v1
 catalog.<%=node['bcpc']['region_name']%>.cloudformation.name = Cloudformation Service
 
-# catalog.<%=node['bcpc']['region_name']%>.metering.publicURL = <%=node['bcpc']['protocol']['ceilometer']%>://<%=node['bcpc']['management']['vip']%>:8777/
-# catalog.<%=node['bcpc']['region_name']%>.metering.adminURL = <%=node['bcpc']['protocol']['ceilometer']%>://<%=node['bcpc']['management']['vip']%>:8777/
-# catalog.<%=node['bcpc']['region_name']%>.metering.internalURL = <%=node['bcpc']['protocol']['ceilometer']%>://<%=node['bcpc']['management']['vip']%>:8777/
+# catalog.<%=node['bcpc']['region_name']%>.metering.publicURL = <%=node['bcpc']['protocol']['ceilometer']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8777/
+# catalog.<%=node['bcpc']['region_name']%>.metering.adminURL = <%=node['bcpc']['protocol']['ceilometer']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8777/
+# catalog.<%=node['bcpc']['region_name']%>.metering.internalURL = <%=node['bcpc']['protocol']['ceilometer']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8777/
 # catalog.<%=node['bcpc']['region_name']%>.metering.name = Metering Service
 
-# catalog.<%=node['bcpc']['region_name']%>.network.publicURL = <%=node['bcpc']['protocol']['neutron']%>://<%=node['bcpc']['management']['vip']%>:9696/
-# catalog.<%=node['bcpc']['region_name']%>.network.adminURL = <%=node['bcpc']['protocol']['neutron']%>://<%=node['bcpc']['management']['vip']%>:9696/
-# catalog.<%=node['bcpc']['region_name']%>.network.internalURL = <%=node['bcpc']['protocol']['neutron']%>://<%=node['bcpc']['management']['vip']%>:9696/
+# catalog.<%=node['bcpc']['region_name']%>.network.publicURL = <%=node['bcpc']['protocol']['neutron']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9696/
+# catalog.<%=node['bcpc']['region_name']%>.network.adminURL = <%=node['bcpc']['protocol']['neutron']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9696/
+# catalog.<%=node['bcpc']['region_name']%>.network.internalURL = <%=node['bcpc']['protocol']['neutron']%>://openstack.<%=node['bcpc']['cluster_domain']%>:9696/
 # catalog.<%=node['bcpc']['region_name']%>.network.name = Networking Service


### PR DESCRIPTION
This PR makes keystone list API endpoints using fqdn instead of ip addresses (makes ssl setup significantly cleaner).