### PR TITLE
Fixes #798 - patches Cinder to be able to fall back to a configured AZ

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -586,7 +586,7 @@ default['bcpc']['nova']['policy'] = {
   "compute:reboot" => "rule:admin_or_owner",
   "compute:delete" => "rule:admin_or_owner",
   "compute:unlock_override" => "rule:admin_api",
-  
+
   "compute:get_instance_metadata" => "rule:admin_or_owner",
   "compute:update_instance_metadata" => "rule:admin_or_owner",
   "compute:delete_instance_metadata" => "rule:admin_or_owner",
@@ -986,6 +986,7 @@ default['bcpc']['nova']['policy'] = {
 # Verbose logging (level INFO)
 default['bcpc']['cinder']['verbose'] = false
 default['bcpc']['cinder']['workers'] = 5
+default['bcpc']['cinder']['allow_az_fallback'] = true
 default['bcpc']['cinder']['quota'] = {
   "volumes" => 10,
   "quota_snapshots" => 10,
@@ -1370,14 +1371,14 @@ default['bcpc']['flavors'] = {
       "vcpus" => 1,
       "memory_mb" => 512,
       "disk_gb" => 1,
-      "ephemeral_gb" => 5,     
+      "ephemeral_gb" => 5,
       "extra_specs" => { "aggregate_instance_extra_specs:ephemeral_compute" => "yes"}
     },
     "e1.small" => {
       "vcpus" => 1,
       "memory_mb" => 2048,
       "disk_gb" => 20,
-      "ephemeral_gb" => 20,     
+      "ephemeral_gb" => 20,
       "extra_specs" => { "aggregate_instance_extra_specs:ephemeral_compute" => "yes"}
     },
     "e1.medium" => {
@@ -1391,21 +1392,21 @@ default['bcpc']['flavors'] = {
       "vcpus" => 4,
       "memory_mb" => 8192,
       "disk_gb" => 40,
-      "ephemeral_gb" => 80,    
+      "ephemeral_gb" => 80,
       "extra_specs" => { "aggregate_instance_extra_specs:ephemeral_compute" => "yes"}
     },
     "e1.xlarge" => {
       "vcpus" => 8,
       "memory_mb" => 16384,
       "disk_gb" => 40,
-      "ephemeral_gb" => 160,   
+      "ephemeral_gb" => 160,
       "extra_specs" => { "aggregate_instance_extra_specs:ephemeral_compute" => "yes"}
     },
     "e1.2xlarge" => {
       "vcpus" => 8,
       "memory_mb" => 32768,
       "disk_gb" => 40,
-      "ephemeral_gb" => 320,     
+      "ephemeral_gb" => 320,
       "extra_specs" => { "aggregate_instance_extra_specs:ephemeral_compute" => "yes"}
     }
 }

--- a/cookbooks/bcpc/files/default/cinder_availability_zone_fallback.patch
+++ b/cookbooks/bcpc/files/default/cinder_availability_zone_fallback.patch
@@ -1,0 +1,46 @@
+diff --git a/cinder/common/config.py b/cinder/common/config.py
+index f6a49c7..7f264ce 100644
+--- a/cinder/common/config.py
++++ b/cinder/common/config.py
+@@ -139,6 +139,12 @@ global_opts = [
+                help='Default availability zone for new volumes. If not set, '
+                     'the storage_availability_zone option value is used as '
+                     'the default for new volumes.'),
++    cfg.BoolOpt('allow_availability_zone_fallback',
++                default=False,
++                help='If the requested Cinder availability zone is '
++                     'unavailable, fall back to the value of '
++                     'default_availability_zone, then '
++                     'storage_availability_zone, instead of failing.'),
+     cfg.StrOpt('default_volume_type',
+                default=None,
+                help='Default volume type to use'),
+diff --git a/cinder/volume/flows/api/create_volume.py b/cinder/volume/flows/api/create_volume.py
+index 7d49006..05431a9 100644
+--- a/cinder/volume/flows/api/create_volume.py
++++ b/cinder/volume/flows/api/create_volume.py
+@@ -327,10 +327,21 @@ class ExtractVolumeRequestTask(flow_utils.CinderTask):
+             else:
+                 # For backwards compatibility use the storage_availability_zone
+                 availability_zone = CONF.storage_availability_zone
++
+         if availability_zone not in self.availability_zones:
+-            msg = _("Availability zone '%s' is invalid") % (availability_zone)
+-            LOG.warn(msg)
+-            raise exception.InvalidInput(reason=msg)
++            if CONF.allow_availability_zone_fallback:
++                original_az = availability_zone
++                availability_zone = (
++                    CONF.default_availability_zone or
++                    CONF.storage_availability_zone)
++                msg = _("Availability zone '%s' not found, falling back to "
++                        "'%s'" % (original_az, availability_zone))
++                LOG.warn(msg)
++            else:
++                msg = _(("Availability zone '%s' is invalid") %
++                        (availability_zone))
++                LOG.warn(msg)
++                raise exception.InvalidInput(reason=msg)
+
+         # If the configuration only allows cloning to the same availability
+         # zone then we need to enforce that.

--- a/cookbooks/bcpc/templates/default/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder.conf.erb
@@ -9,6 +9,7 @@
 #      to serve any volume (since they're RBD backed)
 host = bcpc
 storage_availability_zone=
+allow_availability_zone_fallback=<%= node['bcpc']['cinder']['allow_az_fallback'] %>
 rootwrap_config = /etc/cinder/rootwrap.conf
 api_paste_confg = /etc/cinder/api-paste.ini
 verbose = <%= node['bcpc']['cinder']['verbose'] %>


### PR DESCRIPTION
This PR allows Cinder to work properly in our configuration with no storage availability zones configured, as we manage that through Ceph.

To test:
* with `['bcpc']['cinder']['az_fallback']` set to **false** (the current behavior in upstream OpenStack), executing `cinder create --availability-zone Test-Laptop-Vagrant --display-name blah 10` will fail; setting to **true** will trigger the patch code and the volume creation should then work (`cinder-api.log` will indicate that it's hit the condition by printing out `Availability zone 'BLAH-1' not found, falling back to ''`)
* `nova boot` commands that specify `--block-device` for creation of a root volume at instance start should similarly fail on **false** and work on **true**

This patch will get upstreamed to OpenStack once I have written unit tests.