### PR TITLE
Changes Vagrant behavior so that all nodes but bootstrap get extra disks

### DIFF
--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -269,9 +269,7 @@ Vagrant.configure("2") do |config|
         vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
         vb.customize ["modifyvm", :id, "--ioapic", "on"]
 
-        # this attaches extra disks to the first 3 non-bootstrap nodes (additional cluster
-        # nodes are assumed to be monitoring, which do not need extra disks)
-        if (1..3).include? idx
+        unless idx == 0
           # this is an unpleasing hack to locate the VM on disk, so that additional disks can be stored with it
           # this assumes that all VMs will be going into the default VirtualBox folder
           begin


### PR DESCRIPTION
This is a small behavioral change that has Vagrant create the 4 extra disks for all non-bootstrap nodes rather than just the first 3. Since they're thin provisioned, the extra space take is like 3MB, and it allows for easily re-using the monitoring nodes as Ceph/ephemeral compute nodes.