### PR TITLE
Add fallback firewall rule for out-of-cluster Zabbix-agent communication

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -160,7 +160,6 @@ default['bcpc']['management']['netmask'] = "255.255.255.0"
 default['bcpc']['management']['cidr'] = "10.17.1.0/24"
 default['bcpc']['management']['gateway'] = "10.17.1.1"
 default['bcpc']['management']['interface'] = nil
-default['bcpc']['management']['monitoring']['vip'] = "10.17.1.16"
 # if 'interface' is a VLAN interface, specifying a parent allows MTUs
 # to be set properly
 default['bcpc']['management']['interface-parent'] = nil
@@ -1272,6 +1271,10 @@ default['bcpc']['cpupower']['ondemand_up_threshold'] = nil
 #
 ###########################################
 #
+# Besides being the VIP that monitoring agents/clients will communicate with,
+# monitoring services (carbon/elasticsearch/zabbix-server) will bind to it if
+# BCPC-Monitoring role is assigned in-cluster.
+default['bcpc']['monitoring']['vip'] = "10.17.1.16"
 # List of monitoring clients external to cluster that we are monitoring
 default['bcpc']['monitoring']['external_clients'] = []
 # Monitoring database settings

--- a/cookbooks/bcpc/recipes/default.rb
+++ b/cookbooks/bcpc/recipes/default.rb
@@ -40,4 +40,9 @@ if node['bcpc']['rack_name'].nil? then
     node.set['bcpc']['rack_name'] = (rack_guess.nil?) ? "rack" : "rack-#{rack_guess[1].to_i}"
 end
 
+# Test if deprecated attribute hash still exists
+if node['bcpc']['management']['monitoring'] then
+    raise("node['bcpc']['management']['monitoring'] is deprecated. Please remove and set monitoring VIP in node['bcpc']['monitoring']['vip'].")
+end
+
 node.save rescue nil

--- a/cookbooks/bcpc/recipes/elasticsearch.rb
+++ b/cookbooks/bcpc/recipes/elasticsearch.rb
@@ -102,7 +102,7 @@ if node['bcpc']['enabled']['logging'] then
     bash "set-elasticsearch-replicas" do
         min_quorum = search_nodes("recipe", "elasticsearch").length/2 + 1
         code <<-EOH
-            curl -XPUT '#{node['bcpc']['management']['monitoring']['vip']}:9200/_settings' -d '
+            curl -XPUT '#{node['bcpc']['monitoring']['vip']}:9200/_settings' -d '
             {
                 "index" : {
                     "number_of_replicas" : #{min_quorum-1}

--- a/cookbooks/bcpc/recipes/keepalived-monitoring.rb
+++ b/cookbooks/bcpc/recipes/keepalived-monitoring.rb
@@ -44,7 +44,7 @@ template "/etc/keepalived/keepalived.conf" do
         :router_id_key => "keepalived-monitoring-router-id",
         :password_key => "keepalived-monitoring-password",
         :chk_quorum_script => "/usr/local/bin/chk_mysql_quorum",
-        :vip => "#{node['bcpc']['management']['monitoring']['vip']}"
+        :vip => "#{node['bcpc']['monitoring']['vip']}"
     )
     notifies :restart, "service[keepalived]", :immediately
 end

--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -192,15 +192,15 @@ end
     mode 00644
     # result of get_all_nodes is passed in here because Chef can't get context for running Chef::Search::Query#search inside the template generator
     variables({
-      :all_servers               => get_all_nodes,
-      :float_cidr                => IPAddr.new(node['bcpc']['floating']['available_subnet']),
-      :database_name             => node['bcpc']['dbname']['pdns'],
-      :cluster_domain               => node['bcpc']['cluster_domain'],
-      :floating_vip              => node['bcpc']['floating']['vip'],
-      :management_vip            => node['bcpc']['management']['vip'],
-      :management_monitoring_vip => node['bcpc']['management']['monitoring']['vip'],
-      :reverse_fixed_zone        => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])),
-      :reverse_float_zone        => (node['bcpc']['floating']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])),
+      :all_servers         => get_all_nodes,
+      :float_cidr          => IPAddr.new(node['bcpc']['floating']['available_subnet']),
+      :database_name       => node['bcpc']['dbname']['pdns'],
+      :cluster_domain      => node['bcpc']['cluster_domain'],
+      :floating_vip        => node['bcpc']['floating']['vip'],
+      :management_vip      => node['bcpc']['management']['vip'],
+      :monitoring_vip      => node['bcpc']['monitoring']['vip'],
+      :reverse_fixed_zone  => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])),
+      :reverse_float_zone  => (node['bcpc']['floating']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])),
     })
   end
 

