### PR TITLE
Configure cluster for scheduled MySQL/data bag backups on bootstrap node

### DIFF
--- a/cookbooks/bcpc/files/default/mysql-backup.knife.rb
+++ b/cookbooks/bcpc/files/default/mysql-backup.knife.rb
@@ -1,0 +1,5 @@
+chef_server_url 'https://localhost/organizations/bcpc'
+node_name 'admin'
+client_key '/etc/opscode/admin.pem'
+# :verify_none should be okay for talking to localhost chef server
+ssl_verify_mode :verify_none

--- a/cookbooks/bcpc/recipes/backup-cluster.rb
+++ b/cookbooks/bcpc/recipes/backup-cluster.rb
@@ -1,0 +1,133 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: backup-cluster
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This recipe configures the backup script to run on the bootstrap node.
+# It must be paired with the bcpc::mysql-backup recipe, which configures
+# MySQL on the head node with the database user set up here (otherwise
+# the portion of the backup that tries to back up the database will fail).
+
+# this will install from Ubuntu upstream rather than Percona, so
+# it's 5.5 client instead of 5.6, but it works fine for the backup
+package 'percona-xtradb-cluster-client'
+
+# this user will be used for backing up both the main and monitoring MySQL
+# clusters (if a monitoring cluster is present)
+ruby_block 'create-mysql-backup-user' do
+  block do
+    make_config('mysql-backup-user', 'mysql_backup')
+    make_config('mysql-backup-password', secure_password)
+  end
+end
+
+directory '/root/.chef' do
+  mode  00700
+  owner 'root'
+  group 'root'
+end
+
+cookbook_file '/root/.chef/knife.rb' do
+  source 'mysql-backup.knife.rb'
+  mode   00600
+  owner  'root'
+  group  'root'
+end
+
+backup_script = '/usr/local/bin/bcpc_backup.sh'
+backup_dest = '/var/backups/bcpc'
+
+template backup_script do
+  source 'bcpc_backup.sh.erb'
+  mode   00755
+  owner  'root'
+  group  'root'
+  variables(
+    lazy {
+      {
+        :monitoring_servers => search_nodes("role", "BCPC-Monitoring")
+      }
+    }
+  )
+end
+
+directory backup_dest do
+  mode  00700
+  owner 'root'
+  group 'root'
+end
+
+template '/root/.my.main.cnf' do
+  source 'mysql-backup.my.cnf.erb'
+  mode   00600
+  owner  'root'
+  group  'root'
+  variables(
+    lazy {
+      {
+        :host         => node['bcpc']['management']['vip'],
+        :user_key     => 'mysql-backup-user',
+        :password_key => 'mysql-backup-password'
+      }
+    }
+  )
+end
+
+template '/root/.my.monitoring.cnf' do
+  source 'mysql-backup.my.cnf.erb'
+  mode   00600
+  owner  'root'
+  group  'root'
+  variables(
+    lazy {
+      {
+        :host         => node['bcpc']['monitoring']['vip'],
+        :user_key     => 'mysql-backup-user',
+        :password_key => 'mysql-backup-password'
+      }
+    }
+  )
+  not_if {
+    node['bcpc']['monitoring']['vip'].nil?
+  }
+end
+
+cron 'backup-bcpc-daily' do
+  home    '/root'
+  user    'root'
+  minute  '0'
+  hour    '0'
+  command "#{backup_script} #{backup_dest} daily"
+end
+
+cron 'backup-bcpc-weekly' do
+  home    '/root'
+  user    'root'
+  minute  '5'
+  hour    '0'
+  weekday '1'
+  command "#{backup_script} #{backup_dest} weekly"
+end
+
+cron 'backup-bcpc-monthly' do
+  home    '/root'
+  user    'root'
+  minute  '10'
+  hour    '0'
+  day     '1'
+  command "#{backup_script} #{backup_dest} monthly"
+end

