### PR TITLE
Add iptables safety valve that allows appending rules before the end

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -166,6 +166,10 @@ default['bcpc']['management']['interface'] = nil
 # if 'interface' is a VLAN interface, specifying a parent allows MTUs
 # to be set properly
 default['bcpc']['management']['interface-parent'] = nil
+# the safety valve allows the appending of arbitrary firewall rules to the
+# bottom of the iptables chain immediately before LOGDROP
+# USE WITH EXTREME CARE
+default['bcpc']['management']['iptables_safety_valve'] = nil
 
 default['bcpc']['metadata']['ip'] = "169.254.169.254"
 

--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -97,6 +97,9 @@ iptables-restore <<EOH
 -A INPUT-monitoring -m set --match-set monitoring-clients src -j ACCEPT
 <% end -%>
 
+# safety valve rules appear below here
+<%= @node['bcpc']['management']['iptables_safety_valve'] %>
+
 # Log and drop everything else
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -j LOGDROP
 


### PR DESCRIPTION
While ugly, the use case for this is to allow the addition of arbitrary iptables rules before the end of the iptables INPUT chain. (The specific use case here is to allow certain external hosts access to MySQL to obtain data for statistics purposes without adding 3306 to the list of ports open to the world.)