### PR TITLE
Fixes #816 - boot from volume fails if volume does not match flavor size

### DIFF
--- a/cookbooks/bcpc/files/default/nova-volume-boot-size-AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-volume-boot-size-AFTER.SHASUMS
@@ -1,0 +1,1 @@
+0fbd66db6c2cfbf82ae3f123217db46fcef38707  nova/compute/api.py

--- a/cookbooks/bcpc/files/default/nova-volume-boot-size-BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-volume-boot-size-BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+5d39d372d3ceed4c1ac8159d1a6ea1f24cc84624  nova/compute/api.py

--- a/cookbooks/bcpc/files/default/nova-volume-boot-size.patch
+++ b/cookbooks/bcpc/files/default/nova-volume-boot-size.patch
@@ -1,0 +1,176 @@
+diff --git a/nova/compute/api.py b/nova/compute/api.py
+index 3d04052..3e6bde3 100644
+--- a/nova/compute/api.py
++++ b/nova/compute/api.py
+@@ -651,7 +651,8 @@ class API(base.Base):
+         # reason, we rely on the DB to cast True to a String.
+         return True if bool_val else ''
+ 
+-    def _check_requested_image(self, context, image_id, image, instance_type):
++    def _check_requested_image(self, context, image_id, image,
++                               instance_type, root_bdm):
+         if not image:
+             return
+ 
+@@ -668,15 +669,63 @@ class API(base.Base):
+         if instance_type['memory_mb'] < int(image.get('min_ram') or 0):
+             raise exception.FlavorMemoryTooSmall()
+ 
+-        # NOTE(johannes): root_gb is allowed to be 0 for legacy reasons
+-        # since libvirt interpreted the value differently than other
+-        # drivers. A value of 0 means don't check size.
+-        root_gb = instance_type['root_gb']
+-        if root_gb:
+-            if int(image.get('size') or 0) > root_gb * (1024 ** 3):
+-                raise exception.FlavorDiskTooSmall()
++        # Image min_disk is in gb, size is in bytes. For sanity, have them both
++        # in bytes.
++        image_min_disk = int(image.get('min_disk') or 0) * units.Gi
++        image_size = int(image.get('size') or 0)
++
++        # Target disk is a volume. Don't check flavor disk size because it
++        # doesn't make sense, and check min_disk against the volume size.
++        if (root_bdm is not None and root_bdm.is_volume):
++            # There are 2 possibilities here: either the target volume already
++            # exists, or it doesn't, in which case the bdm will contain the
++            # intended volume size.
++            #
++            # Cinder does its own check against min_disk, so if the target
++            # volume already exists this has already been done and we don't
++            # need to check it again here. In this case, volume_size may not be
++            # set on the bdm.
++            #
++            # If we're going to create the volume, the bdm will contain
++            # volume_size. Therefore we should check it if it exists. This will
++            # still be checked again by cinder when the volume is created, but
++            # that will not happen until the request reaches a host. By
++            # checking it here, the user gets an immediate and useful failure
++            # indication.
++            #
++            # The third possibility is that we have failed to consider
++            # something, and there are actually more than 2 possibilities. In
++            # this case cinder will still do the check at volume creation time.
++            # The behaviour will still be correct, but the user will not get an
++            # immediate failure from the api, and will instead have to
++            # determine why the instance is in an error state with a task of
++            # block_device_mapping.
++            #
++            # We could reasonably refactor this check into _validate_bdm at
++            # some future date, as the various size logic is already split out
++            # in there.
++            dest_size = root_bdm.volume_size
++            if dest_size is not None:
++                dest_size *= units.Gi
++
++                if image_min_disk > dest_size:
++                    # TODO(mdbooth) Raise a more descriptive exception here.
++                    # This is the exception which calling code expects, but
++                    # it's potentially misleading to the user.
++                    raise exception.FlavorDiskTooSmall()
++
++        # Target disk is a local disk whose size is taken from the flavor
++        else:
++            dest_size = instance_type['root_gb'] * units.Gi
++
++            # NOTE(johannes): root_gb is allowed to be 0 for legacy reasons
++            # since libvirt interpreted the value differently than other
++            # drivers. A value of 0 means don't check size.
++            if dest_size != 0:
++                if image_size > dest_size:
++                    raise exception.FlavorDiskTooSmall()
+ 
+-            if int(image.get('min_disk') or 0) > root_gb:
++                if image_min_disk > dest_size:
+                     raise exception.FlavorDiskTooSmall()
+ 
+     def _get_image_defined_bdms(self, base_options, instance_type, image_meta,
+@@ -767,10 +816,11 @@ class API(base.Base):
+ 
+     def _checks_for_create_and_rebuild(self, context, image_id, image,
+                                        instance_type, metadata,
+-                                       files_to_inject):
++                                       files_to_inject, root_bdm):
+         self._check_metadata_properties_quota(context, metadata)
+         self._check_injected_file_quota(context, files_to_inject)
+-        self._check_requested_image(context, image_id, image, instance_type)
++        self._check_requested_image(context, image_id, image,
++                                    instance_type, root_bdm)
+ 
+     def _validate_and_build_base_options(self, context, instance_type,
+                                          boot_meta, image_href, image_id,
+@@ -778,7 +828,7 @@ class API(base.Base):
+                                          display_description, key_name,
+                                          key_data, security_groups,
+                                          availability_zone, forced_host,
+-                                         user_data, metadata, injected_files,
++                                         user_data, metadata,
+                                          access_ip_v4, access_ip_v6,
+                                          requested_networks, config_drive,
+                                          auto_disk_config, reservation_id,
+@@ -810,9 +860,6 @@ class API(base.Base):
+             except base64.binascii.Error:
+                 raise exception.InstanceUserDataMalformed()
+ 
+-        self._checks_for_create_and_rebuild(context, image_id, boot_meta,
+-                instance_type, metadata, injected_files)
+-
+         self._check_requested_secgroups(context, security_groups)
+ 
+         # Note:  max_count is the number of instances requested by the user,
+@@ -1095,7 +1142,7 @@ class API(base.Base):
+                 instance_type, boot_meta, image_href, image_id, kernel_id,
+                 ramdisk_id, display_name, display_description,
+                 key_name, key_data, security_groups, availability_zone,
+-                forced_host, user_data, metadata, injected_files, access_ip_v4,
++                forced_host, user_data, metadata, access_ip_v4,
+                 access_ip_v6, requested_networks, config_drive,
+                 auto_disk_config, reservation_id, max_count)
+ 
+@@ -1115,6 +1162,12 @@ class API(base.Base):
+             base_options, instance_type, boot_meta, min_count, max_count,
+             block_device_mapping, legacy_bdm)
+ 
++        # We can't do this check earlier because we need bdms from all sources
++        # to have been merged in order to get the root bdm.
++        self._checks_for_create_and_rebuild(context, image_id, boot_meta,
++                instance_type, metadata, injected_files,
++                block_device_mapping.root_bdm())
++
+         instance_group = self._get_requested_instance_group(context,
+                                    scheduler_hints, check_server_group_quota)
+ 
+@@ -2333,8 +2386,9 @@ class API(base.Base):
+         self._check_auto_disk_config(image=image, **kwargs)
+ 
+         flavor = instance.get_flavor()
++        root_bdm = self._get_root_bdm(context, instance)
+         self._checks_for_create_and_rebuild(context, image_id, image,
+-                flavor, metadata, files_to_inject)
++                flavor, metadata, files_to_inject, root_bdm)
+ 
+         kernel_id, ramdisk_id = self._handle_kernel_and_ramdisk(
+                 context, None, None, image)
+@@ -3201,15 +3255,18 @@ class API(base.Base):
+         uuids = [instance.uuid for instance in instances]
+         return self.db.instance_fault_get_by_instance_uuids(context, uuids)
+ 
+-    def is_volume_backed_instance(self, context, instance, bdms=None):
+-        if not instance.image_ref:
+-            return True
+-
++    def _get_root_bdm(self, context, instance, bdms=None):
+         if bdms is None:
+             bdms = objects.BlockDeviceMappingList.get_by_instance_uuid(
+                     context, instance.uuid)
+ 
+-        root_bdm = bdms.root_bdm()
++        return bdms.root_bdm()
++
++    def is_volume_backed_instance(self, context, instance, bdms=None):
++        if not instance.image_ref:
++            return True
++
++        root_bdm = self._get_root_bdm(context, instance, bdms)
+         if not root_bdm:
+             return False
+         return root_bdm.is_volume

