### PR TITLE
Guards for conflicting patch files to only patch 2015.1.0 versions of files

### DIFF
--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -60,7 +60,7 @@ bash "patch-backport-for-glance-v2-null-description" do
       exit $rv
     fi
   EOH
-  not_if "grep -q 'THIS FILE PATCHED BY BCPC' /usr/lib/python2.7/dist-packages/glance/schema.py"
+  only_if "shasum /usr/lib/python2.7/dist-packages/glance/schema.py | grep -q e397f917f21e2067721336c5913e0151ed99bb0c"
   notifies :restart, "service[glance-api]", :immediately
   notifies :restart, "service[glance-registry]", :immediately
 end 

--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -60,7 +60,7 @@ bash "patch-backport-for-glance-v2-null-description" do
       exit $rv
     fi
   EOH
-  only_if "shasum /usr/lib/python2.7/dist-packages/glance/schema.py | grep -q e397f917f21e2067721336c5913e0151ed99bb0c"
+  only_if "shasum /usr/lib/python2.7/dist-packages/glance/schema.py | grep -q '^e397f917f21e2067721336c5913e0151ed99bb0c'"
   notifies :restart, "service[glance-api]", :immediately
   notifies :restart, "service[glance-registry]", :immediately
 end 

--- a/cookbooks/bcpc/recipes/horizon.rb
+++ b/cookbooks/bcpc/recipes/horizon.rb
@@ -88,7 +88,7 @@ bash "patch-for-horizon-glance-image-upload" do
          exit $rv
        fi
     EOH
-    not_if "grep -q 'THIS FILE PATCHED BY BCPC' /usr/share/openstack-dashboard/openstack_dashboard/api/glance.py"
+    only_if "shasum /usr/share/openstack-dashboard/openstack_dashboard/api/glance.py | grep -q 81fea34940da24d9c8e8c62da8f71e9a211729b3"
     notifies :restart, "service[apache2]", :delayed
 end
 

--- a/cookbooks/bcpc/recipes/horizon.rb
+++ b/cookbooks/bcpc/recipes/horizon.rb
@@ -88,7 +88,7 @@ bash "patch-for-horizon-glance-image-upload" do
          exit $rv
        fi
     EOH
-    only_if "shasum /usr/share/openstack-dashboard/openstack_dashboard/api/glance.py | grep -q 81fea34940da24d9c8e8c62da8f71e9a211729b3"
+    only_if "shasum /usr/share/openstack-dashboard/openstack_dashboard/api/glance.py | grep -q '^81fea34940da24d9c8e8c62da8f71e9a211729b3'"
     notifies :restart, "service[apache2]", :delayed
 end
 

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -66,7 +66,7 @@ bash "patch-for-nova-network-dhcp-server" do
        fi
        cp /tmp/nova-network-dhcp-server.patch .
     EOH
-    only_if "shasum /usr/lib/python2.7/dist-packages/nova/network/manager.py | grep -q 1da5cc12bc28f97e15e5f0e152d37b548766ee04"
+    only_if "shasum /usr/lib/python2.7/dist-packages/nova/network/manager.py | grep -q '^1da5cc12bc28f97e15e5f0e152d37b548766ee04'"
     notifies :restart, "service[nova-api]", :immediately
 end
 

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -66,7 +66,7 @@ bash "patch-for-nova-network-dhcp-server" do
        fi
        cp /tmp/nova-network-dhcp-server.patch .
     EOH
-    not_if "test -f /usr/lib/python2.7/dist-packages/nova-network-dhcp-server.patch"
+    only_if "shasum /usr/lib/python2.7/dist-packages/nova/network/manager.py | grep -q 1da5cc12bc28f97e15e5f0e152d37b548766ee04"
     notifies :restart, "service[nova-api]", :immediately
 end
 


### PR DESCRIPTION
Rewrite of #779 so that these 3 patches will continue to apply to 2015.1.0 installations, but will not apply for 2015.1.1.