### PR TITLE
Move firewall TCP ports out of template into attribute

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -166,6 +166,11 @@ default['bcpc']['management']['interface'] = nil
 # if 'interface' is a VLAN interface, specifying a parent allows MTUs
 # to be set properly
 default['bcpc']['management']['interface-parent'] = nil
+# list of TCP ports that should be open on the management interface
+# (generally stuff served via HAProxy)
+default['bcpc']['management']['firewall_tcp_ports'] = [
+  80,443,8088,7480,5000,35357,9292,8776,8773,8774,8004,8000,8777
+]
 
 default['bcpc']['metadata']['ip'] = "169.254.169.254"
 

--- a/cookbooks/bcpc/recipes/networking.rb
+++ b/cookbooks/bcpc/recipes/networking.rb
@@ -104,7 +104,7 @@ end
 end
 
 %w{ storage floating }.each do |net|
-  if not node['bcpc'][net]['interface-parent'].nil? 
+  if not node['bcpc'][net]['interface-parent'].nil?
     template "/etc/network/interfaces.d/iface-#{node['bcpc'][net]['interface-parent']}" do
       source "network.iface-parent.erb"
       owner "root"
@@ -115,7 +115,7 @@ end
                 :mtu => node['bcpc'][net]['mtu'],
                 )
     end
-  end    
+  end
 end
 
 # set up the DNS resolvers
@@ -163,8 +163,8 @@ bash "interface-mgmt-make-static-if-dhcp" do
 end
 
 %w{ management storage floating }.each do |iface|
-  
-  if not node['bcpc'][iface]['interface-parent'].nil? 
+
+  if not node['bcpc'][iface]['interface-parent'].nil?
     bash "#{iface} up" do
       user "root"
       code <<-EOH
@@ -179,7 +179,7 @@ end
         end
     end
   end
-    
+
     bash "#{iface} up" do
         user "root"
         code <<-EOH

--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -75,7 +75,7 @@ iptables-restore <<EOH
 ## heat-api 8004
 ## heat-api-cfn 8000
 ## ceilometer-api 8777
--A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --match multiport --dports 80,443,8088,7480,5000,35357,9292,8776,8773,8774,8004,8000,8777 -j ACCEPT
+-A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --match multiport --dports <%= @node['bcpc']['management']['firewall_tcp_ports'].join(',') %> -j ACCEPT
 ## powerdns 53
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p udp --dport 53 -j ACCEPT
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --dport 53 -j ACCEPT


### PR DESCRIPTION
Third time's the charm, right? This moves the list of open TCP ports in iptables from the template to a list attribute, so that it can be adjusted as needed in the environment/roles.