### PR TITLE
Various fixes to smooth 2015.1.0 -> 2015.1.1 upgrade

### DIFF
--- a/cookbooks/bcpc/recipes/ceph-common.rb
+++ b/cookbooks/bcpc/recipes/ceph-common.rb
@@ -24,6 +24,15 @@ apt_repository "ceph" do
   distribution node['lsb']['codename']
   components ["main"]
   key "ceph-release.key"
+  notifies :run, "execute[apt-get update]", :immediately
+end
+
+# delete the compromised Ceph signing key from existing systems
+bash "remove-old-ceph-key" do
+  code <<-EOH
+    apt-key del 17ED316D
+  EOH
+  only_if "apt-key list | grep -q 17ED316D"
 end
 
 if platform?("debian", "ubuntu")

--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -28,8 +28,11 @@ ruby_block "initialize-glance-config" do
     end
 end
 
-package "glance" do
+%w{glance glance-api glance-registry}.each do |pkg|
+  package pkg do 
     action :upgrade
+    options "-o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'"
+  end
 end
 
 %w{glance-api glance-registry}.each do |svc|

--- a/cookbooks/bcpc/recipes/heat.rb
+++ b/cookbooks/bcpc/recipes/heat.rb
@@ -27,13 +27,17 @@ ruby_block "initialize-heat-config" do
     end
 end
 
-%w{heat-api heat-api-cfn heat-engine}.each do |pkg|
-    package pkg do
-        action :upgrade
-    end
-    service pkg do
-        action [:enable, :start]
-    end
+%w{heat-common heat-api heat-api-cfn heat-engine}.each do |pkg|
+  package pkg do
+    action :upgrade
+    options "-o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'"
+  end
+end
+
+%w{heat-api heat-api-cfn heat-engine}.each do |svc|
+  service svc do
+    action [:enable, :start]
+  end
 end
 
 service "heat-api" do

--- a/cookbooks/bcpc/recipes/horizon.rb
+++ b/cookbooks/bcpc/recipes/horizon.rb
@@ -29,9 +29,20 @@ ruby_block "initialize-horizon-config" do
     end
 end
 
+# this cretinous split of the resource is done to accommodate the fact
+# that if you upgrade the package, static asset regeneration will bomb out,
+# so ignore_failure is set when doing an upgrade
+package "openstack-dashboard" do
+    action :install
+    notifies :run, "bash[dpkg-reconfigure-openstack-dashboard]", :delayed
+    not_if "dpkg -S openstack-dashboard >/dev/null 2>&1"
+end
+
 package "openstack-dashboard" do
     action :upgrade
+    ignore_failure true
     notifies :run, "bash[dpkg-reconfigure-openstack-dashboard]", :delayed
+    only_if "dpkg -S openstack-dashboard >/dev/null 2>&1"
 end
 
 #  _   _  ____ _  __   __  ____   _  _____ ____ _   _


### PR DESCRIPTION
This accommodates a couple of failure cases I encountered when doing an in-place upgrade of OpenStack 2015.1.0 to 2015.1.1:

- removed compromised Ceph signing key from existing systems
- provided dpkg options for Glance/Heat upgrades that automatically
  answer the questions about whether to keep or replace config files
  (these options will keep ours, which are managed by Chef)
- added a terrible hack to distinguish installing Horizon vs upgrading
  it and ignoring failures when upgrading because static asset
  compression bombs out (known upstream issue)