### PR TITLE
Make mon_pg_warn_max_per_osd configurable (300 is upstream default)

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -106,6 +106,7 @@ default['bcpc']['ceph']['chooseleaf'] = "rack"
 default['bcpc']['ceph']['pgp_auto_adjust'] = false
 # Need to review...
 default['bcpc']['ceph']['pgs_per_node'] = 1024
+default['bcpc']['ceph']['max_pgs_per_osd'] = 300
 # Journal size could be 10GB or higher in some cases
 default['bcpc']['ceph']['journal_size'] = 2048
 # The 'portion' parameters should add up to ~100 across all pools

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -13,6 +13,7 @@
     cluster network = <%= @node["bcpc"]["storage"]["cidr"] %>
     keyring = /etc/ceph/$cluster.$name.keyring
     mon host = <%= @servers.map{|s| s["bcpc"]["storage"]["ip"] + ":6789"}.join(', ') %>
+    mon_pg_warn_max_per_osd = <%= @node['bcpc']['ceph']['max_pgs_per_osd'] %>
 <% if @node["bcpc"]["ceph"]["rebalance"] %>
     paxos_propose_interval = 60 
 <% end %>


### PR DESCRIPTION
Adding this in to make it possible to suppress the Ceph "too many PGs per OSD" warning, which sets the Ceph cluster status at HEALTH_WARN.