### PR TITLE
Add Diamond openstack collector

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1350,6 +1350,13 @@ default['bcpc']['diamond']['collectors']['rabbitmq']['queues_ignored'] = '.*'
 default['bcpc']['diamond']['collectors']['rabbitmq']['vhosts'] = nil
 # Ceph Collector parameters
 default['bcpc']['diamond']['collectors']['CephCollector']['metrics_whitelist'] = "ceph.mon.#{node['hostname']}.cluster.*"
+# BC2 Collecter parameters
+default['bcpc']['diamond']['collectors']['BC2'] = {
+  "interval" => "900",
+  "path" => "openstack",
+  "hostname" => "#{node['bcpc']['region_name']}",
+  "db_host" => "#{node['bcpc']['management']['vip']}",
+}
 
 
 ###########################################

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1350,8 +1350,8 @@ default['bcpc']['diamond']['collectors']['rabbitmq']['queues_ignored'] = '.*'
 default['bcpc']['diamond']['collectors']['rabbitmq']['vhosts'] = nil
 # Ceph Collector parameters
 default['bcpc']['diamond']['collectors']['CephCollector']['metrics_whitelist'] = "ceph.mon.#{node['hostname']}.cluster.*"
-# BC2 Collecter parameters
-default['bcpc']['diamond']['collectors']['BC2'] = {
+# Openstack Collector parameters
+default['bcpc']['diamond']['collectors']['cloud'] = {
   "interval" => "900",
   "path" => "openstack",
   "hostname" => "#{node['bcpc']['region_name']}",

--- a/cookbooks/bcpc/files/default/diamond-collector-BC2-openstack.py
+++ b/cookbooks/bcpc/files/default/diamond-collector-BC2-openstack.py
@@ -1,0 +1,76 @@
+import diamond.collector
+import MySQLdb as mysql
+
+class BC2Collector(diamond.collector.Collector):
+
+    def get_default_config_help(self):
+        config_help = super(BC2Collector, self).get_default_config_help()
+        config_help.update({
+            'bc2_collector': 'Send BC2 openstack stats',
+        })
+        return config_help
+
+    def get_default_config(self):
+        """
+        Returns the default collector settings
+        """
+        config = super(BC2Collector, self).get_default_config()
+        config.update({
+            'path':        'openstack',
+            'path_prefix': '',
+            'db_user': 'root',
+            'db_password': 'password',
+            'db_host': '127.0.0.1',
+            'hostname': 'local',
+        })
+        return config
+
+
+    def collect(self):
+        cnx = mysql.connect(user=self.config['db_user'], passwd=self.config['db_password'], host=self.config['db_host'])
+        cursor = cnx.cursor()
+
+        # Glance total images size
+        query = ("select sum(size) from glance.images where status = 'active' and deleted = 0")
+        cursor.execute(query)
+        row = cursor.fetchone()
+        self.publish("glance.images_size", row[0])
+
+        # Glance images size per_tenant
+        query = ("select sum(size), kp.name, owner from glance.images gi join keystone.project kp on kp.id = gi.owner where status = 'active' and deleted = 0 group by kp.name")
+        cursor.execute(query)
+
+        for (size, tenant, owner) in cursor:
+            self.publish("glance." + tenant + ".image_size", size)
+
+
+        # Nova total usage
+        query = ("select resource, sum(in_use) from nova.quota_usages where deleted = 0 group by resource")
+        cursor.execute(query)
+
+        for (resource, usage) in cursor:
+            self.publish("nova." + resource, usage)
+
+        # Nova per-tenant usage
+        query = ("select kp.name, qu.project_id, qu.resource, q.hard_limit, sum(in_use) from nova.quota_usages qu left join nova.quotas q on qu.project_id = q.project_id and q.resource = qu.resource join keystone.project kp on kp.id = qu.project_id group by project_id, resource")
+        cursor.execute(query)
+        for (tenant, project_id, resource, hard_limit, usage) in cursor:
+            self.publish("nova." + tenant + "." + resource, usage)
+
+
+        # Cinder total usage
+        query = ("select resource, sum(in_use) from cinder.quota_usages where deleted = 0 group by resource")
+        cursor.execute(query)
+
+        for (resource, usage) in cursor:
+            self.publish("cinder." + resource, usage)
+
+        # Cinder per-tenant usage
+        query = ("select kp.name, qu.project_id, qu.resource, q.hard_limit, sum(in_use) from cinder.quota_usages qu left join cinder.quotas q on qu.project_id = q.project_id and q.resource = qu.resource join keystone.project kp on kp.id = qu.project_id group by project_id, resource")
+        cursor.execute(query)
+        for (tenant, project_id, resource, hard_limit, usage) in cursor:
+            self.publish("cinder." + tenant + "." + resource, usage)
+
+
+        cursor.close()
+        cnx.close()

--- a/cookbooks/bcpc/files/default/diamond-collector-cloud-openstack.py
+++ b/cookbooks/bcpc/files/default/diamond-collector-cloud-openstack.py
@@ -1,12 +1,12 @@
 import diamond.collector
 import MySQLdb as mysql
 
-class BC2Collector(diamond.collector.Collector):
+class CloudCollector(diamond.collector.Collector):
 
     def get_default_config_help(self):
-        config_help = super(BC2Collector, self).get_default_config_help()
+        config_help = super(CloudCollector, self).get_default_config_help()
         config_help.update({
-            'bc2_collector': 'Send BC2 openstack stats',
+            'cloud_collector': 'Send Openstack stats',
         })
         return config_help
 
@@ -14,7 +14,7 @@ class BC2Collector(diamond.collector.Collector):
         """
         Returns the default collector settings
         """
-        config = super(BC2Collector, self).get_default_config()
+        config = super(CloudCollector, self).get_default_config()
         config.update({
             'path':        'openstack',
             'path_prefix': '',

--- a/cookbooks/bcpc/recipes/diamond.rb
+++ b/cookbooks/bcpc/recipes/diamond.rb
@@ -117,6 +117,33 @@ if node['bcpc']['enabled']['metrics'] then
         end
     end
 
+    directory '/usr/share/diamond/collectors/BC2/' do
+        owner 'root'
+        group 'root'
+        mode 00755
+        action :create
+    end
+
+    cookbook_file "/usr/share/diamond/collectors/BC2/BC2.py" do
+        source "diamond-collector-BC2-openstack.py"
+        owner "root"
+        mode 00644
+    end
+
+    template "/etc/diamond/collectors/BC2Collector.conf" do
+        source "diamond-collector.conf.erb"
+        owner "diamond"
+        group "root"
+        mode 00600
+        variables(lazy {
+          {:parameters => node['bcpc']['diamond']['collectors']['BC2'].merge(
+              "db_user" => get_config('mysql-root-user'),
+              "db_password" => get_config('mysql-root-password'),
+          )}
+        })
+        notifies :restart, "service[diamond]", :delayed
+    end
+
     service "diamond" do
         action [:enable, :start]
     end

--- a/cookbooks/bcpc/recipes/diamond.rb
+++ b/cookbooks/bcpc/recipes/diamond.rb
@@ -117,26 +117,26 @@ if node['bcpc']['enabled']['metrics'] then
         end
     end
 
-    directory '/usr/share/diamond/collectors/BC2/' do
+    directory '/usr/share/diamond/collectors/Cloud/' do
         owner 'root'
         group 'root'
         mode 00755
         action :create
     end
 
-    cookbook_file "/usr/share/diamond/collectors/BC2/BC2.py" do
-        source "diamond-collector-BC2-openstack.py"
+    cookbook_file "/usr/share/diamond/collectors/Cloud/CloudCollector.py" do
+        source "diamond-collector-cloud-openstack.py"
         owner "root"
         mode 00644
     end
 
-    template "/etc/diamond/collectors/BC2Collector.conf" do
+    template "/etc/diamond/collectors/CloudCollector.conf" do
         source "diamond-collector.conf.erb"
         owner "diamond"
         group "root"
         mode 00600
         variables(lazy {
-          {:parameters => node['bcpc']['diamond']['collectors']['BC2'].merge(
+          {:parameters => node['bcpc']['diamond']['collectors']['cloud'].merge(
               "db_user" => get_config('mysql-root-user'),
               "db_password" => get_config('mysql-root-password'),
           )}


### PR DESCRIPTION
Adds Diamond collector that sends general openstack stats to graphite. 
To test: build cluster with 'MONITORING_NODES=1', open graphite, you should see metrics under 'BC2' (might have to wait up to 15 minutes for metrics to appear - default collection interval)