### PR TITLE
Improve routemon behavior when network is funky.

### DIFF
--- a/cookbooks/bcpc/files/default/routemon.pl
+++ b/cookbooks/bcpc/files/default/routemon.pl
@@ -108,8 +108,9 @@ sub fix_routes {
             myprint "Fixed. Remaining fixes: $fixes\n";
             $routedown = 0;
         } else {
-            myprint "Not fixed. Unknown behaviours, aborting fix attempts\n";
-            $fixes = 0;
+	    myprint("routemon: Network not fully up - terminating\n");
+	    sleep 10;
+	    exit 0;
         }
     } else {
         myprint "No fixes left\n";


### PR DESCRIPTION
If routemon gets started before the network is fully up, it was
disabling itself a stupid permanent way, instead just exit and let
upstart respawn us. Sleep for 10 seconds first to give the network
some time to wake up and to avoid being killed by upstart for spawning
over and over again too often.

Fixes https://github.com/bloomberg/chef-bcpc/issues/674