### PR TITLE
Remove use_bootstrap_v2 toggle that is no longer needed

### DIFF
--- a/cookbooks/bcpc/recipes/rally.rb
+++ b/cookbooks/bcpc/recipes/rally.rb
@@ -58,7 +58,7 @@ cookbook_file "/tmp/rally.tar.gz" do
     mode 00444
 end
 
-pip_version = node['bcpc']['use_bootstrap_v2'] ? '7.0.3' : '6.1.1'
+pip_version = '7.0.3'
 
 cookbook_file "/tmp/python-pip_#{pip_version}_all.deb" do
     source "bins/python-pip_#{pip_version}_all.deb"

--- a/environments/Test-Laptop-Vagrant.json
+++ b/environments/Test-Laptop-Vagrant.json
@@ -2,7 +2,6 @@
   "name": "Test-Laptop-Vagrant",
   "override_attributes": {
     "bcpc": {
-      "use_bootstrap_v2": true,
       "vagrant": {
         "nat_ip": "10.0.2.15"
       },


### PR DESCRIPTION
This toggle originally gated more things, but they've all been removed, and we can safely use pip 7.0.3 for Rally.