### PR TITLE
Gate nova-volume-boot-size patch to only apply to 2015.1.0/2015.1.1

### DIFF
--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -310,10 +310,12 @@ end
 
 # this patch patches Nova to work correctly if you attempt to boot an instance from
 # a root volume larger than the root volume specified by the flavor
+# upstream bug #1457517 - only needed for 2015.1.0 and 2015.1.1
 bcpc_patch "nova-volume-boot-size" do
   patch_file           'nova-volume-boot-size.patch'
   patch_root_dir       '/usr/lib/python2.7/dist-packages'
   shasums_before_apply 'nova-volume-boot-size-BEFORE.SHASUMS'
   shasums_after_apply  'nova-volume-boot-size-AFTER.SHASUMS'
   notifies :restart, 'service[nova-api]', :immediately
+  only_if "dpkg -s python-nova | egrep -q '^Version: 1:2015.1.(0|1)'"
 end


### PR DESCRIPTION
This is the only patch that does not apply cleanly onto 2015.1.2, because it is already included in 2015.1.2. Added gate to prevent it from applying to versions other than 2015.1.0 and 2015.1.1.