--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -62,6 +62,8 @@ iptables-restore <<EOH
 ## ssh 22
 ## nova-novncproxy 6080
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["ip"]%> -p tcp --match multiport --dports 22,6080 -j ACCEPT
+## Fallback rule in case node is monitored by out-of-cluster Zabbix
+-A INPUT -i <%= @node["bcpc"]["management"]["interface"] %> -s <%= @node["bcpc"]["monitoring"]["vip"] %> -d <%= @node["bcpc"]["management"]["ip"] %> -p tcp --dport 10050 -j ACCEPT
 
 # Allow external access to some VIP services
 ## apache 80, 443
@@ -81,13 +83,13 @@ iptables-restore <<EOH
 <% if node["roles"].include? "BCPC-Monitoring" -%>
 ## kibana 443
 ## graphite 8888
--A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["monitoring"]["vip"]%> -p tcp --match multiport --dports 443,8888 -j ACCEPT
+-A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["monitoring"]["vip"]%> -p tcp --match multiport --dports 443,8888 -j ACCEPT
 
 ## carbon-relay 2013, 2014
 ## elasticsearch 9200
 ## zabbix-server 10051
 :INPUT-monitoring - [0:0]
--A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["monitoring"]["vip"]%> -p tcp --match multiport --dports 2013,2014,9200,10051 -j INPUT-monitoring
+-A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["monitoring"]["vip"]%> -p tcp --match multiport --dports 2013,2014,9200,10051 -j INPUT-monitoring
 
 ###########################
 # INPUT-monitoring chain

--- a/cookbooks/bcpc/templates/default/diamond.conf.erb
+++ b/cookbooks/bcpc/templates/default/diamond.conf.erb
@@ -60,7 +60,7 @@ days = 7
 ### Options for GraphiteHandler
 
 # Graphite server host
-host = <%=node['bcpc']['management']['monitoring']['vip']%>
+host = <%=node['bcpc']['monitoring']['vip']%>
 
 # Port to send metrics to
 port = 2013
@@ -75,7 +75,7 @@ batch = 512
 ### Options for GraphitePickleHandler
 
 # Graphite server host
-host = <%=node['bcpc']['management']['monitoring']['vip']%>
+host = <%=node['bcpc']['monitoring']['vip']%>
 
 # Port to send metrics to
 port = 2014

--- a/cookbooks/bcpc/templates/default/fluentd-td-agent.conf.erb
+++ b/cookbooks/bcpc/templates/default/fluentd-td-agent.conf.erb
@@ -219,7 +219,7 @@
 
 <match bcpc.**>
     type elasticsearch
-    host <%=node['bcpc']['management']['monitoring']['vip']%>
+    host <%=node['bcpc']['monitoring']['vip']%>
     port 9200
     logstash_format true
     include_tag_key true

--- a/cookbooks/bcpc/templates/default/graphite.local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/graphite.local_settings.py.erb
@@ -131,7 +131,7 @@ DATABASES = {
         'NAME': '<%=node['bcpc']['dbname']['graphite']%>',
         'USER': '<%=get_config('mysql-graphite-user')%>',
         'PASSWORD': '<%=get_config('mysql-graphite-password')%>',
-        'HOST': '<%=node['bcpc']['management']['monitoring']['vip']%>',
+        'HOST': '<%=node['bcpc']['monitoring']['vip']%>',
         'default-character-set': 'utf8'
     },
 }

--- a/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
@@ -15,7 +15,7 @@ global
 
 defaults
   log global
-  source <%=node['bcpc']['management']['monitoring']['vip']%>
+  source <%=node['bcpc']['monitoring']['vip']%>
   mode http
   option http-server-close
   option abortonclose
@@ -31,7 +31,7 @@ defaults
   timeout client 30m
   timeout server 30m
 
-listen mysql-galera <%=node['bcpc']['management']['monitoring']['vip']%>:3306
+listen mysql-galera <%=node['bcpc']['monitoring']['vip']%>:3306
   timeout client 24h
   timeout server 24h
   mode tcp
@@ -44,7 +44,7 @@ listen mysql-galera <%=node['bcpc']['management']['monitoring']['vip']%>:3306
 <% end -%>
 
 frontend https
-  bind <%=node['bcpc']['management']['monitoring']['vip']%>:443 ssl crt /etc/haproxy/haproxy.pem
+  bind <%=node['bcpc']['monitoring']['vip']%>:443 ssl crt /etc/haproxy/haproxy.pem
   option tcplog
   stats enable
   stats uri /haproxy
