### PR TITLE
adding 8080/TCP and 8443/TCP to default open ports

### DIFF
--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -66,7 +66,8 @@ iptables-restore <<EOH
 -A INPUT -i <%= @node["bcpc"]["management"]["interface"] %> -s <%= @node["bcpc"]["monitoring"]["vip"] %> -d <%= @node["bcpc"]["management"]["ip"] %> -p tcp --dport 10050 -j ACCEPT
 
 # Allow external access to some VIP services
-## apache 80, 443
+## apache 80, 443, 8080, 8443
+## radosgw 8088 7480
 ## keystone 5000 35357
 ## glance 9292
 ## cinder 8776
@@ -75,7 +76,7 @@ iptables-restore <<EOH
 ## heat-api 8004
 ## heat-api-cfn 8000
 ## ceilometer-api 8777
--A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --match multiport --dports 80,443,8088,7480,5000,35357,9292,8776,8773,8774,8004,8000,8777 -j ACCEPT
+-A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --match multiport --dports 80,443,8080,8443,8088,7480,5000,35357,9292,8776,8773,8774,8004,8000,8777 -j ACCEPT
 ## powerdns 53
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p udp --dport 53 -j ACCEPT
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --dport 53 -j ACCEPT


### PR DESCRIPTION
This replaces the more extensive PR in #841 with something that just opens 8080/8443 as hooks for additional services to run on.