--- a/cookbooks/bcpc/recipes/mysql-backup.rb
+++ b/cookbooks/bcpc/recipes/mysql-backup.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: mysql-backup
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ruby_block "initial-mysql-backup-config" do
+    block do
+        %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+            mysql -u root -e "GRANT SELECT,EVENT ON *.* TO '#{get_config('mysql-backup-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-backup-password')}';"
+            mysql -u root -e "FLUSH PRIVILEGES;"
+        ]
+    end
+    only_if {
+      %x[MYSQL_PWD=#{get_config('mysql-root-password')} mysql -N --batch -uroot -e 'SELECT count(user) from mysql.user where user=\"#{get_config('mysql-backup-user')}\";'].to_i < 1
+    }
+end

--- a/cookbooks/bcpc/recipes/mysql-monitoring-backup.rb
+++ b/cookbooks/bcpc/recipes/mysql-monitoring-backup.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: mysql-monitoring-backup
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ruby_block "initial-mysql-monitoring-backup-config" do
+    block do
+        %x[ export MYSQL_PWD=#{get_config('mysql-monitoring-root-password')};
+            mysql -u root -e "GRANT SELECT,EVENT ON *.* TO '#{get_config('mysql-backup-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-backup-password')}';"
+            mysql -u root -e "FLUSH PRIVILEGES;"
+        ]
+    end
+    only_if {
+      %x[MYSQL_PWD=#{get_config('mysql-monitoring-root-password')} mysql -N --batch -uroot -e 'SELECT count(user) from mysql.user where user=\"#{get_config('mysql-backup-user')}\";'].to_i < 1
+    }
+end

--- a/cookbooks/bcpc/templates/default/bcpc_backup.sh.erb
+++ b/cookbooks/bcpc/templates/default/bcpc_backup.sh.erb
@@ -1,0 +1,185 @@
+#!/bin/bash
+function error {
+  echo "ERROR: $1" >&2
+  log "$1"
+  echo "Terminating abnormally." >&2
+  log "Terminating abnormally."
+  exit 1
+}
+
+function warn {
+  echo "WARNING: $1" >&2
+  log "$1"
+}
+
+function check_for_bin {
+  if ! which $1 >/dev/null; then
+    error "$1 not found on path."
+  fi
+}
+
+function log {
+  if ! [ -z $BACKUP_VERBOSE ]; then
+    echo "LOG: $1"
+  fi
+  logger -t BCPCBackup "$1"
+}
+
+# path to base directory to store backups is expected as an argument to the script
+if [[ $1 == "" ]]; then
+  error "You must supply the base directory to store backups as the first argument to this script."
+fi
+# also supply word daily, weekly or monthly to drop backup in particular frequency directory
+TIME_PERIODS=( daily weekly monthly )
+VALID_TIME_PERIOD_FOUND=0
+for TIME_PERIOD in ${TIME_PERIODS[@]}; do
+  if [[ $2 =~ $TIME_PERIOD ]]; then
+    VALID_TIME_PERIOD_FOUND=1
+  fi
+done
+if [ $VALID_TIME_PERIOD_FOUND -eq 0 ]; then
+  error "You must supply daily/weekly/monthly as the second argument to this script."
+fi
+
+log "Backup mode $2 requested."
+
+# verify that base directory is RWX for this user
+if ! [[ -r $1 && -w $1 && -x $1 ]]; then
+  error "User $USER does not have full access to $1."
+fi
+
+DATE=$(date +%Y%m%d)
+
+log "Backing up for date $DATE."
+
+BACKUP_PATH=$1/$2/$DATE
+if [ ! -d $BACKUP_PATH ]; then
+  mkdir -p $BACKUP_PATH
+  mkdir -p $BACKUP_PATH/main_db
+  <% if @monitoring_servers.length > 0 %>
+  mkdir -p $BACKUP_PATH/monitoring_db
+  <% end %>
+else
+  warn "Directory $BACKUP_PATH already exists, attempting to continue."
+fi
+
+# perform backup of MySQL databases from the host in ~/.my.cnf
+MYSQLDUMP=mysqldump
+check_for_bin $MYSQLDUMP
+
+MYSQL=mysql
+check_for_bin $MYSQL
+
+# .my.main.cnf (and .my.monitoring.conf if monitoring is set up)
+# is expected to exist in the following format:
+# [client]
+# host=xxx
+# user=xxx
+# password=xxx
+if [ ! -f $HOME/.my.main.cnf ]; then
+  error "$HOME/.my.main.cnf not found."
+fi
+<% if @monitoring_servers.length > 0 %>
+if [ ! -f $HOME/.my.monitoring.cnf ]; then
+  error "$HOME/.my.monitoring.cnf not found."
+fi
+<% end %>
+
+# get list of databases from MySQL
+MAIN_DATABASES_RAW=$(mysql --defaults-file=$HOME/.my.main.cnf --batch --skip-column-names -e "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.schemata WHERE SCHEMA_NAME != 'information_schema' AND SCHEMA_NAME != 'performance_schema' AND SCHEMA_NAME != 'test'")
+if [ $? -ne 0 ]; then
+  log "WARNING: unable to obtain information for main cluster databases."
+fi
+
+MAIN_DATABASES=( $MAIN_DATABASES_RAW )
+for DATABASE in ${MAIN_DATABASES[@]}; do
+  DB_BACKUP_PATH=$BACKUP_PATH/main_db/$DATABASE.sql.gz
+  if [ ! -f $DB_BACKUP_PATH ]; then
+    $MYSQLDUMP --defaults-file=$HOME/.my.main.cnf --single-transaction --events $DATABASE | gzip > $DB_BACKUP_PATH
+    log "Backed up database $DATABASE to $DB_BACKUP_PATH."
+  else
+    error "File $DB_BACKUP_PATH already exists, refusing to overwrite."
+  fi
+done
+
+<% if @monitoring_servers.length > 0 %>
+# if we have monitoring servers to back up, do the same thing for them as well
+MONITORING_DATABASES_RAW=$(mysql --defaults-file=$HOME/.my.monitoring.cnf --batch --skip-column-names -e "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.schemata WHERE SCHEMA_NAME != 'information_schema' AND SCHEMA_NAME != 'performance_schema' AND SCHEMA_NAME != 'test'")
+if [ $? -ne 0 ]; then
+  log "WARNING: unable to obtain information for monitoring cluster databases."
+fi
+
+MONITORING_DATABASES=( $MONITORING_DATABASES_RAW )
+for DATABASE in ${MONITORING_DATABASES[@]}; do
+  DB_BACKUP_PATH=$BACKUP_PATH/monitoring_db/$DATABASE.sql.gz
+  if [ ! -f $DB_BACKUP_PATH ]; then
+    $MYSQLDUMP --defaults-file=$HOME/.my.monitoring.cnf --single-transaction --events $DATABASE | gzip > $DB_BACKUP_PATH
+    log "Backed up database $DATABASE to $DB_BACKUP_PATH."
+  else
+    error "File $DB_BACKUP_PATH already exists, refusing to overwrite."
+  fi
+done
+<% end %>
+
+# back up Chef data bag
+KNIFE=knife
+check_for_bin $KNIFE
+
+# ~/.chef/knife.rb must exist
+if [ ! -f $HOME/.chef/knife.rb ]; then
+  error "$HOME/.chef/knife.rb not found."
+fi
+
+CHEF_ENVS_RAW=$(knife data bag show configs)
+CHEF_ENVS=( $CHEF_ENVS_RAW )
+for CHEF_ENV in ${CHEF_ENVS[@]}; do
+  DATABAG_BACKUP_PATH=$BACKUP_PATH/$CHEF_ENV-databag.json
+  if [ ! -f $DATABAG_BACKUP_PATH ]; then
+    $KNIFE data bag show configs -f json $CHEF_ENV > $DATABAG_BACKUP_PATH 2>/dev/null
+    log "Backed up data bag for $CHEF_ENV to $DATABAG_BACKUP_PATH."
+  else
+    error "File $DATABAG_BACKUP_PATH already exists, refusing to overwrite."
+  fi
+
+  ENVIRONMENT_BACKUP_PATH=$BACKUP_PATH/$CHEF_ENV-environment.json
+  if [ ! -f $ENVIRONMENT_BACKUP_PATH ]; then
+    $KNIFE environment show -f json $CHEF_ENV > $ENVIRONMENT_BACKUP_PATH 2>/dev/null
+    log "Backed up environment for $CHEF_ENV to $ENVIRONMENT_BACKUP_PATH."
+  else
+    error "File $ENVIRONMENT_BACKUP_PATH already exists, refusing to overwrite."
+  fi
+done
+
+# prune old backups for currently given retention ($2)
+
+# per original JIRA ticket EN-203, retention period is at least last 7 dailies
+# and last 12 monthlies; extending to also have a weekly schedule that retains last 5
+# instead of wackity find -atime/-ctime stuff, we can rely on lexical sort here
+# to prune the oldest backups
+case $2 in
+  daily)
+    BACKUPS_TO_KEEP=7
+    ;;
+  weekly)
+    BACKUPS_TO_KEEP=5
+    ;;
+  monthly)
+    BACKUPS_TO_KEEP=12
+    ;;
+esac
+
+BACKUPS_TO_PRUNE_RAW=$(ls -1 $1/$2 | head -n -$BACKUPS_TO_KEEP)
+BACKUPS_TO_PRUNE=( $BACKUPS_TO_PRUNE_RAW )
+
+for BACKUP_TO_PRUNE in ${BACKUPS_TO_PRUNE[@]}; do
+  BACKUP_DIR=$1/$2/$BACKUP_TO_PRUNE
+  if [ -d $BACKUP_DIR ]; then
+    rm -rf $BACKUP_DIR
+    log "Purged backup directory $BACKUP_DIR."
+  else
+    warn "Got request to delete nonexistent directory $BACKUP_DIR."
+  fi
+done
+
+# ding!
+log "Backup for $DATE complete."

