### PR TITLE
Script to enable/disable Elasticsearch shard rebalancing

### DIFF
--- a/cookbooks/bcpc/files/default/ess-shard-rebalancing
+++ b/cookbooks/bcpc/files/default/ess-shard-rebalancing
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import json
+import requests
+import argparse
+import sys
+
+def set_rebalance(args):
+    content = {}
+    content['transient'] = {}
+
+    if args.rebalance is False:
+        content['transient']['cluster.routing.allocation.enable'] = 'none'
+    else:
+        content['transient']['cluster.routing.allocation.enable'] = 'all'
+
+    es_url = "http://%s:%d/_cluster/settings" % (args.es_host, args.es_port)
+    try:
+        response = requests.put(es_url, data=json.dumps(content), timeout=10)
+    except requests.exceptions.RequestException as e:
+        raise Exception(e)
+
+    # Raise error if HTTP code is not 200
+    response.raise_for_status()
+
+    ack = response.json()
+    print ack
+
+    if ack['acknowledged'] is True:
+        return
+    else:
+        raise Exception('Elasticsearch did not acknowledge successfully')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog=__file__, usage='%(prog)s [--yes|--no] [--host <Elasticsearch server>]')
+    parser.add_argument('--host', action='store', dest='es_host', required=True, help='Elasticsearch host')
+    parser.add_argument('--port', action='store', dest='es_port', default=9200, type=int, help='Elasticsearch port')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--yes', action='store_true', dest='rebalance', help='enable shard rebalancing')
+    group.add_argument('--no', action='store_false', dest='rebalance', help='disable shard rebalancing')
+    args = parser.parse_args(sys.argv[1:])
+
+    set_rebalance(args)

--- a/cookbooks/bcpc/recipes/elasticsearch.rb
+++ b/cookbooks/bcpc/recipes/elasticsearch.rb
@@ -41,6 +41,13 @@ if node['bcpc']['enabled']['logging'] then
         action :install
     end
 
+    cookbook_file "/usr/local/bin/ess-shard-rebalancing" do
+        source "ess-shard-rebalancing"
+        owner "root"
+        group "root"
+        mode 00755
+    end
+
     template "/etc/default/elasticsearch" do
         source "elasticsearch-default.erb"
         owner "root"


### PR DESCRIPTION
During planned maintenance windows, we may not want Elasticsearch to rebalance shards. This provides a little convenience in enabling/disabling rebalancing.