--- a/cookbooks/bcpc/providers/patch.rb
+++ b/cookbooks/bcpc/providers/patch.rb
@@ -21,18 +21,18 @@ def whyrun_supported?
   true
 end
 
-# expects the name of the patch file and the cookbook (can be nil)
-# returns the path to the staged patch file
-def stage_patch(patch_file, file_cookbook)
-  path = ::File.join Chef::Config[:file_cache_path], patch_file
+# expects the name of the file to stage and the cookbook (can be nil)
+# returns the path to the staged file
+def stage_file(file_to_stage, file_cookbook)
+  path = ::File.join(Chef::Config[:file_cache_path], file_to_stage)
   cookbook = file_cookbook || cookbook_name
 
   Chef::Log.debug("creating #{path}")
   @file_patch_path = Chef::Resource::CookbookFile.new(path, run_context)
-  @file_patch_path.source patch_file
-  @file_patch_path.owner 'root'
-  @file_patch_path.mode 00644
-  @file_patch_path.cookbook cookbook
+  @file_patch_path.source(patch_file)
+  @file_patch_path.owner('root')
+  @file_patch_path.mode(00644)
+  @file_patch_path.cookbook(cookbook)
   @file_patch_path.run_action(:create)
 
   path
@@ -40,9 +40,9 @@ end
 
 action :apply do
   # stage all files
