### PR TITLE
Add PowerDNS master/slave capability

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -207,6 +207,21 @@ default['bcpc']['proxy_server_url'] = nil
 
 ###########################################
 #
+#  PowerDNS master/slave hosting
+#
+###########################################
+# If another cluster is acting as slave NS server, set these up.
+# IP address/full hostname KV pair of slave NS server(s)
+# i.e. '10.0.100.5' => 'openstack.bcpc.example.com'
+default['bcpc']['dns']['slave'] = {}
+#
+# If this cluster hosts slave zones for another cluster, set up supermasters.
+# IP address/full hostname KV pair of master NS server(s)
+# i.e. '10.0.100.5' => 'openstack.bcpc.example.com'
+default['bcpc']['dns']['master'] = {}
+
+###########################################
+#
 #  Repos for things we rely on
 #
 ###########################################

--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -79,6 +79,10 @@ iptables-restore <<EOH
 ## powerdns 53
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p udp --dport 53 -j ACCEPT
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --dport 53 -j ACCEPT
+<% node['bcpc']['dns']['slave'].merge(node['bcpc']['dns']['master']).sort.each do |ip, nameserver| %>
+-A INPUT -i <%= @node["bcpc"]["management"]["interface"] %> -d <%= ip %> -p udp --dport 53 -j ACCEPT
+-A INPUT -i <%= @node["bcpc"]["management"]["interface"] %> -d <%= ip %> -p tcp --dport 53 -j ACCEPT
+<% end %>
 
 <% if node["roles"].include? "BCPC-Monitoring" -%>
 ## kibana 443

--- a/cookbooks/bcpc/templates/default/pdns.conf.erb
+++ b/cookbooks/bcpc/templates/default/pdns.conf.erb
@@ -94,7 +94,7 @@ guardian=yes
 #################################
 # local-address Local IP address to which we bind
 #
-local-address=<%=node['bcpc']['management']['vip']%>
+local-address=<%= node['bcpc']['management']['vip'] %>,<%= node['bcpc']['management']['ip'] %>
 
 #################################
 # local-ipv6    Local IP address to which we bind
@@ -135,6 +135,7 @@ local-port=53
 # master    Act as a master
 #
 # master=no
+master=yes
 
 #################################
 # max-queue-length  Maximum queuelength before considering situation lost
@@ -215,6 +216,7 @@ setuid=pdns
 # slave Act as a slave
 #
 # slave=no
+slave=yes
 
 #################################
 # slave-cycle-interval  Reschedule failed SOA serial checks once every .. seconds

--- a/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
@@ -11,16 +11,27 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
 CREATE TEMPORARY TABLE soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%> (id int);
 <% [@cluster_domain, @reverse_float_zone, @reverse_fixed_zone].each do |zone| %>
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), '<%=zone%>', 'NS', '<%=@management_vip%>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), name='<%=zone%>', type='NS', content='<%=@management_vip%>', bcpc_record_type='STATIC';
+    ((SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), '<%=zone%>', 'NS', 'openstack.<%=@cluster_domain%>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), name='<%=zone%>', type='NS', content='openstack.<%=@cluster_domain%>', bcpc_record_type='STATIC';
+    <% if not node['bcpc']['dns']['slave'].empty? %>
+        <% node['bcpc']['dns']['slave'].sort.each do |ip, nameserver| %>
+            INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
+                ((SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), '<%=zone%>', 'NS', '<%=nameserver%>', 'STATIC')
+                ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), name='<%=zone%>', type='NS', content='<%=nameserver%>', bcpc_record_type='STATIC';
+        <% end %>
+    <% end %>
 
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), '<%=zone%>', 'SOA', '<%=@cluster_domain%> root.<%=@cluster_domain%> <%=get_config('powerdns-update-timestamp')%>', 'static')
-    ON DUPLICATE KEY UPDATE domain_id=(select id from <%=@database_name%>.domains where name='<%=zone%>'), name='<%=zone%>', type='soa', content='<%=@cluster_domain%> root.<%=@cluster_domain%> <%=get_config('powerdns-update-timestamp')%>', bcpc_record_type='STATIC';
+    ((SELECT id FROM <%=@database_name%>.domains WHERE name='<%=zone%>'), '<%=zone%>', 'SOA', 'openstack.<%=@cluster_domain%> root.<%=@cluster_domain%> <%=get_config('powerdns-update-timestamp')%>', 'static')
+    ON DUPLICATE KEY UPDATE domain_id=(select id from <%=@database_name%>.domains where name='<%=zone%>'), name='<%=zone%>', type='soa', content='openstack.<%=@cluster_domain%> root.<%=@cluster_domain%> <%=get_config('powerdns-update-timestamp')%>', bcpc_record_type='STATIC';
 
 INSERT INTO soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%> SELECT id FROM <%=@database_name%>.records WHERE type='SOA' AND name='<%=zone%>' AND id < (SELECT max(id) FROM <%=@database_name%>.records WHERE type='SOA' AND name='<%=zone%>');
 <% end %>
 DELETE FROM <%=@database_name%>.records WHERE id IN (SELECT id FROM soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%>);
+-- Delete old NS/SOA records
+DELETE FROM <%=@database_name%>.records WHERE type = 'NS' AND content = '<%=@management_vip%>';
+DELETE FROM <%=@database_name%>.records WHERE type = 'SOA' AND content LIKE '<%=@cluster_domain%>%';
+
 
 -- insert A records for all BCPC physical hosts
 <% @all_servers.each do |server| %>

--- a/cookbooks/bcpc/templates/default/powerdns_generate_supermaster_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_supermaster_records.sql.erb
@@ -1,0 +1,7 @@
+-- create supermaster records
+<% @master.sort.each do |ip, nameserver| %>
+    INSERT IGNORE INTO <%= @database_name %>.supermasters (ip, nameserver) VALUES ('<%= ip %>', '<%= nameserver %>');
+<% end %>
+
+-- convert PowerDNS natives zones to master
+UPDATE <%= @database_name %>.domains SET type = 'MASTER' WHERE type = 'NATIVE';


### PR DESCRIPTION
Initial draft to add master/slave capability to PowerDNS. This allows hosting of slave zones on an independent cluster.

This also corrects the NS records, as the value should not be a numerical IP address.

Before:
<pre>
;; ANSWER SECTION:
bcpc.example.com.       300     IN      NS      10.0.100.5.
</pre>

After:
<pre>
;; ANSWER SECTION:
bcpc.example.com.       300     IN      NS      openstack.bcpc.example.com.
</pre>

Marking this as do-not-merge until I can write up a test approach.