### PR TITLE
Add reserved tcp ports

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1275,6 +1275,16 @@ default['bcpc']['mysql-head']['max_connections'] = 0
 
 ###########################################
 #
+# BCPC system (systcl) settings
+#
+###########################################
+#
+# Use this to *add* more reserved ports; i.e. modifiy value of
+# net.ipv4.ip_local_reserved_ports
+default['bcpc']['system']['additional_reserved_ports'] = []
+
+###########################################
+#
 # CPU governor settings
 #
 ###########################################

--- a/cookbooks/bcpc/recipes/system.rb
+++ b/cookbooks/bcpc/recipes/system.rb
@@ -24,6 +24,7 @@ template "/etc/sysctl.d/70-bcpc.conf" do
     owner "root"
     group "root"
     mode 00644
+    variables(:additional_reserved_ports => node['bcpc']['system']['additional_reserved_ports'])
     notifies :run, "execute[reload-sysctl]", :immediately
 end
 

--- a/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
+++ b/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
@@ -7,6 +7,10 @@
 # Increase ephermeral IP ports
 net.ipv4.ip_local_port_range = 10000 65000
 
+# Reserve additional ports
+<% default_reserved = [10050,10051,11211,15672,16509,16514,25672,35357,35358,55672] %>
+net.ipv4.ip_local_reserved_ports = <%= ( default_reserved + @additional_reserved_ports ).sort.join(',') %>
+
 # Increase Linux autotuning TCP buffer limits
 # Set max to 16MB for 1GE and 32M (33554432) or 54M (56623104) for 10GE
 # Don't set tcp_mem itself! Let the kernel scale it based on RAM.


### PR DESCRIPTION
Prevents potential confict with expanded ephemeral port range:

zabbix      10050,10051
memcached   11211
rabbitmq    15672,55672
libvirtd    16509,16514
erlang      25672
keystone    35357,35358

Also allows configuration of ports additional to the hard-coded defaults above. Initially, I toyed with idea of calling `uniq` on the array/summarizing the ranges, but the kernel is generous enough to do so. Also, no doing so will make duplicates in the attributes file more obvious.

If everything works, this should be the following output by default:
```
$ cat /proc/sys/net/ipv4/ip_local_reserved_ports
10050-10051,11211,15672,16509,16514,25672,35357-35358,55672
```