### PR TITLE
Parameterize nova default log levels

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -549,6 +549,8 @@ default['bcpc']['nova']['live_migration_patch'] = false
 default['bcpc']['nova']['verbose'] = false
 # Nova debug toggle
 default['bcpc']['nova']['debug'] = false
+# Nova default log levels
+default['bcpc']['nova']['default_log_levels'] = nil
 # Nova scheduler default filters
 default['bcpc']['nova']['scheduler_default_filters'] = ['AggregateInstanceExtraSpecsFilter', 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter']
 

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -111,7 +111,9 @@ rootwrap_config=/etc/nova/rootwrap.conf
 verbose=<%= node['bcpc']['nova']['verbose'] %>
 debug=<%= node['bcpc']['nova']['debug'] %>
 ec2_private_dns_show_ip=True
-#default_log_levels="amqplib=DEBUG,sqlalchemy=DEBUG,boto=WARN,suds=INFO,eventlet.wsgi.server=WARN"
+<% if not node['bcpc']['nova']['default_log_levels'].nil? %>
+default_log_levels="<%= node['bcpc']['nova']['default_log_levels'] %>"
+<% end %>
 #rpc_response_timeout=120
 
 # ca_file = /etc/ssl/certs/ssl-bcpc.pem


### PR DESCRIPTION
Parameterizes `default_log_levels` (http://docs.openstack.org/kilo/config-reference/content/list-of-compute-config-options.html) to provide more granular control over logging requirements. For example, `"oslo_concurrency.lockutils=DEBUG, oslo_concurrency.processutils=DEBUG"` can be set to log at DEBUG for oslo_concurrency module without enabling debug [globally](https://github.com/bloomberg/chef-bcpc/blob/master/cookbooks/bcpc/attributes/default.rb#L551).