### PR TITLE
Add haproxy BASIC auth for kibana backend

### DIFF
--- a/cookbooks/bcpc/recipes/haproxy-monitoring.rb
+++ b/cookbooks/bcpc/recipes/haproxy-monitoring.rb
@@ -20,11 +20,24 @@
 include_recipe "bcpc::default"
 include_recipe "bcpc::haproxy-common"
 
+ruby_block "initialize-haproxy-monitoring-config" do
+    block do
+        make_config('monitoring-admin-user', "monitoring_admin")
+        make_config('monitoring-admin-password', secure_password)
+    end
+end
+
 template "/etc/haproxy/haproxy.cfg" do
     source "haproxy-monitoring.cfg.erb"
     mode 00644
     variables(
-        :servers => search_nodes("role", "BCPC-Monitoring")
+        lazy {
+          {
+            :monitoring_admin_username => get_config("monitoring-admin-user"),
+            :monitoring_admin_password => get_config("monitoring-admin-password"),
+            :servers => search_nodes("role", "BCPC-Monitoring")
+          }
+        }
     )
     notifies :restart, "service[haproxy]", :immediately
 end

--- a/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
@@ -84,7 +84,7 @@ backend kibana-backend
   option httpchk HEAD /elasticsearch/ HTTP/1.1\r\nHost: <%=node['bcpc']['monitoring']['vip']%>
   http-check expect status 200
   acl AuthOkay_kibana http_auth(admins)
-  http-request auth realm <%= "monitoring.openstack.#{node['bcpc']['domain_name']}" %> if !AuthOkay_kibana
+  http-request auth realm <%= node['bcpc']['kibana']['fqdn'] %> if !AuthOkay_kibana
   reqrep ^([^\ :]*)\ /kibana/(.*) \1\ /\2
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:5601 check inter 5s rise 1 fall 1" %>

--- a/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-monitoring.cfg.erb
@@ -31,6 +31,9 @@ defaults
   timeout client 30m
   timeout server 30m
 
+userlist admins
+  user <%= @monitoring_admin_username %> password <%= salt=secure_password_alphanum_upper(2); @monitoring_admin_password.crypt('$6$'+salt) %>
+
 listen mysql-galera <%=node['bcpc']['monitoring']['vip']%>:3306
   timeout client 24h
   timeout server 24h
@@ -80,6 +83,8 @@ backend kibana-backend
   balance source
   option httpchk HEAD /elasticsearch/ HTTP/1.1\r\nHost: <%=node['bcpc']['monitoring']['vip']%>
   http-check expect status 200
+  acl AuthOkay_kibana http_auth(admins)
+  http-request auth realm <%= "monitoring.openstack.#{node['bcpc']['domain_name']}" %> if !AuthOkay_kibana
   reqrep ^([^\ :]*)\ /kibana/(.*) \1\ /\2
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:5601 check inter 5s rise 1 fall 1" %>


### PR DESCRIPTION
Simply way to secure kibana via haproxy using BASIC HTTP autentication. It may be the case that
1) This is desired as an optional feature
2) Other haproxied urls will require authentication
The general approach can be extended

To test:
First, both `monitoring-admin-user` and `monitoring-admin-password` will need to be queried from the `configs` data bag. Then,
```
$ curl -I -k https://10.0.100.6/kibana/
HTTP/1.0 401 Unauthorized
Cache-Control: no-cache
Connection: close
Content-Type: text/html
WWW-Authenticate: Basic realm="monitoring.openstack.bcpc.example.com"

$ curl -u monitoring_admin:cgJgggUKago7R68SjHJC -I -k https://10.0.100.6/kibana/
HTTP/1.1 200 OK
X-App-Name: kibana
Accept-Ranges: bytes
Cache-Control: public, max-age=0
Last-Modified: Thu, 30 Jul 2015 18:47:51 GMT
ETag: W/"6f9-14ee04abbd8"
Content-Type: text/html; charset=UTF-8
Content-Length: 1785
Vary: Accept-Encoding
Date: Thu, 17 Sep 2015 16:48:09 GMT
```