### PR TITLE
Availability zones

### DIFF
--- a/cookbooks/bcpc/recipes/host-aggregates.rb
+++ b/cookbooks/bcpc/recipes/host-aggregates.rb
@@ -16,11 +16,8 @@
 # limitations under the License.
 #
 
-az_number = if node['hostname'] =~ /bcpc\-vm/
-  node['bcpc']['node_number']
-else
-  node['bcpc']['rack'].nil? ? 1 : node['bcpc']['rack']
-end 
+parsed_rack_number = node['bcpc']['rack_name'].match(/^rack-(\d+)/)
+az_number = parsed_rack_number.nil? ? 1 : parsed_rack_number.captures[0].to_i
 availability_zone = (node['bcpc']['availability_zone'].nil? ) ? node['bcpc']['region_name'] + "-" + az_number.to_s : node['bcpc']['availability_zone'].to_s
 
 node['bcpc']['host_aggregates'].each do |name, properties| 

--- a/cookbooks/bcpc/recipes/host-aggregates.rb
+++ b/cookbooks/bcpc/recipes/host-aggregates.rb
@@ -16,6 +16,13 @@
 # limitations under the License.
 #
 
+az_number = if node['hostname'] =~ /bcpc\-vm/
+  node['bcpc']['node_number']
+else
+  node['bcpc']['rack'].nil? ? 1 : node['bcpc']['rack']
+end 
+availability_zone = (node['bcpc']['availability_zone'].nil? ) ? node['bcpc']['region_name'] + "-" + az_number.to_s : node['bcpc']['availability_zone'].to_s
+
 node['bcpc']['host_aggregates'].each do |name, properties| 
   bcpc_host_aggregate name do
     metadata properties
@@ -25,7 +32,16 @@ end
 node['bcpc']['aggregate_membership'].each do |name| 
     bcpc_host_aggregate name do
         action :member 
-        zone  node['bcpc']['region_name']
     end
 end 
+
+bcpc_host_aggregate availability_zone do
+  action :create
+  zone availability_zone
+end
+
+bcpc_host_aggregate availability_zone do
+  action :member
+end
+
 

--- a/cookbooks/bcpc/templates/default/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder.conf.erb
@@ -8,7 +8,7 @@
 # XXX: The following is a work-around to allow any cinder process
 #      to serve any volume (since they're RBD backed)
 host = bcpc
-storage_availability_zone=<%=node['bcpc']['region_name']%>
+storage_availability_zone=
 rootwrap_config = /etc/cinder/rootwrap.conf
 api_paste_confg = /etc/cinder/api-paste.ini
 verbose = False

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -67,7 +67,7 @@ send_arp_for_ha=True
 my_ip=<%=node['bcpc']['management']['ip']%>
 routing_source_ip=<%=node['bcpc']['floating']['ip']%>
 dhcp_domain=<%=node['bcpc']['cluster_domain']%>
-default_availability_zone=<%=node['bcpc']['region_name']%>
+default_availability_zone=
 
 # Nova Compute settings
 compute_driver=libvirt.LibvirtDriver


### PR DESCRIPTION
I was unable to repo @erhudy's issue in #747 but I suspect its the cinder zone setting that was wrong and must have got mangled in the commit. 

Anyhow, this PR has been rebased against master and allows the specification of AZs. It would prob be a good plan to call 1+ racks an AZ (depending on the size of your cloud).

To test I have to change bcpc-vm3's role back to a non ephemeral worknode. I did also chef this in over a running 5.5 cluster (with running instances) with success.