-  before_checksum_path = stage_patch new_resource.shasums_before_apply, new_resource.file_cookbook
-  after_checksum_path = stage_patch new_resource.shasums_after_apply, new_resource.file_cookbook
-  patch_path = stage_patch new_resource.patch_file, new_resource.file_cookbook
+  before_checksum_path = stage_file(new_resource.shasums_before_apply, new_resource.file_cookbook)
+  after_checksum_path = stage_file(new_resource.shasums_after_apply, new_resource.file_cookbook)
+  patch_path = stage_file(new_resource.patch_file, new_resource.file_cookbook)
 
   # test to see if checksums match
   before_cmd_str = "cd #{new_resource.patch_root_dir} && shasum -c #{before_checksum_path}"
@@ -52,11 +52,11 @@ action :apply do
   after_cmd = Mixlib::ShellOut.new(after_cmd_str).run_command
 
   # check stderr on before and after to find out if any files could not be found and raise if so
-  if before_cmd.stderr.end_with? "could not be read\n"
+  if before_cmd.stderr.end_with?("could not be read\n")
     raise "Error reading files during before checksum: stdout: #{before_cmd.stdout}\nstderr:#{before_cmd.stderr}"
   end
 
-  if after_cmd.stderr.end_with? "could not be read\n"
+  if after_cmd.stderr.end_with?("could not be read\n")
     raise "Error reading files during after checksum: stdout: #{after_cmd.stdout}\nstderr:#{after_cmd.stderr}"
   end
 

