### PR TITLE
Use post 0.50 cephx config

### DIFF
--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -6,7 +6,9 @@
 
 [global]
     fsid = <%=get_config('ceph-fs-uuid')%>
-    auth supported = cephx
+    auth cluster required = cephx
+    auth service required = cephx
+    auth client required = cephx
     public network = <%= @node["bcpc"]["storage"]["cidr"] %>
     cluster network = <%= @node["bcpc"]["storage"]["cidr"] %>
     keyring = /etc/ceph/$cluster.$name.keyring


### PR DESCRIPTION
the auth_support config has been deprecated since 0.50. 

There is a bunch of things not right/fishy about ceph auth in bcpc, will work through them.