### PR TITLE
Fixes #772 - Relocates RADOSgw log for logrotate

### DIFF
--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -65,7 +65,7 @@
 [client.radosgw.gateway]
     host = <%=node['hostname']%>
     keyring = /var/lib/ceph/radosgw/$cluster-$id/keyring
-    log file = /var/log/ceph/radosgw.log
+    log file = /var/log/radosgw/radosgw.log
     rgw data = /var/lib/ceph/radosgw/$cluser-$id
     rgw enable ops log = false
     rgw enable usage log = false

--- a/cookbooks/bcpc/templates/default/zabbix_rgw.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_rgw.conf.erb
@@ -4,8 +4,8 @@ UserParameter=ceph.rgw.bucket.objects[*],HOME=/var/lib/zabbix radosgw-admin buck
 UserParameter=ceph.rgw.bucket.usage[*],HOME=/var/lib/zabbix  /usr/local/bin/zabbix_bucket_stats $1 $2 | egrep '^$3 ' | awk '{}{print $$2}'
 UserParameter=ceph.rgw.bucket.discovery,HOME=/var/lib/zabbix /usr/local/bin/zabbix_discover_buckets
 <% if @rgw_frontend.include? 'civetweb' %>
-UserParameter=ceph.rgw.haproxy[*],HOME=/var/lib/zabbix logtail -o /tmp/civetweb_rgw_haproxy -f /var/log/ceph/radosgw.log | grep -B 1 '"GET / HTTP/1.0"' | grep http_status=200 | wc -l
-UserParameter=ceph.rgw.http500[*],HOME=/var/lib/zabbix logtail -o /tmp/civetweb_rgw_500 -f /var/log/ceph/radosgw.log | egrep 'http_status=50[0-9]' | wc -l
+UserParameter=ceph.rgw.haproxy[*],HOME=/var/lib/zabbix logtail -o /tmp/civetweb_rgw_haproxy -f /var/log/radosgw/radosgw.log | grep -B 1 '"GET / HTTP/1.0"' | grep http_status=200 | wc -l
+UserParameter=ceph.rgw.http500[*],HOME=/var/lib/zabbix logtail -o /tmp/civetweb_rgw_500 -f /var/log/radosgw/radosgw.log | egrep 'http_status=50[0-9]' | wc -l
 <% else %>
 UserParameter=ceph.rgw.haproxy[*],HOME=/var/lib/zabbix logtail -o /tmp/apache_rgw_haproxy -f   /var/log/apache2/rgw_access.log | grep '"GET / HTTP/1.0" 200 ' | wc -l
 UserParameter=ceph.rgw.http500[*],HOME=/var/lib/zabbix logtail -o /tmp/aache_rgw_500 -f /var/log/apache2/rgw_access.log | egrep 'HTTP\/1\.[0-9]" 500 ' | wc -l


### PR DESCRIPTION
This fixes #772 by relocating the RADOSgw log to `/var/log/radosgw`, where `/etc/logrotate.d/radosgw` expects it to be, and updates the Zabbix agent template appropriately.

NOTE: if cheffing onto an existing cluster, you will need to roll RADOSgw manually with `sudo service radosgw-all restart`, as changes to `ceph.conf` intentionally do not trigger service restarts due to the large number of services controlled by the configuration file and the potential Extreme Badness of Ceph daemons being restarted haphazardly.