### PR TITLE
List buckets with prefix and log on failures in rgw check

### DIFF
--- a/cookbooks/bcpc/files/default/checks/rgw
+++ b/cookbooks/bcpc/files/default/checks/rgw
@@ -6,6 +6,7 @@ import boto.s3.connection
 import unittest
 import uuid
 import time
+import syslog
 
 from numpy.random.mtrand import RandomState
 import binascii
@@ -29,10 +30,14 @@ class TestRadosGateway(object):
 
         bucket = self.conn.create_bucket(self.bucket_name)
         if not bucket:
-            return False, "Unable to create s3 bucket"
+            errmsg = 'Unable to create s3 bucket ' + self.bucket_name
+            syslog.syslog(errmsg)
+            return False, errmsg
  
         if self.bucket_name not in [ b.name for b in self.conn.get_all_buckets()] :
-            return False, "Unable to find bucket list" + str(self.conn.get_all_buckets())
+            errmsg = 'Unable to find bucket ' + self.bucket_name
+            syslog.syslog(errmsg)
+            return False, errmsg
 
         rand = RandomState()
         
@@ -50,12 +55,15 @@ class TestRadosGateway(object):
         contents = k.get_contents_as_string()
 
         if contents != 'value':
-            return False, "Return bucket contents no equal to input"
+            errmsg = 'Return bucket contents for ' + key_name + ' not equal to input'
+            syslog.syslog(errmsg)
+            return False, errmsg
  
-        if key_name not in [key.key for key in bucket.list()]:
-            return False, "Key not returned in list bucket contents"  + ",".join(bucket.list())
+        if key_name not in [key.key for key in bucket.list(prefix=key_name)]:
+            errmsg = 'Key ' + key_name + ' not returned in list bucket contents'
+            syslog.syslog(errmsg)
+            return False, errmsg
           
-        
         bucket.delete_key(key_name)
 
         time.sleep(1) # eventually consistent !


### PR DESCRIPTION
`check rgw` occasionally fails, so adding some logging for debugging purposes. We will also prefix `bucket.list()` with key name since rest of bucket contents are not of interest to the check.