### PR TITLE
Two CephX changes: Cinder/Glance CephX clients and perms on admin sockets

### DIFF
--- a/cookbooks/bcpc/recipes/ceph-common.rb
+++ b/cookbooks/bcpc/recipes/ceph-common.rb
@@ -77,6 +77,25 @@ template '/etc/ceph/ceph.conf' do
     variables(:servers => get_head_nodes)
 end
 
+directory "/var/run/ceph/" do  
+  owner "root"
+  group "root"
+  mode  "0755"  
+end
+
+directory "/var/run/ceph/guests/" do  
+  owner "libvirt-qemu"
+  group "libvirtd"
+  mode  "0755"  
+end
+
+directory "/var/log/qemu/" do
+  owner "libvirt-qemu"
+  group "libvirtd"
+  mode  "0755"  
+
+end 
+
 bcpc_cephconfig 'paxos_propose_interval' do  
   value node["bcpc"]["ceph"]["rebalance"] ? "60" : "1"
   target "ceph-*"

--- a/cookbooks/bcpc/recipes/ceph-head.rb
+++ b/cookbooks/bcpc/recipes/ceph-head.rb
@@ -252,6 +252,29 @@ end
     end
   end
 end
-    
+
+bash "create-ceph-cinder-user" do
+  user "root"
+  code "ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rx pool=images'"
+  not_if "ceph auth get client.cinder"
+end
+
+bash "create-ceph-glance-user" do
+  user "root"
+  code "ceph auth get-or-create client.glance mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=images'"
+  not_if "ceph auth get client.glance"
+end
+
+bash "create-ceph-cinder-keyring" do
+  user "root"
+  code "ceph auth get-or-create client.cinder  > /etc/ceph/ceph.client.cinder.keyring"
+  not_if "test -f  /etc/ceph/ceph.client.cinder.keyring"
+end
+
+bash "create-ceph-glance-keyring" do
+  user "root"
+  code "ceph auth get-or-create client.glance  > /etc/ceph/ceph.client.glance.keyring"
+  not_if "test -f  /etc/ceph/ceph.client.glance.keyring"
+end
 
 include_recipe "bcpc::ceph-work"

--- a/cookbooks/bcpc/recipes/ceph-head.rb
+++ b/cookbooks/bcpc/recipes/ceph-head.rb
@@ -255,7 +255,7 @@ end
 
 bash "create-ceph-cinder-user" do
   user "root"
-  code "ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rx pool=images'"
+  code "ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes-ssd,allow rwx pool=volumes-hdd, allow rwx pool=vms, allow rx pool=images'"
   not_if "ceph auth get client.cinder"
 end
 

--- a/cookbooks/bcpc/recipes/ceph-head.rb
+++ b/cookbooks/bcpc/recipes/ceph-head.rb
@@ -271,10 +271,25 @@ bash "create-ceph-cinder-keyring" do
   not_if "test -f  /etc/ceph/ceph.client.cinder.keyring"
 end
 
+ruby_block "store-cinder-ceph-key" do
+  block do
+    make_config("cinder-ceph-key", `ceph auth get-key client.cinder`)
+  end
+  only_if "test -f  /etc/ceph/ceph.client.cinder.keyring"
+end
+
 bash "create-ceph-glance-keyring" do
   user "root"
   code "ceph auth get-or-create client.glance  > /etc/ceph/ceph.client.glance.keyring"
   not_if "test -f  /etc/ceph/ceph.client.glance.keyring"
 end
+
+ruby_block "store-glance-ceph-key" do
+  block do
+    make_config("glance-ceph-key", `ceph auth get-key client.glance`)
+  end
+  only_if "test -f  /etc/ceph/ceph.client.glance.keyring"
+end
+
 
 include_recipe "bcpc::ceph-work"

--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -132,6 +132,9 @@ bash "glance-database-sync" do
     notifies :restart, "service[glance-registry]", :immediately
 end
 
+# Note, glance connects to ceph using client.glance, but we have already generated
+# the key for that in ceph-head.rb, so by now we should have it in /etc/ceph/ceph.client.glance.key
+
 bash "create-glance-rados-pool" do
     user "root"
     optimal = power_of_2(get_ceph_osd_nodes.length*node['bcpc']['ceph']['pgs_per_node']/node['bcpc']['ceph']['images']['replicas']*node['bcpc']['ceph']['images']['portion']/100)

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -164,9 +164,9 @@ end
 
 ruby_block 'load-virsh-keys' do
     block do
