### PR TITLE
Increase default MySQL connections to ease multi-headnode deployments

### DIFF
--- a/cookbooks/bcpc/recipes/mysql-head.rb
+++ b/cookbooks/bcpc/recipes/mysql-head.rb
@@ -58,7 +58,7 @@ template "/etc/mysql/debian.cnf" do
 end
 
 if node['bcpc']['mysql-head']['max_connections'] == 0 then
-    node.default['bcpc']['mysql-head']['max_connections'] = [get_head_nodes.length*150+get_all_nodes.length*10, 200].max
+    node.default['bcpc']['mysql-head']['max_connections'] = [get_head_nodes.length*150+get_all_nodes.length*10, 450].max
 end
 
 template "/etc/mysql/conf.d/wsrep.cnf" do


### PR DESCRIPTION
This is a small change to boost the number of MySQL connections (again) to ease multi-head node deployments, by setting the minimum number of connections equivalent to a 3-head node cluster. This allows us to avoid the annoyance of having to rechef head nodes in some sort of pyramidal order in order  to avoid random convergence failures and 500 responses from APIs due to connections running out.