### PR TITLE
Collect Ceph pools and cluster metrics

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1318,6 +1318,9 @@ default['bcpc']['diamond']['collectors']['rabbitmq']['queues'] = nil
 default['bcpc']['diamond']['collectors']['rabbitmq']['queues_ignored'] = '.*'
 # List of vhosts to report on. If nil, report none.
 default['bcpc']['diamond']['collectors']['rabbitmq']['vhosts'] = nil
+# Ceph Collector parameters
+default['bcpc']['diamond']['collectors']['CephCollector']['metrics_whitelist'] = "ceph.mon.#{node['hostname']}.cluster.*"
+
 
 ###########################################
 #

--- a/cookbooks/bcpc/files/default/diamond-collector-cephpools.py
+++ b/cookbooks/bcpc/files/default/diamond-collector-cephpools.py
@@ -1,0 +1,78 @@
+
+"""
+This is a modified copy of https://github.com/python-diamond/Diamond/pull/105
+which is pending fix/merge.
+"""
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+import subprocess
+import re
+import os
+import sys
+import diamond.collector
+
+"""
+Get usage statistics from the ceph cluster.
+Total as well as per pool.
+"""
+
+class CephPoolStatsCollector(diamond.collector.Collector):
+
+    labels = {
+        'rd_bytes': 'read_bytes',
+        'wr_bytes': 'written_bytes',
+        'bytes_used': 'used_bytes',
+        'objects': 'objects'
+    }
+
+    def collect(self):
+
+        try:
+            output = subprocess.check_output([
+                'ceph',
+                'df',
+                'detail',
+                '--format=json'
+            ])
+        except subprocess.CalledProcessError, err:
+            self.log.info('Could not get stats: %s' % err)
+            self.log.exception('Could not get stats')
+            return False
+
+        try:
+            jsonData = json.loads(output)
+        except Exception, err:
+            self.log.info('Could not parse stats from ceph df: %s', err)
+            self.log.exception('Could not parse stats from ceph df')
+            return False
+
+        stats = jsonData["stats"]
+
+        for s in ['total_bytes', 'total_used_bytes', 'total_objects']:
+            self.publish(s, stats[s], metric_type='GAUGE')
+
+        pools = jsonData["pools"]
+
+        for p in pools:
+            metric = 'pool.' + p["name"]
+
+            for s in p["stats"]:
+                if s in ['bytes_used', 'objects']:
+                    self.publish(
+                        metric + '.' + self.labels[s],
+                        p["stats"][s],
+                        metric_type='GAUGE'
+                    )
+
+                if s in ['rd_bytes', 'wr_bytes']:
+                    self.publish(
+                        metric + '.' + self.labels[s],
+                        p["stats"][s],
+                        metric_type='COUNTER'
+                    )
+
+        return True

--- a/cookbooks/bcpc/recipes/diamond.rb
+++ b/cookbooks/bcpc/recipes/diamond.rb
@@ -90,6 +90,33 @@ if node['bcpc']['enabled']['metrics'] then
         only_if "test -f /etc/init.d/elasticsearch"
     end
 
+    directory "/usr/share/diamond/collectors/cephpools" do
+        owner "root"
+        group "root"
+        mode 00755
+    end
+
+    cookbook_file "/usr/share/diamond/collectors/cephpools/cephpools.py" do
+        source "diamond-collector-cephpools.py"
+        owner "root"
+        group "root"
+        mode 00644
+    end
+
+    %w{CephPoolStatsCollector CephCollector}.each do |collector|
+        template "/etc/diamond/collectors/#{collector}.conf" do
+            source "diamond-collector.conf.erb"
+            owner "diamond"
+            group "root"
+            mode 00600
+            variables(
+                :parameters => node['bcpc']['diamond']['collectors'][collector]
+            )
+            notifies :restart, "service[diamond]", :delayed
+            only_if "test -d /var/lib/ceph/mon/ceph-#{node['hostname']}"
+        end
+    end
+
     service "diamond" do
         action [:enable, :start]
     end

--- a/cookbooks/bcpc/templates/default/diamond-collector.conf.erb
+++ b/cookbooks/bcpc/templates/default/diamond-collector.conf.erb
@@ -1,0 +1,6 @@
+enabled = True
+<% if not @parameters.nil? %>
+<% @parameters.each do |key, value| %>
+<%= key %> = <%= value %>
+<% end %>
+<% end %>

--- a/cookbooks/bcpc/templates/default/diamond.conf.erb
+++ b/cookbooks/bcpc/templates/default/diamond.conf.erb
@@ -196,9 +196,6 @@ enabled = True
 [[NtpdCollector]]
 enabled = True
 
-[[CephCollector]]
-enabled = False
-
 <% if node['bcpc']['virt_type'] == "kvm" -%>
 [[KVMCollector]]
 enabled = True


### PR DESCRIPTION
The `CephPoolStatsCollector` PR has been dormant for a while, hence the fork (with minor mods to work with our current version of Ceph).

When deployed, you should see metrics under `CephCollector` and `CephPoolStatsCollector` for head nodes.