### PR TITLE
Fixes #826 - backports patch to fix refreshing security groups

### DIFF
--- a/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.0-AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.0-AFTER.SHASUMS
@@ -1,0 +1,1 @@
+931596fb33cb5806f0c502ec72b2586a0c46c08f  nova/compute/manager.py

--- a/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.0-BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.0-BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+9992dcec1e578ad9867699ef05627173b92df636  nova/compute/manager.py

--- a/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.0.patch
+++ b/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.0.patch
@@ -1,0 +1,24 @@
+diff --git a/nova/compute/manager.py b/nova/compute/manager.py
+index 5d86698..7f77bc9 100644
+--- a/nova/compute/manager.py
++++ b/nova/compute/manager.py
+@@ -420,6 +420,11 @@ def object_compat(function):
+     def decorated_function(self, context, *args, **kwargs):
+         def _load_instance(instance_or_dict):
+             if isinstance(instance_or_dict, dict):
++                # try to get metadata and system_metadata for most cases but
++                # only attempt to load those if the db instance already has
++                # those fields joined
++                metas = [meta for meta in ('metadata', 'system_metadata')
++                         if meta in instance_or_dict]
+                 instance = objects.Instance._from_db_object(
+                     context, objects.Instance(), instance_or_dict,
+                     expected_attrs=metas)
+@@ -427,7 +432,6 @@ def object_compat(function):
+                 return instance
+             return instance_or_dict
+ 
+-        metas = ['metadata', 'system_metadata']
+         try:
+             kwargs['instance'] = _load_instance(kwargs['instance'])
+         except KeyError:

--- a/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.1-AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.1-AFTER.SHASUMS
@@ -1,0 +1,1 @@
+de74f3caa3f78777ad713695ac65d88fcbbe3154  nova/compute/manager.py

--- a/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.1-BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.1-BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+a5ccaff829106c99caf1de9b9c5f27c992d01510  nova/compute/manager.py

--- a/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.1.patch
+++ b/cookbooks/bcpc/files/default/nova-fix-refresh-secgroups-2015.1.1.patch
@@ -1,0 +1,24 @@
+diff --git a/nova/compute/manager.py b/nova/compute/manager.py
+index 11668bd..e6ab1ac 100644
+--- a/nova/compute/manager.py
++++ b/nova/compute/manager.py
+@@ -420,6 +420,11 @@ def object_compat(function):
+     def decorated_function(self, context, *args, **kwargs):
+         def _load_instance(instance_or_dict):
+             if isinstance(instance_or_dict, dict):
++                # try to get metadata and system_metadata for most cases but
++                # only attempt to load those if the db instance already has
++                # those fields joined
++                metas = [meta for meta in ('metadata', 'system_metadata')
++                         if meta in instance_or_dict]
+                 instance = objects.Instance._from_db_object(
+                     context, objects.Instance(), instance_or_dict,
+                     expected_attrs=metas)
+@@ -427,7 +432,6 @@ def object_compat(function):
+                 return instance
+             return instance_or_dict
+ 
+-        metas = ['metadata', 'system_metadata']
+         try:
+             kwargs['instance'] = _load_instance(kwargs['instance'])
+         except KeyError:


### PR DESCRIPTION
Testable by creating a VM and then editing a security group attached to it. Changes will take effect immediately, though because iptables allows RELATED,ESTABLISHED on the Nova filter chain, existing connections/pings will continue to operate when the change takes effect, but new ones will not (so don't be surprised when you delete the ICMP rule while pinging the VM and finding that the ping continues to go after you edit the security group).