@@ -78,7 +78,7 @@ backend graphite-web-backend
 
 backend kibana-backend
   balance source
-  option httpchk HEAD /elasticsearch/ HTTP/1.1\r\nHost: <%=node['bcpc']['management']['monitoring']['vip']%>
+  option httpchk HEAD /elasticsearch/ HTTP/1.1\r\nHost: <%=node['bcpc']['monitoring']['vip']%>
   http-check expect status 200
   reqrep ^([^\ :]*)\ /kibana/(.*) \1\ /\2
 <% @servers.each do |server| -%>
@@ -105,12 +105,12 @@ backend zabbix-backend
 
 # This is temporary until graphite supports being served under /graphite
 frontend graphite-web
-  bind <%="#{node['bcpc']['management']['monitoring']['vip']}:8888"%> ssl crt /etc/haproxy/haproxy.pem
+  bind <%="#{node['bcpc']['monitoring']['vip']}:8888"%> ssl crt /etc/haproxy/haproxy.pem
   option tcplog
   reqadd X-Forwarded-Proto:\ https
   default_backend graphite-web-backend
 
-listen graphite-carbon-relay-line <%=node['bcpc']['management']['monitoring']['vip']%>:2013
+listen graphite-carbon-relay-line <%=node['bcpc']['monitoring']['vip']%>:2013
   mode tcp
   balance leastconn
   option tcplog
