### PR TITLE
Parameterize limit on whisper files to create per minute

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1309,6 +1309,11 @@ default['bcpc']['graphite']['fqdn'] = "graphite.#{node['bcpc']['cluster_domain']
 # Default retention rates
 # http://graphite.readthedocs.org/en/latest/config-carbon.html#storage-schemas-conf
 default['bcpc']['graphite']['retention'] = '60s:1d'
+#
+# Maximum number of whisper files to create per minute. This is set low to avoid
+# I/O storm when new nodes are enrolled into cluster.
+# Set to 'inf' (infinite) to remove limit.
+default['bcpc']['graphite']['max_creates_per_min'] = '60'
 
 ###########################################
 #

--- a/cookbooks/bcpc/templates/default/carbon.conf.erb
+++ b/cookbooks/bcpc/templates/default/carbon.conf.erb
@@ -60,7 +60,7 @@ MAX_UPDATES_PER_SECOND = 500
 # database files to all get created and thus longer until the data becomes usable.
 # Setting this value high (like "inf" for infinity) will cause graphite to create
 # the files quickly but at the risk of slowing I/O down considerably for a while.
-MAX_CREATES_PER_MINUTE = inf
+MAX_CREATES_PER_MINUTE = <%= node['bcpc']['graphite']['max_creates_per_min'] %>
 
 LINE_RECEIVER_INTERFACE = <%=node['bcpc']['management']['ip']%>
 LINE_RECEIVER_PORT = 2003

--- a/environments/Test-Laptop-VMware.json
+++ b/environments/Test-Laptop-VMware.json
@@ -14,6 +14,9 @@
         "ssd_disks" : [ "sdd", "sde" ],
         "chooseleaf" : "host"
       },
+      "graphite": {
+        "max_creates_per_min": "inf"
+      },
       "nova" : {
         "ram_allocation_ratio" : "20.0",
         "cpu_allocation_ratio": "20.0"

--- a/environments/Test-Laptop-Vagrant.json
+++ b/environments/Test-Laptop-Vagrant.json
@@ -20,6 +20,9 @@
         "ssd_disks" : [ "sdd", "sde" ],
         "chooseleaf" : "host"
       },
+      "graphite": {
+        "max_creates_per_min": "inf"
+      },
       "nova" : {
         "ram_allocation_ratio" : "20.0",
         "cpu_allocation_ratio": "20.0"

--- a/environments/Test-Laptop.json
+++ b/environments/Test-Laptop.json
@@ -16,6 +16,9 @@
         "ssd_disks" : [ "sdd", "sde" ],
         "chooseleaf" : "host"
       },
+      "graphite": {
+        "max_creates_per_min": "inf"
+      },
       "nova" : {
         "ram_allocation_ratio" : "20.0",
         "cpu_allocation_ratio": "20.0"


### PR DESCRIPTION
Enrolling nodes into a cluster can create a storm of whisper files creation as metrics are pushed for the first time. This parameterizes the limit and only lowers the default for non-laptop builds, as waiting at least an hour for availability of all metrics seem undesirable for testing/development purposes.

When a limit is enforced, i.e. 60, you can remove `/opt/graphite/storage/whisper/`entirely from a monitoring node and run `watch 'find /opt/graphite/storage/whisper -type f -print | wc -l'` or similar to observe the rate of whisper files creation.