### PR TITLE
Fixes bug where Ceph keys in data bag could beome desynced

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -48,9 +48,9 @@ def init_config
     end
 end
 
-def make_config(key, value)
+def make_config(key, value, force=false)
     init_config if $dbi.nil?
-    if $dbi[key].nil?
+    if $dbi[key].nil? or force
         $dbi[key] = (node['bcpc']['enabled']['encrypt_data_bag']) ? Chef::EncryptedDataBagItem.encrypt_value(value, Chef::EncryptedDataBagItem.load_secret) : value
         $dbi.save
         $edbi = Chef::EncryptedDataBagItem.load('configs', node.chef_environment) if node['bcpc']['enabled']['encrypt_data_bag']

--- a/cookbooks/bcpc/recipes/ceph-head.rb
+++ b/cookbooks/bcpc/recipes/ceph-head.rb
@@ -273,9 +273,9 @@ end
 
 ruby_block "store-cinder-ceph-key" do
   block do
-    make_config("cinder-ceph-key", `ceph auth get-key client.cinder`)
+    make_config("cinder-ceph-key", `ceph auth get-key client.cinder`, force=true)
   end
-  only_if "test -f  /etc/ceph/ceph.client.cinder.keyring"
+  only_if { File.exist?('/etc/ceph/ceph.client.cinder.keyring') and ((config_defined('cinder-ceph-key') and (get_config('cinder-ceph-key') != `ceph auth get-key client.cinder`)) or (not config_defined('cinder-ceph-key'))) }
 end
 
 bash "create-ceph-glance-keyring" do
@@ -286,9 +286,9 @@ end
 
 ruby_block "store-glance-ceph-key" do
   block do
-    make_config("glance-ceph-key", `ceph auth get-key client.glance`)
+    make_config("glance-ceph-key", `ceph auth get-key client.glance`, force=true)
   end
-  only_if "test -f  /etc/ceph/ceph.client.glance.keyring"
+  only_if { File.exist?('/etc/ceph/ceph.client.glance.keyring') and ((config_defined('glance-ceph-key') and (get_config('glance-ceph-key') != `ceph auth get-key client.glance`)) or (not config_defined('glance-ceph-key'))) }
 end
 
 include_recipe "bcpc::ceph-osd"


### PR DESCRIPTION
This fixes a bug where, if you destroyed and re-Cheffed a cluster without clearing the Cinder/Glance keys out of the data bag, those keys wouldn't get updated from Ceph auth when new keys were generated and nova-compute wouldn't be able to talk to Ceph. The data bag key is now updated when the new value is generated, and the solution has been generalized to adding a `force` keyword on `make_config()` to allow overwriting values.

(Technically only the Cinder value from the data bag is used, Glance one is not, but this fixes both for the sake of consistency.)