### PR TITLE
Parameterize sysctl

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1275,13 +1275,15 @@ default['bcpc']['mysql-head']['max_connections'] = 0
 
 ###########################################
 #
-# BCPC system (systcl) settings
+# BCPC system (sysctl) settings
 #
 ###########################################
 #
-# Use this to *add* more reserved ports; i.e. modifiy value of
+# Use this to *add* more reserved ports; i.e. modify value of
 # net.ipv4.ip_local_reserved_ports
 default['bcpc']['system']['additional_reserved_ports'] = []
+# Any other sysctl parameters
+default['bcpc']['system']['parameters'] = {}
 
 ###########################################
 #

--- a/cookbooks/bcpc/recipes/system.rb
+++ b/cookbooks/bcpc/recipes/system.rb
@@ -24,7 +24,10 @@ template "/etc/sysctl.d/70-bcpc.conf" do
     owner "root"
     group "root"
     mode 00644
-    variables(:additional_reserved_ports => node['bcpc']['system']['additional_reserved_ports'])
+    variables(
+        :additional_reserved_ports => node['bcpc']['system']['additional_reserved_ports'],
+        :parameters                => node['bcpc']['system']['parameters']
+    )
     notifies :run, "execute[reload-sysctl]", :immediately
 end
 

--- a/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
+++ b/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
@@ -50,3 +50,9 @@ net.ipv4.ip_nonlocal_bind=1
 # Avoid swapping
 vm.swappiness = 0
 vm.min_free_kbytes = 135168
+<% if not @parameters.empty? %>
+# Customized parameters
+<% @parameters.sort.each do |key, value| %>
+<%= key %> = <%= value %>
+<% end %>
+<% end %>


### PR DESCRIPTION
This allows additional non-default system parameters to be set via Chef. For example, in an environment file:
<pre>
    ...
    "bcpc": {
      "system": {
        "parameters": {
          "kernel.shmmax": 33554432,
          "kernel.shmall": 2097152
        }
      },
      ...
</pre>

