### PR TITLE
Fixes #713 - no longer requires config overrides file to exist

### DIFF
--- a/bootstrap/vagrant_scripts/BOOT_GO.sh
+++ b/bootstrap/vagrant_scripts/BOOT_GO.sh
@@ -45,7 +45,11 @@ fi
 
 BOOTSTRAP_CONFIG_DEFAULTS="$REPO_ROOT/bootstrap/config/bootstrap_config.sh.defaults"
 BOOTSTRAP_CONFIG_OVERRIDES="$REPO_ROOT/bootstrap/config/bootstrap_config.sh.overrides"
-if [[ -f $BOOTSTRAP_CONFIG_DEFAULTS ]]; then source $BOOTSTRAP_CONFIG_DEFAULTS; fi
+if [[ ! -f $BOOTSTRAP_CONFIG_DEFAULTS ]]; then
+  echo "Bootstrap configuration defaults are missing! Your repository is corrupt; please restore $REPO_ROOT/bootstrap/config/bootstrap_config.sh.overrides." >&2
+  exit 1
+fi
+source $BOOTSTRAP_CONFIG_DEFAULTS
 if [[ -f $BOOTSTRAP_CONFIG_OVERRIDES ]]; then source $BOOTSTRAP_CONFIG_OVERRIDES; fi
 
 # Perform preflight checks to validate environment sanity as much as possible.
@@ -81,4 +85,3 @@ $REPO_ROOT/bootstrap/shared/shared_configure_chef.sh
 
 # Dump out useful information for users.
 $REPO_ROOT/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
-

--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -22,7 +22,7 @@ def extract_and_export_envvar(line)
     # this blob interpolates existing environment variables in
     interpolated_value = value.dup
     envvars_to_interpolate = interpolated_value.scan /\$\w+/
-    envvars_to_interpolate.flatten.each {|v| interpolated_value.gsub!(v, ENV[v.tr('$', '')])}    
+    envvars_to_interpolate.flatten.each {|v| interpolated_value.gsub!(v, ENV[v.tr('$', '')])}
     explanation = (ENV[name] ? "Overriding " : "Setting ") + "#{name} = #{interpolated_value}"
     explanation << " (originally #{value})" if interpolated_value != value
     # puts explanation
@@ -31,12 +31,15 @@ def extract_and_export_envvar(line)
 end
 
 config_path = File.join ENV['REPO_ROOT'], 'bootstrap', 'config'
-[
-  File.join(config_path, 'bootstrap_config.sh.defaults'),
-  File.join(config_path, 'bootstrap_config.sh.overrides')
-].each do |config_file|
-  File.open(config_file).each do |line|
+config_defaults = File.join(config_path, 'bootstrap_config.sh.defaults')
+config_overrides = File.join(config_path, 'bootstrap_config.sh.overrides')
+
+File.open(config_defaults).each do |line|
     extract_and_export_envvar(line)
+end
+if File.exist?(config_overrides)
+  File.open(config_overrides).each do |line|
+      extract_and_export_envvar(line)
   end
 end
 
@@ -177,7 +180,7 @@ Vagrant.configure("2") do |config|
   vms_to_build = ['bootstrap', (1..cluster_nodes).collect {|x| "vm#{x}"}].flatten
 
   vms_to_build.each_with_index do |vm, idx|
-    config.vm.define vm do |m|  
+    config.vm.define vm do |m|
       # use .3 as the final octet for the bootstrap node, otherwise 11, 12, etc.
       final_octet = (vm == 'bootstrap' ? 3 : 10+idx)
       bootstrap_domain = (ENV['BOOTSTRAP_DOMAIN'] or "bcpc.example.com")
@@ -200,12 +203,12 @@ Vagrant.configure("2") do |config|
         s.privileged = false
         s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
       end
-    
+
       # configure extra CA certificates
       m.vm.provision "configure-ca-certificates", type: "shell" do |s|
         s.inline = $update_ca_certificates_script
       end
-    
+
       # configure proxy servers (do not run as root)
       m.vm.provision "configure-proxy-servers", type: "shell" do |s|
         s.privileged = false
@@ -225,29 +228,29 @@ Vagrant.configure("2") do |config|
       m.vm.provision "configure-repositories", type: "shell" do |s|
         s.inline = $repos_script
       end
-    
+
       # configure a hostfile entry with the IP of the bootstrap node (for Chef)
       m.vm.provision "configure-bootstrap-hostfile-entry", type: "shell" do |s|
         s.inline = "echo -e '10.0.100.3\tbcpc-bootstrap.#{bootstrap_domain}\n' >> /etc/hosts"
       end
-    
-      # clean up some packages installed in this image by default      
+
+      # clean up some packages installed in this image by default
       m.vm.provision "clean-up-unnecessary-packages", type: "shell" do |s|
         s.inline = "apt-get remove -y #{$packages_to_remove.join(' ')}"
       end if $packages_to_remove.length > 0
-    
+
       # add swap space
       m.vm.provision "add-swap-space", type: "shell" do |s|
         s.inline = $add_swap_script
       end
-    
+
       m.vm.box = "trusty64"
       m.vm.box_url = "#{ENV['BOOTSTRAP_CACHE_DIR']}/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
       if vm == 'bootstrap'
         memory = ( ENV["BOOTSTRAP_VM_MEM"] or "2048" )
         cpus = ( ENV["BOOTSTRAP_VM_CPUS"] or "2" )
-      else      
+      else
         memory = ( ENV["CLUSTER_VM_MEM"] or "2560" )
         cpus = ( ENV["CLUSTER_VM_CPUS"] or "2" )
         disk_size = ( ENV["CLUSTER_VM_DRIVE_SIZE"] or "20480" )
@@ -277,8 +280,8 @@ Vagrant.configure("2") do |config|
             vm_dir = File.join(default_vm_loc, vm)
           rescue
             fail "Unable to locate VM #{vm} on disk, terminating"
-          end        
-        
+          end
+
           ('b'..'e').each_with_index do |disk, disk_idx|
             disk_file = File.join(vm_dir, "#{vm}-#{disk}.vdi")
             unless File.exist?(disk_file)


### PR DESCRIPTION
Additional semi-related change in this PR is to require that the defaults file exist in `BOOT_GO.sh`, so that it won't try to plow ahead when required environment variables are unconfigured.