-        %x[ ADMIN_KEY=`ceph --name mon. --keyring /etc/ceph/ceph.mon.keyring auth get-or-create-key client.admin`
+        %x[ CINDER_KEY=`ceph --name mon. --keyring /etc/ceph/ceph.mon.keyring auth get-or-create-key client.cinder`
             virsh secret-define --file /etc/nova/virsh-secret.xml
-            virsh secret-set-value --secret #{get_config('libvirt-secret-uuid')} --base64 "$ADMIN_KEY"
+            virsh secret-set-value --secret #{get_config('libvirt-secret-uuid')} --base64 "$CINDER_KEY"
         ]
     end
     not_if { system "virsh secret-list | grep -i #{get_config('libvirt-secret-uuid')} >/dev/null" }

--- a/cookbooks/bcpc/templates/default/apparmor-libvirt-qemu.erb
+++ b/cookbooks/bcpc/templates/default/apparmor-libvirt-qemu.erb
@@ -1,0 +1,196 @@
+# Last Modified: Wed Jul  8 09:57:41 2009
+
+  #include <abstractions/base>
+  #include <abstractions/consoles>
+  #include <abstractions/nameservice>
+
+  # required for reading disk images
+  capability dac_override,
+  capability dac_read_search,
+  capability chown,
+
+  # needed to drop privileges
+  capability setgid,
+  capability setuid,
+
+  # this is needed with libcap-ng support, however it breaks a lot of things
+  # atm, so just silence the denial until libcap-ng works right. LP: #522845
+  deny capability setpcap,
+
+  network inet stream,
+  network inet6 stream,
+
+  /dev/net/tun rw,
+  /dev/tap* rw,
+  /dev/kvm rw,
+  /dev/ptmx rw,
+  /dev/kqemu rw,
+  @{PROC}/*/status r,
+  @{PROC}/sys/kernel/cap_last_cap r,
+  owner @{PROC}/*/auxv r,
+  @{PROC}/sys/vm/overcommit_memory r,
+
+  # For hostdev access. The actual devices will be added dynamically
+  /sys/bus/usb/devices/ r,
+  /sys/devices/**/usb[0-9]*/** r,
+
+  # WARNING: this gives the guest direct access to host hardware and specific
+  # portions of shared memory. This is required for sound using ALSA with kvm,
+  # but may constitute a security risk. If your environment does not require
+  # the use of sound in your VMs, feel free to comment out or prepend 'deny' to
+  # the rules for files in /dev.
+  /{dev,run}/shm r,
+  /{dev,run}/shmpulse-shm* r,
+  /{dev,run}/shmpulse-shm* rwk,
+  /dev/snd/* rw,
+  capability ipc_lock,
+  # spice
+  /usr/bin/qemu-system-i386-spice rmix,
+  /usr/bin/qemu-system-x86_64-spice rmix,
+  /{dev,run}/shm/ r,
+  owner /{dev,run}/shm/spice.* rw,
+  # 'kill' is not required for sound and is a security risk. Do not enable
+  # unless you absolutely need it.
+  deny capability kill,
+
+  # Uncomment the following if you need access to /dev/fb*
+  #/dev/fb* rw,
+
+  /etc/pulse/client.conf r,
+  @{HOME}/.pulse-cookie rwk,
+  owner /root/.pulse-cookie rwk,
+  owner /root/.pulse/ rw,
+  owner /root/.pulse/* rw,
+  /usr/share/alsa/** r,
+  owner /tmp/pulse-*/ rw,
+  owner /tmp/pulse-*/* rw,
+  /var/lib/dbus/machine-id r,
+
+  # access to firmware's etc
+  /usr/share/kvm/** r,
+  /usr/share/qemu/** r,
+  /usr/share/bochs/** r,
+  /usr/share/openbios/** r,
+  /usr/share/openhackware/** r,
+  /usr/share/proll/** r,
+  /usr/share/vgabios/** r,
+  /usr/share/seabios/** r,
+  /usr/share/misc/sgabios.bin r,
+  /usr/share/ovmf/** r,
+  /usr/share/slof/** r,
+
+  # access PKI infrastructure
+  /etc/pki/libvirt-vnc/** r,
+
+  # the various binaries
+  /usr/bin/kvm rmix,
+  /usr/bin/qemu rmix,
+  /usr/bin/qemu-system-aarch64 rmix,
+  /usr/bin/qemu-system-arm rmix,
+  /usr/bin/qemu-system-cris rmix,
+  /usr/bin/qemu-system-i386 rmix,
+  /usr/bin/qemu-system-m68k rmix,
+  /usr/bin/qemu-system-microblaze rmix,
+  /usr/bin/qemu-system-microblazeel rmix,
+  /usr/bin/qemu-system-mips rmix,
+  /usr/bin/qemu-system-mips64 rmix,
+  /usr/bin/qemu-system-mips64el rmix,
+  /usr/bin/qemu-system-mipsel rmix,
+  /usr/bin/qemu-system-ppc rmix,
+  /usr/bin/qemu-system-ppc64 rmix,
+  /usr/bin/qemu-system-ppcemb rmix,
+  /usr/bin/qemu-system-sh4 rmix,
+  /usr/bin/qemu-system-sh4eb rmix,
+  /usr/bin/qemu-system-sparc rmix,
+  /usr/bin/qemu-system-sparc64 rmix,
+  /usr/bin/qemu-system-x86_64 rmix,
+  /usr/bin/qemu-system-x86_64-spice rmix,
+  /usr/bin/qemu-alpha rmix,
+  /usr/bin/qemu-arm rmix,
+  /usr/bin/qemu-armeb rmix,
+  /usr/bin/qemu-cris rmix,
+  /usr/bin/qemu-i386 rmix,
+  /usr/bin/qemu-m68k rmix,
+  /usr/bin/qemu-microblaze rmix,
+  /usr/bin/qemu-microblazeel rmix,
+  /usr/bin/qemu-mips rmix,
+  /usr/bin/qemu-mipsel rmix,
+  /usr/bin/qemu-ppc rmix,
+  /usr/bin/qemu-ppc64 rmix,
+  /usr/bin/qemu-ppc64abi32 rmix,
+  /usr/bin/qemu-sh4 rmix,
+  /usr/bin/qemu-sh4eb rmix,
+  /usr/bin/qemu-sparc rmix,
+  /usr/bin/qemu-sparc64 rmix,
+  /usr/bin/qemu-sparc32plus rmix,
+  /usr/bin/qemu-sparc64 rmix,
+  /usr/bin/qemu-x86_64 rmix,
+
+  # for save and resume
+  /bin/dash rmix,
+  /bin/dd rmix,
+  /bin/cat rmix,
+  /etc/pki/CA/ r,
+  /etc/pki/CA/* r,
+  /etc/pki/libvirt/ r,
+  /etc/pki/libvirt/** r,
+
+  # kvm.powerpc executes this
+  /bin/uname rmix,
+
+  # for rbd
+  /etc/ceph/ceph.conf r,
+  capability mknod,
+  # for rbd
+  /var/log/qemu/* rw,
+  /{,var/}run/ceph/guests/** rw,
+
+
+  # for access to hugepages
+  owner "/run/hugepages/kvm/libvirt/qemu/**" rw,
+
+  # for usb access
+  /dev/bus/usb/ r,
+  /etc/udev/udev.conf r,
+  /sys/bus/ r,
+  /sys/class/ r,
+
+  signal (receive) peer=/usr/sbin/libvirtd,
+  ptrace (tracedby) peer=/usr/sbin/libvirtd,
+
+  # for ppc device-tree access
+  @{PROC}/device-tree/ r,
+  @{PROC}/device-tree/** r,
+  /sys/firmware/devicetree/** r,
+
+  # allow access to charm-specific ceph config (see lp#1403648)
+  /var/lib/charm/*/ceph.conf r,
+  # silence spurious denials (see lp#1403648)
+  deny /tmp/{,**} r,
+  deny /var/tmp/{,**} r,
+
+  # silence refusals to open lttng files (see lp#1432644)
+  deny /dev/shm/lttng-ust-wait-* r,
+
+  /usr/{lib,libexec}/qemu-bridge-helper Cx -> qemu_bridge_helper,
+  # child profile for bridge helper process
+  profile qemu_bridge_helper {
+   #include <abstractions/base>
+
+   capability setuid,
+   capability setgid,
+   capability setpcap,
+   capability net_admin,
+
+   # for 9p
+   capability fsetid,
+   capability fowner,
+
+   network inet stream,
+
+   /dev/net/tun rw,
+   /etc/qemu/** r,
+   owner @{PROC}/*/status r,
+
+   /usr/{lib,libexec}/qemu-bridge-helper rmix,
+  }

--- a/cookbooks/bcpc/templates/default/ceph-client-cinder-keyring.erb
+++ b/cookbooks/bcpc/templates/default/ceph-client-cinder-keyring.erb
@@ -1,0 +1,3 @@
+[client.cinder]
+	key = <%= get_config("cinder-ceph-key") %>
+	

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -40,12 +40,25 @@
     osd mon report interval min = 30
 <% end %>
 
-[client]
+[client.admin]
+    # dont want the admin client creating sockets/logs
+    admin socket = 
+    log file = 
+
+[client.cinder]
     rbd cache = true
     rbd cache writethrough until flush = true
     admin socket = /var/run/ceph/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
     log file = /var/log/qemu/qemu-guest-$pid.log
+    rbd concurrent management ops = 20
 
+[client.glance]
+    rbd cache = true
+    rbd cache writethrough until flush = true
+    admin socket = /var/run/ceph/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
+    log file = /var/log/qemu/qemu-guest-$pid.log
+    rbd concurrent management ops = 20
+    
 [client.radosgw.gateway]
     host = <%=node['hostname']%>
     keyring = /var/lib/ceph/radosgw/$cluster-$id/keyring

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -43,19 +43,19 @@
 [client.admin]
     # dont want the admin client creating sockets/logs
     admin socket = 
-    log file = 
-
+    log file =
+    
 [client.cinder]
     rbd cache = true
     rbd cache writethrough until flush = true
-    admin socket = /var/run/ceph/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
+    admin socket = /var/run/ceph/guests/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
     log file = /var/log/qemu/qemu-guest-$pid.log
     rbd concurrent management ops = 20
 
 [client.glance]
     rbd cache = true
     rbd cache writethrough until flush = true
-    admin socket = /var/run/ceph/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
+    admin socket = /var/run/ceph/guests/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
     log file = /var/log/qemu/qemu-guest-$pid.log
     rbd concurrent management ops = 20
     

--- a/cookbooks/bcpc/templates/default/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder.conf.erb
@@ -84,9 +84,12 @@ signing_dir = /var/lib/cinder
 [<%= type.upcase %>]
 volume_driver=cinder.volume.drivers.rbd.RBDDriver
 volume_backend_name=<%= type.upcase %>
-rbd_user=admin
+rbd_user=cinder
 rbd_pool=<%="#{node['bcpc']['ceph']['volumes']['name']}-#{type}"%>
 rbd_secret_uuid=<%=get_config('libvirt-secret-uuid')%>
 rbd_flatten_volume_from_snapshot=False
 rbd_max_clone_depth=5
+rbd_store_chunk_size = 4
+rados_connect_timeout = -1
+glance_api_version = 2
 <% end -%>

--- a/cookbooks/bcpc/templates/default/glance-api.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-api.conf.erb
@@ -142,7 +142,7 @@ image_cache_dir = /var/lib/glance/image-cache/
 default_store = rbd
 stores = rbd
 rbd_store_pool = <%=node['bcpc']['ceph']['images']['name']%>
-rbd_store_user = admin
+rbd_store_user = glance
 rbd_store_ceph_conf = /etc/ceph/ceph.conf
 rbd_store_chunk_size = 8
 

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -167,7 +167,7 @@ api_insecure=True
 images_type=rbd
 images_rbd_pool=<%=node['bcpc']['ceph']['vms']['name']%>
 images_rbd_ceph_conf=/etc/ceph/ceph.conf
-rbd_user=admin
+rbd_user=cinder
 rbd_secret_uuid=<%=get_config('libvirt-secret-uuid')%>
 disk_cachemodes="network=writeback"
 # do not allow libvirt to try to inject into the local partition
@@ -178,6 +178,7 @@ inject_partition=-2
 live_migration_flag="VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRATE_LIVE,VIR_MIGRATE_PERSIST_DEST,VIR_MIGRATE_TUNNELLED"
 virt_type=<%=node['bcpc']['virt_type']%>
 use_virtio_for_bridges=True
+hw_disk_discard = unmap
 
 
 <% unless node["bcpc"]["vendordata_config"].nil? %>

--- a/cookbooks/bcpc/templates/default/virsh-secret.xml.erb
+++ b/cookbooks/bcpc/templates/default/virsh-secret.xml.erb
@@ -7,7 +7,7 @@
 -->
 <secret ephemeral='no' private='no'>
    <usage type='ceph'>
-     <name>client.admin secret</name>
+     <name>client.cinder secret</name>
    </usage>
    <uuid><%=get_config('libvirt-secret-uuid')%></uuid>
 </secret>


### PR DESCRIPTION
This PR does two things:
* Previously we were using the admin key for every ceph operation. This key has the following perms:
```
	caps mds = "allow"
	caps mon = "allow *"
	caps osd = "allow *"
```
For various security reasons this seems like a bad idea. In a future PR I will remove the admin key from the compute nodes. However, there may be monitoring consequences as you will be unable to do things like `ceph health` without passing your own key. If indeed this is a problem we can create a readonly key for mons. Monitoring should however be able to get everything it needs through the admin sockets.  @kelvk will have to comment.
* Secondly, ceph was configured to create an admin socket for *all* ceph clients. This includes the admin client (which *should* just be used to do admin tasks on the cluster, see above). Now we break down the configuration of the clients based on type. So cinder and glance clients create sockets, but things like `ceph health` does not. I found that this functionality was actually broken for any of the useful clients anyhow. So we weren't even creating admin sockets for cinder clients (no matter which cephx client they use). This is a simple fix to apparmor config.  Fixes #652 

This should be able to be cheff-ed in to an already running BCPC cluster, perhaps bouncing openstack services will be required. 
  