@@ -119,7 +119,7 @@ listen graphite-carbon-relay-line <%=node['bcpc']['management']['monitoring']['v
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:2013 check inter 5s rise 1 fall 1 observe layer4" %>
 <% end -%>
 
-listen graphite-carbon-relay-pickle <%=node['bcpc']['management']['monitoring']['vip']%>:2014
+listen graphite-carbon-relay-pickle <%=node['bcpc']['monitoring']['vip']%>:2014
   mode tcp
   balance leastconn
   option tcplog
@@ -128,7 +128,7 @@ listen graphite-carbon-relay-pickle <%=node['bcpc']['management']['monitoring'][
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:2014 check inter 5s rise 1 fall 1 observe layer4" %>
 <% end -%>
 
-listen elasticsearch <%=node['bcpc']['management']['monitoring']['vip']%>:9200
+listen elasticsearch <%=node['bcpc']['monitoring']['vip']%>:9200
   balance source
   option tcplog
   option httpchk GET /

--- a/cookbooks/bcpc/templates/default/index.html.erb
+++ b/cookbooks/bcpc/templates/default/index.html.erb
@@ -68,22 +68,22 @@
             <tr>
                 <td><em>Elasticsearch</em></td>
                 <td>---</td>
-                <td><a href="http://<%= node['bcpc']['management']['monitoring']['vip'] %>:9200/_plugin/head/">http://<%= node['bcpc']['management']['monitoring']['vip'] %>:9200/_plugin/head/</a></td>
+                <td><a href="http://<%= node['bcpc']['monitoring']['vip'] %>:9200/_plugin/head/">http://<%= node['bcpc']['monitoring']['vip'] %>:9200/_plugin/head/</a></td>
             </tr>
             <tr>
                 <td><em>Kibana</em></td>
                 <td><a href="https://<%= node['bcpc']['kibana']['fqdn'] %>">https://<%= node['bcpc']['kibana']['fqdn'] %></a></td>
-                <td><a href="https://<%= node['bcpc']['management']['monitoring']['vip'] %>/kibana/">https://<%= node['bcpc']['management']['monitoring']['vip'] %>/kibana/</a></td>
+                <td><a href="https://<%= node['bcpc']['monitoring']['vip'] %>/kibana/">https://<%= node['bcpc']['monitoring']['vip'] %>/kibana/</a></td>
             </tr>
             <tr>
                 <td><em>Graphite</em></td>
                 <td><a href="https://<%= node['bcpc']['graphite']['fqdn'] %>">https://<%= node['bcpc']['graphite']['fqdn'] %></a></td>    
-                <td><a href="https://<%= node['bcpc']['management']['monitoring']['vip'] %>:8888">https://<%= node['bcpc']['management']['monitoring']['vip'] %>:8888</a></td>
+                <td><a href="https://<%= node['bcpc']['monitoring']['vip'] %>:8888">https://<%= node['bcpc']['monitoring']['vip'] %>:8888</a></td>
             </tr>
             <tr>
                 <td><em>Zabbix</em></td>
                 <td><a href="https://<%= node['bcpc']['zabbix']['fqdn'] %>">https://<%= node['bcpc']['zabbix']['fqdn'] %></a></td>
-                <td><a href="https://<%= node['bcpc']['management']['monitoring']['vip'] %>/zabbix/">https://<%= node['bcpc']['management']['monitoring']['vip'] %>/zabbix/</a></td>
+                <td><a href="https://<%= node['bcpc']['monitoring']['vip'] %>/zabbix/">https://<%= node['bcpc']['monitoring']['vip'] %>/zabbix/</a></td>
         </table>
 
 		<h3>API Endpoints</h3>

--- a/cookbooks/bcpc/templates/default/keepalived-if_monitoring_vip.erb
+++ b/cookbooks/bcpc/templates/default/keepalived-if_monitoring_vip.erb
@@ -5,6 +5,6 @@
 #
 ################################################
 
-if ip addr show dev <%=node['bcpc']['management']['interface']%> | grep " <%=node['bcpc']['management']['monitoring']['vip']%>/" > /dev/null; then
+if ip addr show dev <%=node['bcpc']['management']['interface']%> | grep " <%=node['bcpc']['monitoring']['vip']%>/" > /dev/null; then
     $*
 fi

--- a/cookbooks/bcpc/templates/default/keepalived-if_not_monitoring_vip.erb
+++ b/cookbooks/bcpc/templates/default/keepalived-if_not_monitoring_vip.erb
@@ -5,6 +5,6 @@
 #
 ################################################
 
-if ! ip addr show dev <%=node['bcpc']['management']['interface']%> | grep " <%=node['bcpc']['management']['monitoring']['vip']%>/" > /dev/null; then
+if ! ip addr show dev <%=node['bcpc']['management']['interface']%> | grep " <%=node['bcpc']['monitoring']['vip']%>/" > /dev/null; then
     $*
 fi

--- a/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
@@ -41,14 +41,14 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
     ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), 'openstack.<%=@cluster_domain%>', 'A', '<%=@management_vip%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='openstack.<%=@cluster_domain%>', type='A', content='<%=@management_vip%>', bcpc_record_type='STATIC';
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), 'zabbix.<%=@cluster_domain%>', 'A', '<%=@management_monitoring_vip%>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='zabbix.<%=@cluster_domain%>', type='A', content='<%=@management_monitoring_vip%>', bcpc_record_type='STATIC';
+    ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), 'zabbix.<%=@cluster_domain%>', 'A', '<%=@monitoring_vip%>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='zabbix.<%=@cluster_domain%>', type='A', content='<%=@monitoring_vip%>', bcpc_record_type='STATIC';
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), 'graphite.<%=@cluster_domain%>', 'A', '<%=@management_monitoring_vip%>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='graphite.<%=@cluster_domain%>', type='A', content='<%=@management_monitoring_vip%>', bcpc_record_type='STATIC';
+    ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), 'graphite.<%=@cluster_domain%>', 'A', '<%=@monitoring_vip%>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='graphite.<%=@cluster_domain%>', type='A', content='<%=@monitoring_vip%>', bcpc_record_type='STATIC';
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), 'kibana.<%=@cluster_domain%>', 'A', '<%=@management_monitoring_vip%>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='kibana.<%=@cluster_domain%>', type='A', content='<%=@management_monitoring_vip%>', bcpc_record_type='STATIC';
+    ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), 'kibana.<%=@cluster_domain%>', 'A', '<%=@monitoring_vip%>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='kibana.<%=@cluster_domain%>', type='A', content='<%=@monitoring_vip%>', bcpc_record_type='STATIC';
 -- insert A record and CNAME for object storage
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
     ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), 's3.<%=@cluster_domain%>', 'A', '<%=@floating_vip%>', 'STATIC')

--- a/cookbooks/bcpc/templates/default/zabbix.conf.php.erb
+++ b/cookbooks/bcpc/templates/default/zabbix.conf.php.erb
@@ -9,7 +9,7 @@
 global $DB;
 
 $DB['TYPE']     = 'MYSQL';
-$DB['SERVER']   = '<%=node['bcpc']['management']['monitoring']['vip']%>';
+$DB['SERVER']   = '<%=node['bcpc']['monitoring']['vip']%>';
 $DB['PORT']     = '0';
 $DB['DATABASE'] = '<%=node['bcpc']['dbname']['zabbix']%>';
 $DB['USER']     = '<%=get_config('mysql-zabbix-user')%>';
@@ -18,7 +18,7 @@ $DB['PASSWORD'] = '<%=get_config('mysql-zabbix-password')%>';
 // SCHEMA is relevant only for IBM_DB2 database
 $DB['SCHEMA'] = '';
 
