### PR TITLE
Fixes #791 - stops getty log spam on Vagrant builds

### DIFF
--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -268,6 +268,10 @@ Vagrant.configure("2") do |config|
         vb.customize ["modifyvm", :id, "--vtxvpid", "on"]
         vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
         vb.customize ["modifyvm", :id, "--ioapic", "on"]
+        vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+        vb.customize ["modifyvm", :id, "--uart2", "0x2F8", "3"]
+        vb.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
+        vb.customize ["modifyvm", :id, "--uartmode2", "disconnected"]
 
         unless idx == 0
           # this is an unpleasing hack to locate the VM on disk, so that additional disks can be stored with it


### PR DESCRIPTION
This adds two serial ports to each Vagrant-built VM so that getty will have a real COM1 and COM2 port to attach to, which will stop it from crashing and respawning repeatedly.