### PR TITLE
Removing explicit package versions, adding repository pins

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -36,19 +36,6 @@ default['bcpc']['s3_ssl_intermediate_certificate'] = nil
 
 ###########################################
 #
-# Package versions
-#
-###########################################
-default['bcpc']['elasticsearch']['version'] = '1.5.1'
-default['bcpc']['ceph']['version'] = '0.94.5-1trusty'
-default['bcpc']['ceph']['version_number'] = '0.94.5'
-default['bcpc']['erlang']['version'] = '1:17.5.3'
-default['bcpc']['haproxy']['version'] = '1.5.15-1ppa1~trusty'
-default['bcpc']['kibana']['version'] = '4.0.2'
-default['bcpc']['rabbitmq']['version'] = '3.6.0-1'
-
-###########################################
-#
 #  Flags to enable/disable BCPC cluster features
 #
 ###########################################
@@ -64,7 +51,9 @@ default['bcpc']['enabled']['dns'] = true
 default['bcpc']['enabled']['host_firewall'] = true
 # This will enable of encryption of the chef data bag
 default['bcpc']['enabled']['encrypt_data_bag'] = false
-# This will enable auto-upgrades on all nodes (not recommended for stability)
+# These will enable automatic dist-upgrade/upgrade at the start of a Chef run
+# (not recommended for stability)
+default['bcpc']['enabled']['apt_dist_upgrade'] = false
 default['bcpc']['enabled']['apt_upgrade'] = false
 # This will enable running apt-get update at the start of every Chef run
 default['bcpc']['enabled']['always_update_package_lists'] = true

--- a/cookbooks/bcpc/recipes/ceph-common.rb
+++ b/cookbooks/bcpc/recipes/ceph-common.rb
@@ -38,23 +38,12 @@ if platform?("debian", "ubuntu")
     include_recipe "bcpc::networking"
 end
 
-cookbook_file "/usr/local/bin/apt-pkg-check-version" do
-    source "apt-pkg-check-version"
-    owner "root"
-    mode 00755
-end
-
-bash "check-ceph-version" do
-    code <<-EOH
-        /usr/local/bin/apt-pkg-check-version ceph #{node['bcpc']['ceph']['version_number']}
-        exit $?
-	EOH
-end
-
 %w{librados2 librbd1 libcephfs1 python-ceph ceph ceph-common ceph-fs-common ceph-mds ceph-fuse}.each do |pkg|
   package pkg do
+    # use Ceph repository instead of UCA
+    # UCA release looks like "trusty-proposed" or "trusty-updates"
+    default_release 'trusty'
     action :upgrade
-    version node['bcpc']['ceph']['version']
   end
 end
 

--- a/cookbooks/bcpc/recipes/ceph-rgw.rb
+++ b/cookbooks/bcpc/recipes/ceph-rgw.rb
@@ -25,8 +25,8 @@ include_recipe "bcpc::apache2"
 include_recipe "bcpc::ceph-work"
 
 package "radosgw" do
-    action :install
-    version node['bcpc']['ceph']['version']
+  default_release 'trusty'  # use Ceph repository instead of UCA
+  action :upgrade
 end
 
 package "python-boto"
@@ -122,7 +122,7 @@ end
 service "radosgw-all" do
   provider Chef::Provider::Service::Upstart
   action [ :enable, :start ]
-end 
+end
 
 ruby_block "initialize-radosgw-admin-user" do
     block do

--- a/cookbooks/bcpc/recipes/elasticsearch.rb
+++ b/cookbooks/bcpc/recipes/elasticsearch.rb
@@ -28,11 +28,6 @@ if node['bcpc']['enabled']['logging'] then
         key 'elasticsearch.key'
     end
 
-    apt_preference 'elasticsearch' do
-        pin          "version #{node['bcpc']['elasticsearch']['version']}"
-        pin_priority '600'
-    end
-
     package "openjdk-7-jre-headless" do
         action :install
     end

--- a/cookbooks/bcpc/recipes/haproxy-common.rb
+++ b/cookbooks/bcpc/recipes/haproxy-common.rb
@@ -34,8 +34,7 @@ apt_repository "haproxy" do
 end
 
 package "haproxy" do
-    action :install
-    version node['bcpc']['haproxy']['version']
+    action :upgrade
 end
 
 bash "enable-defaults-haproxy" do

--- a/cookbooks/bcpc/recipes/packages-common.rb
+++ b/cookbooks/bcpc/recipes/packages-common.rb
@@ -15,34 +15,39 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
-
 
 # This recipe installs OS packages which are required by all node types.
 
+# run apt-get update at the start of every Chef run if so configured
+if node['bcpc']['enabled']['always_update_package_lists'] then
+  bash "run-apt-get-update" do
+    user "root"
+    code "DEBIAN_FRONTEND=noninteractive apt-get update"
+  end
+end
+
 package 'patch'