-$ZBX_SERVER      = '<%=node['bcpc']['management']['monitoring']['vip']%>';
+$ZBX_SERVER      = '<%=node['bcpc']['monitoring']['vip']%>';
 $ZBX_SERVER_PORT = '10051';
 $ZBX_SERVER_NAME = '<%=node['bcpc']['region_name']%>';
 

--- a/cookbooks/bcpc/templates/default/zabbix_agent.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_agent.conf.erb
@@ -16,7 +16,7 @@
 # Default:
 # Server=
 
-Server=<%=node['bcpc']['management']['monitoring']['vip']%>
+Server=<%=node['bcpc']['monitoring']['vip']%>
 
 ############ ADVANCED PARAMETERS #################
 

--- a/cookbooks/bcpc/templates/default/zabbix_agentd.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_agentd.conf.erb
@@ -83,7 +83,7 @@ LogRemoteCommands=1
 #
 # Mandatory: no
 # Default:
-Server=<%=node['bcpc']['management']['monitoring']['vip']%>
+Server=<%=node['bcpc']['monitoring']['vip']%>
 
 ### Option: ListenPort
 #   Agent will listen on this port for connections from the server.
@@ -122,7 +122,7 @@ StartAgents=3
 #
 # Mandatory: no
 # Default:
-ServerActive=<%=node['bcpc']['management']['monitoring']['vip']%>
+ServerActive=<%=node['bcpc']['monitoring']['vip']%>
 
 ### Option: Hostname
 #   Unique, case sensitive hostname.

--- a/cookbooks/bcpc/templates/default/zabbix_server.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_server.conf.erb
@@ -32,7 +32,7 @@
 #
 # Mandatory: no
 # Default:
-SourceIP=<%=node['bcpc']['management']['monitoring']['vip']%>
+SourceIP=<%=node['bcpc']['monitoring']['vip']%>
 
 ### Option: LogFile
 #   Name of log file.
@@ -80,7 +80,7 @@ PidFile=/var/run/zabbix/zabbix_server.pid
 #
 # Mandatory: no
 # Default:
-DBHost=<%=node['bcpc']['management']['monitoring']['vip']%>
+DBHost=<%=node['bcpc']['monitoring']['vip']%>
 
 ### Option: DBName
 #   Database name.
@@ -233,7 +233,7 @@ DBPassword=<%=get_config('mysql-zabbix-password')%>
 #
 # Mandatory: no
 # Default:
-ListenIP=<%=node['bcpc']['management']['monitoring']['vip']%>
+ListenIP=<%=node['bcpc']['monitoring']['vip']%>
 
 ### Option: HousekeepingFrequency
 #   How often Zabbix will perform housekeeping procedure (in hours).

--- a/environments/Test-Laptop-VMware.json
+++ b/environments/Test-Laptop-VMware.json
@@ -24,10 +24,10 @@
         "interface" : "eth1",
         "netmask" : "255.255.255.0",
         "cidr" : "10.0.100.0/24",
-        "gateway" : "10.0.100.3",
-        "monitoring": {
-          "vip" : "10.0.100.6"
-        }
+        "gateway" : "10.0.100.3"
+      },
+      "monitoring": {
+        "vip" : "10.0.100.6"
       },
       "storage": {
         "interface" : "eth2",

--- a/environments/Test-Laptop-Vagrant.json
+++ b/environments/Test-Laptop-Vagrant.json
@@ -30,10 +30,10 @@
         "interface" : "eth1",
         "netmask" : "255.255.255.0",
         "cidr" : "10.0.100.0/24",
-        "gateway" : "10.0.100.3",
-        "monitoring": {
-          "vip" : "10.0.100.6"
-        }
+        "gateway" : "10.0.100.3"
+      },
+      "monitoring": {
+        "vip" : "10.0.100.6"
       },
       "storage": {
         "interface" : "eth2",

--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -26,10 +26,10 @@
         "interface" : "eth0",
         "netmask" : "255.255.255.0",
         "cidr" : "10.0.100.0/24",
-        "gateway" : "10.0.100.3",
-        "monitoring": {
-          "vip" : "10.0.100.6"
-        }
+        "gateway" : "10.0.100.3"
+      },
+      "monitoring": {
+        "vip" : "10.0.100.6"
       },
       "storage": {
         "interface" : "eth1",


### PR DESCRIPTION
This creates a rule to permit inbound Zabbix-agent connectivity. This is necessary for nodes monitored by a VIP that lives outside of its management subnet.