### PR TITLE
open 8443/TCP for a web server for external integrations

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -274,6 +274,7 @@ default['bcpc']['protocol']['glance'] = "https"
 default['bcpc']['protocol']['nova'] = "https"
 default['bcpc']['protocol']['cinder'] = "https"
 default['bcpc']['protocol']['heat'] = "https"
+default['bcpc']['protocol']['ext_integration'] = "https"
 
 
 ###########################################

--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -67,6 +67,7 @@ iptables-restore <<EOH
 
 # Allow external access to some VIP services
 ## apache 80, 443
+## radosgw 8088 7480
 ## keystone 5000 35357
 ## glance 9292
 ## cinder 8776
@@ -75,7 +76,8 @@ iptables-restore <<EOH
 ## heat-api 8004
 ## heat-api-cfn 8000
 ## ceilometer-api 8777
--A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --match multiport --dports 80,443,8088,7480,5000,35357,9292,8776,8773,8774,8004,8000,8777 -j ACCEPT
+## extra integrations web server 8443
+-A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --match multiport --dports 80,443,8088,7480,5000,35357,9292,8776,8773,8774,8004,8000,8777,8443 -j ACCEPT
 ## powerdns 53
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p udp --dport 53 -j ACCEPT
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --dport 53 -j ACCEPT

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -31,6 +31,9 @@ defaults
   timeout client 30m
   timeout server 30m
 
+userlist ext_integration
+  user <%= @ext_integration_username %> password <%= salt=secure_password_alphanum_upper(2); @ext_integration_password.crypt('$6$'+salt) %>
+
 listen mysql-galera <%=node['bcpc']['management']['vip']%>:3306
   timeout client 24h
   timeout server 24h
@@ -151,12 +154,14 @@ listen ceilometer-api
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8777 check inter 5s rise 1 fall 1" %>
 <% end -%>
 
-listen integrations-server
+listen ext_integration_server
   bind <%=node['bcpc']['management']['vip']%>:8443 <%= (node['bcpc']['protocol']['ext_integration'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source
   option tcplog
   option httpchk GET /
   http-check expect status 200
+  acl AuthOkay_ext_integration http_auth(ext_integration)
+  http-request auth realm openstack.<%= node['bcpc']['cluster_domain'] %> if !AuthOkay_ext_integration
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8443 check inter 5s rise 1 fall 1" %>
 <% end -%>

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -151,6 +151,16 @@ listen ceilometer-api
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8777 check inter 5s rise 1 fall 1" %>
 <% end -%>
 
+listen integrations-server
+  bind <%=node['bcpc']['management']['vip']%>:8443 <%= (node['bcpc']['protocol']['ext_integration'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
+  balance source
+  option tcplog
+  option httpchk GET /
+  http-check expect status 200
+<% @servers.each do |server| -%>
+  <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8443 check inter 5s rise 1 fall 1" %>
+<% end -%>
+
 frontend http
   bind <%=node['bcpc']['management']['vip']%>:80
   option tcplog


### PR DESCRIPTION
This replaces #837 and opens 8443/TCP to allow running arbitrary servers within a cluster that provide endpoints for external integrations.