-package 'sshpass'  # GitHub #112 -- required for nodessh.sh 
+package 'sshpass'  # GitHub #112 -- required for nodessh.sh
 # logtail is used for some zabbix checks
 package 'logtail'
 
 # Remove spurious logging failures from this package
 package "powernap" do
-    action :remove
+  action :remove
 end
 
-if node['bcpc']['enabled']['apt_upgrade'] then
-    include_recipe "apt::default"
-    bash "perform-upgrade" do
-        user "root"
-        code "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade"
-    end
+if node['bcpc']['enabled']['apt_dist_upgrade']
+  include_recipe "apt::default"
+  bash "perform-dist-upgrade" do
+    user "root"
+    code "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" dist-upgrade"
+  end
 end
 
-# run apt-get update at the start of every Chef run if so configured
-if node['bcpc']['enabled']['always_update_package_lists'] then
-    bash "run-apt-get-update" do
-        user "root"
-        code "DEBIAN_FRONTEND=noninteractive apt-get update"
-    end
+if node['bcpc']['enabled']['apt_upgrade']
+  include_recipe "apt::default"
+  bash "perform-upgrade" do
+    user "root"
+    code "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade"
+  end
 end

--- a/cookbooks/bcpc/recipes/rabbitmq.rb
+++ b/cookbooks/bcpc/recipes/rabbitmq.rb
@@ -41,44 +41,8 @@ apt_repository "rabbitmq" do
     key "rabbitmq.key"
 end
 
-%w{
-   erlang-base
-   erlang-syntax-tools
-   erlang-mnesia
-   erlang-runtime-tools
-   erlang-crypto
-   erlang-asn1
-   erlang-public-key
-   erlang-ssl
-   erlang-inets
-   erlang-corba
-   erlang-diameter
-   erlang-xmerl
-   erlang-edoc
-   erlang-eldap
-   erlang-erl-docgen
-   erlang-eunit
-   erlang-ic
-   erlang-inviso
-   erlang-odbc
-   erlang-snmp
-   erlang-os-mon
-   erlang-parsetools
-   erlang-percept
-   erlang-ssh
-   erlang-webtool
-   erlang-tools
-   erlang-nox
-}.each do |erlang_package|
-  package erlang_package do
-    action :install
-    version node['bcpc']['erlang']['version']
-  end
-end
-
 package "rabbitmq-server" do
-    action :install
-    version node['bcpc']['rabbitmq']['version']
+    action :upgrade
     notifies :stop, "service[rabbitmq-server]", :immediately
 end
 

--- a/docs/upgrading_rabbitmq_or_erlang.md
+++ b/docs/upgrading_rabbitmq_or_erlang.md
@@ -1,0 +1,20 @@
+Upgrading RabbitMQ or Erlang
+===
+
+If upgrading RabbitMQ or Erlang in a multi-head node cluster, please read the guide below.
+
+Per the [RabbitMQ guide to upgrading](https://www.rabbitmq.com/clustering.html#upgrading), a single cluster can run with different minor RabbitMQ versions, but all RabbitMQ nodes must be using the same Erlang version.
+
+If upgrading between minor RabbitMQ versions, things should continue to operate without drama throughout. Using `hup_openstack` to restart services on each head node in turn may help clear up any lingering issues.
+
+If upgrading Erlang:
+
+1. Stop RabbitMQ on all nodes but one with `sudo service rabbitmq-server stop` (ideally keep the one that is holding the stats role running).
+2. Upgrade Erlang on the running node and restart RabbitMQ.
+3. Verify that the node has restarted properly.
+4. Upgrade each other RabbitMQ node in turn.
+
+If upgrading major RabbitMQ versions:
+
+1. Read RabbitMQ's release notes carefully for any issues that may be encountered in upgrading from one major version to another.
+2. Follow the steps for an Erlang upgrade, stopping all nodes but one and gradually reintroducing upgraded nodes into the cluster.


### PR DESCRIPTION
Explicit package version pinning was never successful and only made it more difficult to build master, especially with badly behaved upstream repositories that purged older versions of packages when new ones were released. In practice, we control the versions of software that are installed on clusters via local mirrors.

**Two important notes**: 

1. deploying this to an existing cluster will uncork an upgrade to Erlang 18.x that was previously being thwarted. If deploying to a multi-head node cluster, please read `docs/upgrading_rabbitmq_or_erlang.md` (included in this pull request).
2. Repository pins have been added to encourage apt to prefer packages from those repositories using **origin**. An unfortunate side effect of maintaining a local mirror is that every locally mirrored repository will have the same origin, negating the repository pin. (It is not possible to specify anything more than a simple hostname for the origin, which can be verified by editing the origin statement and then checking `apt-cache policy` output for an affected package.) This does not seem to be a problem at present, but could for example cause issues if the same version of Ceph were provided by both the Ceph mirror and Ubuntu Cloud Archive and apt for some reason decided to newly prefer the one from UCA over Ceph. I am open to suggestions on how to work around this.