### PR TITLE
python-tz is required for Graphite webapp

### DIFF
--- a/cookbooks/bcpc/recipes/graphite.rb
+++ b/cookbooks/bcpc/recipes/graphite.rb
@@ -63,7 +63,7 @@ if node['bcpc']['enabled']['metrics'] then
         end
     end
 
-    %w{python-pip python-cairo python-django python-django-tagging python-ldap python-twisted python-memcache memcached python-mysqldb}.each do |pkg|
+    %w{python-pip python-cairo python-django python-django-tagging python-ldap python-twisted python-memcache memcached python-mysqldb python-tz}.each do |pkg|
         package pkg do
             action :upgrade
         end


### PR DESCRIPTION
Fixes #821. Graphite web should not return a broken image when viewing the absolute time range of any metric.