--- a/cookbooks/bcpc/templates/default/mysql-backup.my.cnf.erb
+++ b/cookbooks/bcpc/templates/default/mysql-backup.my.cnf.erb
@@ -1,0 +1,5 @@
+[client]
+host=<%= @host %>
+user=<%= get_config(@user_key) %>
+password=<%= get_config(@password_key) %>
+

--- a/roles/BCPC-Bootstrap.json
+++ b/roles/BCPC-Bootstrap.json
@@ -8,6 +8,7 @@
       "recipe[bcpc::cobbler]",
       "recipe[bcpc::bootstrap]",
       "recipe[bcpc::ufw]",
+      "recipe[bcpc::backup-cluster]",
       "recipe[bcpc::rally]"
     ],
     "description": "A bootstrap node in a BCPC cluster",

--- a/roles/BCPC-Headnode.json
+++ b/roles/BCPC-Headnode.json
@@ -14,6 +14,7 @@
       "recipe[bcpc::networking-route-test]",
       "recipe[bcpc::ceph-head]",
       "recipe[bcpc::mysql-head]",
+      "recipe[bcpc::mysql-backup]",
       "recipe[bcpc::powerdns]",
       "recipe[bcpc::rabbitmq]",
       "recipe[bcpc::memcached]",

--- a/roles/BCPC-Monitoring.json
+++ b/roles/BCPC-Monitoring.json
@@ -12,6 +12,7 @@
       "recipe[bcpc::networking-gw-test]",
       "recipe[bcpc::networking-route-test]",
       "recipe[bcpc::mysql-monitoring]",
+      "recipe[bcpc::mysql-monitoring-backup]",
       "recipe[bcpc::haproxy-monitoring]",
       "recipe[bcpc::keepalived-monitoring]",
       "recipe[bcpc::graphite]",


### PR DESCRIPTION
This is a first hack at configuring scheduled backups of the MySQL cluster and Chef data bag to `/var/backups/bcpc` on the bootstrap node. The amount of space take is quite minimal; about 10-15 MB per backup per day, so given the configured retention periods, you shouldn't lose any more than about 400 MB of space on the bootstrap node.

This PR does not deal with shipping backups off-cluster.