### PR TITLE
Randomize host selection from scheduler

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -529,6 +529,8 @@ default['bcpc']['keystone']['policy'] = {
 default['bcpc']['nova']['ram_allocation_ratio'] = 1.0
 default['bcpc']['nova']['reserved_host_memory_mb'] = 1024
 default['bcpc']['nova']['cpu_allocation_ratio'] = 2.0
+# select from between this many equally optimal hosts when launching an instance
+default['bcpc']['nova']['scheduler_host_subset_size'] = 3
 # "workers" parameters in nova are set to number of CPUs
 # available by default. This provides an override.
 default['bcpc']['nova']['workers'] = 5

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -43,6 +43,7 @@ scheduler_default_filters=<%=node['bcpc']['nova']['scheduler_default_filters'].j
 ram_allocation_ratio=<%=node['bcpc']['nova']['ram_allocation_ratio']%>
 reserved_host_memory_mb=<%=node['bcpc']['nova']['reserved_host_memory_mb']%>
 cpu_allocation_ratio=<%=node['bcpc']['nova']['cpu_allocation_ratio']%>
+scheduler_host_subset_size=<%= node['bcpc']['nova']['scheduler_host_subset_size'] %>
 
 # Nova Network settings
 network_manager=nova.network.manager.VlanManager


### PR DESCRIPTION
It drives me potty that if you keep starting and stopping an instance it always lands on the same host. This PR randomizes the selection a bit.