--- a/cookbooks/bcpc/providers/patch.rb
+++ b/cookbooks/bcpc/providers/patch.rb
@@ -1,0 +1,100 @@
+#
+# Cookbook Name:: bcpc
+# Provider:: patch
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def whyrun_supported?
+  true
+end
+
+# expects the name of the patch file and the cookbook (can be nil)
+# returns the path to the staged patch file
+def stage_patch(patch_file, file_cookbook)
+  path = ::File.join Chef::Config[:file_cache_path], patch_file
+  cookbook = file_cookbook || cookbook_name
+
+  Chef::Log.debug("creating #{path}")
+  @file_patch_path = Chef::Resource::CookbookFile.new(path, run_context)
+  @file_patch_path.source patch_file
+  @file_patch_path.owner 'root'
+  @file_patch_path.mode 00644
+  @file_patch_path.cookbook cookbook
+  @file_patch_path.run_action(:create)
+
+  path
+end
+
+action :apply do
+  # stage all files
+  before_checksum_path = stage_patch new_resource.shasums_before_apply, new_resource.file_cookbook
+  after_checksum_path = stage_patch new_resource.shasums_after_apply, new_resource.file_cookbook
+  patch_path = stage_patch new_resource.patch_file, new_resource.file_cookbook
+
+  # test to see if checksums match
+  before_cmd_str = "cd #{new_resource.patch_root_dir} && shasum -c #{before_checksum_path}"
+  before_cmd = Mixlib::ShellOut.new(before_cmd_str).run_command
+
+  after_cmd_str = "cd #{new_resource.patch_root_dir} && shasum -c #{after_checksum_path}"
+  after_cmd = Mixlib::ShellOut.new(after_cmd_str).run_command
+
+  # check stderr on before and after to find out if any files could not be found and raise if so
+  if before_cmd.stderr.end_with? "could not be read\n"
+    raise "Error reading files during before checksum: stdout: #{before_cmd.stdout}\nstderr:#{before_cmd.stderr}"
+  end
+
+  if after_cmd.stderr.end_with? "could not be read\n"
+    raise "Error reading files during after checksum: stdout: #{after_cmd.stdout}\nstderr:#{after_cmd.stderr}"
+  end
+
+  if before_cmd.exitstatus == 0 and after_cmd.exitstatus > 0
+    need_to_apply = true
+  elsif before_cmd.exitstatus > 0 and after_cmd.exitstatus == 0
+    need_to_apply = false
+  elsif before_cmd.exitstatus == 0 and after_cmd.exitstatus == 0
+    raise <<-EOH
+      both before and after checksums matched, not a possible outcome
+      BEFORE stdout: #{before_cmd.stdout}
+      BEFORE stderr: #{before_cmd.stderr}
+      AFTER stdout: #{after_cmd.stdout}
+      AFTER stderr: #{after_cmd.stderr}
+    EOH
+  else
+    raise <<-EOH
+      errors raised by shasum both before and after:
+      BEFORE: #{before_cmd.stderr}
+      AFTER: #{after_cmd.stderr}
+    EOH
+  end
+
+  next unless need_to_apply
+
+  converge_by "apply patch #{new_resource.patch_file}" do
+    patch_apply_cmd_str = <<-EOH
+      cd #{new_resource.patch_root_dir}
+      PREPATCH=$(patch -f -s --dry-run -p#{new_resource.patch_level} < '#{patch_path}' 2>&1)
+      if [ $? -eq 0 ]; then
+        patch -b -p#{new_resource.patch_level} < '#{patch_path}'
+      else
+        echo "$PREPATCH" >&2
+        exit 1
+      fi
+    EOH
+
+    patch_apply_cmd = Mixlib::ShellOut.new(patch_apply_cmd_str).run_command
+    patch_apply_cmd.error!
+  end
+end

--- a/cookbooks/bcpc/resources/patch.rb
+++ b/cookbooks/bcpc/resources/patch.rb
@@ -1,0 +1,36 @@
+
+# Cookbook Name:: bcpc
+# Resource:: patch
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :apply
+default_action :apply
+
+attribute :name, :name_attribute => true, :kind_of => String, :required => true
+# patch_file is the path to a cookbook file (i.e., must be under files/)
+attribute :patch_file, :kind_of => String, :required => true
+# patch_root_dir is the directory from which the patch will be run
+attribute :patch_root_dir, :kind_of => String, :required => true
+# patch_level corresponds to -p with the patch command
+attribute :patch_level, :kind_of => Integer, :default => 1
+# these are cookbook file names that will be passed to shasum -c
+# shasum is executed from patch_root_dir, so paths must be relative to
+# that location within the checksum files
+attribute :shasums_before_apply, :kind_of => String, :required => true
+attribute :shasums_after_apply, :kind_of => String, :required => true
+# the cookbook to find the files in (nil will use current cookbook)
+attribute :file_cookbook, :kind_of => [NilClass, String], :required => false, :default => nil


### PR DESCRIPTION
This backports a patch from stable/kilo (merged after 2015.1.1 was released) to nova-api to fix the indicated issue.

I tested via a build off master (with 2015.1.1), and cherry-picking onto 5.6.1 and recheffing onto an existing 5.6.1 lab cluster. Both scenarios worked without incident.

**Testing information**
The symptom of the issue is that if you attempt to boot an instance from a root volume that does not match the size of the root disk for the selected flavor, Nova will fail instance creation with the error `Error: Flavor's disk is too small for requested image. (HTTP 400)`. Applying this patch will fix it.

**To test**
* Create a volume from an image for use as a root volume, intentionally specifying a size that no flavor will have (e.g., 53GB).
* Select a flavor like m1.small that specifies a smaller root volume (20GB).