### PR TITLE
Enabled isolcpus

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -518,6 +518,9 @@ default['bcpc']['keystone']['policy'] = {
 default['bcpc']['nova']['ram_allocation_ratio'] = 1.0
 default['bcpc']['nova']['reserved_host_memory_mb'] = 1024
 default['bcpc']['nova']['cpu_allocation_ratio'] = 2.0
+
+default['bcpc']['nova']['host_cpus'] = [0]
+default['bcpc']['nova']['vm_cpus'] = [1]
 # "workers" parameters in nova are set to number of CPUs
 # available by default. This provides an override.
 default['bcpc']['nova']['workers'] = 5

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -266,3 +266,17 @@ bash "patch-for-ip-hostnames-networking" do
     notifies :restart, "service[nova-compute]", :immediately
     notifies :restart, "service[nova-network]", :immediately
 end 
+
+#
+# Pin all host processes (including OSDs) to the following cpus
+#
+if not node['bcpc']['nova']['host_cpus'].nil?
+bash "set-cpu-isolation" do
+    user "root"
+    code <<-EOH
+        echo GRUB_CMDLINE_LINUX_DEFAULT=\\\"\\$GRUB_CMDLINE_LINUX_DEFAULT isolcpus=#{ node['bcpc']['nova']['host_cpus'].join(',')}\\\" >> /etc/default/grub
+        update-grub
+    EOH
+    not_if "grep 'isolcpus=#{ node['bcpc']['nova']['host_cpus'].join(',')}' /etc/default/grub"
+end
+end

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -76,6 +76,11 @@ use_cow_images=True
 #start_guests_on_host_boot=True
 #resume_guests_state_on_host_boot=True
 
+<% if not node['bcpc']['nova']['vm_cpus'].nil? %>
+# pin vcpus to cpus
+vcpu_pin_set=<%=node['bcpc']['nova']['vm_cpus'].join(',')%>
+<% end %>
+
 # Nova Volume settings
 volume_api_class=nova.volume.cinder.API
 


### PR DESCRIPTION
restrict the kernel scheduler to a subset of the cpus on the host and force libvirt to use the others. 

Really we should enable the cpu pinning filter and do the full monte here, especially for deployments that are not doing overcommit, because the performance boost is supposed to be quite impressive.

Note I wasn't able to get this to work on virtual box(something about the boot loader), but was able to get it working on a hardware clusters. To deploy on hardware, use `virsh capabilities` to grab the cpu tags and the numa groups. then split up the cpus however you like,,, 

Note, currently there is no way to set isolcpus outside of the boot cmd params, so  *reboot is required*