### PR TITLE
Collect Elasticsearch metrics

### DIFF
--- a/cookbooks/bcpc/recipes/diamond.rb
+++ b/cookbooks/bcpc/recipes/diamond.rb
@@ -81,6 +81,15 @@ if node['bcpc']['enabled']['metrics'] then
         notifies :restart, "service[diamond]", :delayed
     end
 
+    template "/etc/diamond/collectors/ElasticSearchCollector.conf" do
+        source "diamond-collector-elasticsearch.conf.erb"
+        owner "diamond"
+        group "root"
+        mode 00600
+        notifies :restart, "service[diamond]", :delayed
+        only_if "test -f /etc/init.d/elasticsearch"
+    end
+
     service "diamond" do
         action [:enable, :start]
     end

--- a/cookbooks/bcpc/templates/default/diamond-collector-elasticsearch.conf.erb
+++ b/cookbooks/bcpc/templates/default/diamond-collector-elasticsearch.conf.erb
@@ -1,0 +1,3 @@
+enabled = True
+host = <%= @node['bcpc']['management']['ip'] %>
+logstash_mode = True

--- a/cookbooks/bcpc/templates/default/diamond.conf.erb
+++ b/cookbooks/bcpc/templates/default/diamond.conf.erb
@@ -199,9 +199,6 @@ enabled = True
 [[CephCollector]]
 enabled = False
 
-[[ElasticSearchCollector]]
-enabled = False
-
 <% if node['bcpc']['virt_type'] == "kvm" -%>
 [[KVMCollector]]
 enabled = True


### PR DESCRIPTION
When deployed, metrics will show up in Graphite under the monitoring servers (bcpc-vm[456]).