### PR TITLE
Bump rabbitmq-server version to 3.5.5-3

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -41,7 +41,7 @@ default['bcpc']['ceph']['version_number'] = '0.94.3'
 default['bcpc']['erlang']['version'] = '1:17.5.3'
 default['bcpc']['haproxy']['version'] = '1.5.14-1ppa~trusty'
 default['bcpc']['kibana']['version'] = '4.0.2'
-default['bcpc']['rabbitmq']['version'] = '3.5.4-1'
+default['bcpc']['rabbitmq']['version'] = '3.5.5-3'
 
 ###########################################
 #


### PR DESCRIPTION
This isn't thoroughly tested yet, but it *is* necessary to complete build