### PR TITLE
Parameterize Openstack logging verbosity option

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -535,6 +535,8 @@ default['bcpc']['nova']['scheduler_host_subset_size'] = 3
 default['bcpc']['nova']['workers'] = 5
 # Patch toggle for https://github.com/bloomberg/chef-bcpc/pull/493
 default['bcpc']['nova']['live_migration_patch'] = false
+# Verbose logging (level INFO)
+default['bcpc']['nova']['verbose'] = false
 # Nova debug toggle
 default['bcpc']['nova']['debug'] = false
 # Nova scheduler default filters
@@ -980,6 +982,8 @@ default['bcpc']['nova']['policy'] = {
 #  Cinder Settings
 #
 ###########################################
+# Verbose logging (level INFO)
+default['bcpc']['cinder']['verbose'] = false
 default['bcpc']['cinder']['workers'] = 5
 default['bcpc']['cinder']['quota'] = {
   "volumes" => 10,
@@ -1085,6 +1089,8 @@ default['bcpc']['cinder']['policy'] = {
 #  Glance policy Settings
 #
 ###########################################
+# Verbose logging (level INFO)
+default['bcpc']['glance']['verbose'] = false
 default['bcpc']['glance']['workers'] = 5
 default['bcpc']['glance']['policy'] = {
   "context_is_admin" => "role:admin",

--- a/cookbooks/bcpc/templates/default/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder.conf.erb
@@ -11,7 +11,7 @@ host = bcpc
 storage_availability_zone=
 rootwrap_config = /etc/cinder/rootwrap.conf
 api_paste_confg = /etc/cinder/api-paste.ini
-verbose = False
+verbose = <%= node['bcpc']['cinder']['verbose'] %>
 debug = False
 auth_strategy = keystone
 state_path = /var/lib/cinder

--- a/cookbooks/bcpc/templates/default/glance-api.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-api.conf.erb
@@ -5,7 +5,7 @@
 ################################################
 
 [DEFAULT]
-#verbose = False
+verbose = <%= node['bcpc']['glance']['verbose'] %>
 #debug = False
 default_store = rbd
 known_stores = glance.store.rbd.Store

--- a/cookbooks/bcpc/templates/default/glance-cache.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-cache.conf.erb
@@ -6,7 +6,7 @@
 
 [DEFAULT]
 # Show more verbose log output (sets INFO log level output)
-#verbose = False
+verbose = <%= node['bcpc']['glance']['verbose'] %>
 
 # Show debugging output in logs (sets DEBUG log level output)
 #debug = False

--- a/cookbooks/bcpc/templates/default/glance-registry.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-registry.conf.erb
@@ -6,7 +6,7 @@
 
 [DEFAULT]
 # Show more verbose log output (sets INFO log level output)
-#verbose = False
+verbose = <%= node['bcpc']['glance']['verbose'] %>
 
 # Show debugging output in logs (sets DEBUG log level output)
 #debug = False

--- a/cookbooks/bcpc/templates/default/glance-scrubber.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-scrubber.conf.erb
@@ -6,7 +6,7 @@
 
 [DEFAULT]
 # Show more verbose log output (sets INFO log level output)
-#verbose = False
+verbose = <%= node['bcpc']['glance']['verbose'] %>
 
 # Show debugging output in logs (sets DEBUG log level output)
 #debug = False

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -108,8 +108,8 @@ cnt_vpn_clients=5
 logdir=/var/log/nova
 state_path=/var/lib/nova
 rootwrap_config=/etc/nova/rootwrap.conf
-verbose=False
-debug=<%=node['bcpc']['nova']['debug']%>
+verbose=<%= node['bcpc']['nova']['verbose'] %>
+debug=<%= node['bcpc']['nova']['debug'] %>
 ec2_private_dns_show_ip=True
 #default_log_levels="amqplib=DEBUG,sqlalchemy=DEBUG,boto=WARN,suds=INFO,eventlet.wsgi.server=WARN"
 #rpc_response_timeout=120


### PR DESCRIPTION
Log level remains unchanged (WARN by [default](http://docs.openstack.org/kilo/config-reference/content/list-of-compute-config-options.html)). Log level post-change can be verified by inspecting `/var/log/{nova,glance,cinder}/*.log`.