### PR TITLE
Apt-mirror cleanup

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -231,6 +231,7 @@ default['bcpc']['mirror']['ubuntu-dist'] = ['trusty']
 default['bcpc']['mirror']['ceph-dist'] = ['hammer']
 default['bcpc']['mirror']['os-dist'] = ['kilo']
 default['bcpc']['mirror']['elasticsearch-dist'] = '1.5'
+default['bcpc']['mirror']['kibana-dist'] = '4.1'
 
 ###########################################
 #

--- a/cookbooks/bcpc/templates/default/apache-mirror.erb
+++ b/cookbooks/bcpc/templates/default/apache-mirror.erb
@@ -63,12 +63,11 @@
     Alias /elasticsearch /var/spool/apt-mirror/mirror/packages.elasticsearch.org/elasticsearch/<%=@node['bcpc']['mirror']['elasticsearch-dist']%>/debian
     Alias /fluentd /var/spool/apt-mirror/mirror/packages.treasure-data.com/2/ubuntu/trusty
     Alias /hwraid /var/spool/apt-mirror/mirror/hwraid.le-vert.net/ubuntu
+    Alias /kibana /var/spool/apt-mirror/mirror/packages.elasticsearch.org/kibana/<%=@node['bcpc']['mirror']['kibana-dist']%>/debian
     Alias /percona /var/spool/apt-mirror/mirror/repo.percona.com/apt
     Alias /ubuntu-cloud /var/spool/apt-mirror/mirror/ubuntu-cloud.archive.canonical.com/ubuntu
     Alias /rabbitmq /var/spool/apt-mirror/mirror/www.rabbitmq.com/debian
     Alias /ubuntu /var/spool/apt-mirror/mirror/<%=@node['bcpc']['mirror']['ubuntu']%>
     Alias /launchpad /var/spool/apt-mirror/mirror/ppa.launchpad.net
-    Alias /cassandra /var/spool/apt-mirror/mirror/www.apache.org/dist/cassandra/debian
-    Alias /hdp /var/spool/apt-mirror/mirror/public-repo-1.hortonworks.com/HDP/ubuntu12/2.x
-    Alias /hdp-utils /var/spool/apt-mirror/mirror/public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.16/repos/ubuntu12
+    Alias /zabbix /var/spool/apt-mirror/mirror/repo.zabbix.com/zabbix/2.4/ubuntu
 </VirtualHost>

--- a/cookbooks/bcpc/templates/default/apt-mirror.mirror.list.erb
+++ b/cookbooks/bcpc/templates/default/apt-mirror.mirror.list.erb
@@ -17,6 +17,10 @@
 # set run_postmirror 0
 set nthreads     20
 set _tilde 0
+<% if not @node['bcpc']['bootstrap']['proxy'].nil? %>
+set use_proxy on
+set http_proxy <%= @node['bcpc']['bootstrap']['proxy'] %>
+<% end %>
 #
 ############# end config ##############
 

--- a/cookbooks/bcpc/templates/default/apt-mirror.mirror.list.erb
+++ b/cookbooks/bcpc/templates/default/apt-mirror.mirror.list.erb
@@ -62,7 +62,7 @@ deb-i386 http://ubuntu-cloud.archive.canonical.com/ubuntu precise-<%= @repo %>/<
 <% end %>
 <% end %>
 
-deb <%= @node['bcpc']['repos']['fluentd'] %> <%= @distro %> contrib
+deb http://packages.treasure-data.com/2/ubuntu/trusty/ trusty contrib
 
 <% end %>
 
@@ -70,11 +70,9 @@ deb <%= @node['bcpc']['repos']['fluentd'] %> <%= @distro %> contrib
 deb http://www.rabbitmq.com/debian testing main
 deb-i386 http://www.rabbitmq.com/debian testing main
 
-# no trusty packages yet (20140529)
-deb http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.16/repos/ubuntu12 HDP-UTILS main
-deb http://public-repo-1.hortonworks.com/HDP/ubuntu12/2.x HDP main
-
-deb <%=@node['bcpc']['repos']['elasticsearch']%> stable main
+deb http://packages.elasticsearch.org/elasticsearch/1.5/debian stable main
+deb http://packages.elasticsearch.org/kibana/4.1/debian stable main
+deb http://repo.zabbix.com/zabbix/2.4/ubuntu <%= @distro %>  main
 
 clean http://<%=@node['bcpc']['mirror']['ubuntu']%>
 clean http://ceph.com
@@ -85,5 +83,5 @@ clean http://ubuntu-cloud.archive.canonical.com/ubuntu
 clean http://apt.opscode.com
 clean http://www.rabbitmq.com/debian
 clean http://packages.treasure-data.com
-clean http://public-repo-1.hortonworks.com
 clean http://packages.elasticsearch.org
+clean http://repo.zabbix.com

--- a/docs/example_apt_mirror_config.list
+++ b/docs/example_apt_mirror_config.list
@@ -33,6 +33,11 @@ deb http://packages.elasticsearch.org/elasticsearch/1.5/debian stable main
 deb-i386 http://packages.elasticsearch.org/elasticsearch/1.5/debian stable main
 clean http://packages.elasticsearch.org/elasticsearch/1.5/debian
 
+# kibana repository in BCPC
+deb http://packages.elasticsearch.org/kibana/4.1/debian stable main
+deb-i386 http://packages.elasticsearch.org/kibana/4.1/debian stable main
+clean http://packages.elasticsearch.org/kibana/4.1/debian
+
 # ubuntu repository in BCPC
 deb http://mirror.pnl.gov/ubuntu/ trusty main restricted universe multiverse main/debian-installer
 deb http://mirror.pnl.gov/ubuntu/ trusty-security main restricted universe multiverse main/debian-installer
@@ -67,5 +72,5 @@ deb-i386 http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-updates/kilo ma
 clean http://ubuntu-cloud.archive.canonical.com/ubuntu
 
 # zabbix repository in BCPC
-deb http://repo.zabbix.com/zabbix/2.2/ubuntu/ trusty main
-clean http://repo.zabbix.com/zabbix/2.2/ubuntu/
+deb http://repo.zabbix.com/zabbix/2.4/ubuntu/ trusty main
+clean http://repo.zabbix.com/zabbix/2.4/ubuntu/


### PR DESCRIPTION
Apt-mirror doesn't currently work when run behind a proxy. This also removes repos (cassandra/hadoop) that are not known to be used and adds Zabbix repo, since Zabbix is now installed from packages.

Test steps:
1. If bootstrap VM needs a proxy, define `proxy` key in https://github.com/bloomberg/bcpc/blob/master/environments/Test-Laptop-Vagrant.json#L52 using `knife environment edit ...`. Value should be a full URL (i.e. `http://<proxy fqdn>:<proxy port>`)
2. Associate apt-mirror and apache-mirror recipes with Bootstrap role and rechef.
3. Execute `apt-mirror`. To speed things up, you may wish to remove ubuntu/ceph/percona/etc `deb` definitions from `/etc/apt/mirror.list`, leaving just the ones of interest (elasticsearch/treasure-data/zabbix).
4. Check downloaded debs are in `/var/spool/apt-mirror/mirror`.
5. Check apt repos are available:
http://10.0.100.3/zabbix/
http://10.0.100.3/elasticsearch/
http://10.0.100.3/fluentd/