### PR TITLE
Workaround for #786 - Only reload PowerDNS data into MySQL if it changes

### DIFF
--- a/cookbooks/bcpc/recipes/powerdns-nova.rb
+++ b/cookbooks/bcpc/recipes/powerdns-nova.rb
@@ -32,12 +32,14 @@ if node['bcpc']['enabled']['dns']
       :cluster_domain        => node['bcpc']['cluster_domain'],
       :reverse_fixed_zone => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])),
     })
+    notifies :run, 'ruby_block[powerdns-load-fixed-records]', :immediately
   end
 
   ruby_block "powerdns-load-fixed-records" do
     block do
       system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot #{node['bcpc']['dbname']['pdns']} < #{fixed_records_file}"
     end
+    action :nothing
   end
 
   # dns_fill.py handles creating CNAMEs based on instance and tenancy

--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -203,12 +203,14 @@ end
       :reverse_fixed_zone  => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])),
       :reverse_float_zone  => (node['bcpc']['floating']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])),
     })
+    notifies :run, 'ruby_block[powerdns-load-float-records]', :immediately
   end
 
   ruby_block "powerdns-load-float-records" do
     block do
       system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot #{node['bcpc']['dbname']['pdns']} < #{float_records_file}"
     end
+    action :nothing
   end
 
   # these files are added by the pdns-server package and will conflict with


### PR DESCRIPTION
This doesn't fix the underlying issue, but should at least decrease the frequency of its occurrence by only reloading the data into MySQL when necessary (i.e., when the template contents change).