### PR TITLE
Fixes #513 - makes scrub load threshold configurable

### DIFF
--- a/cookbooks/bcpc/attributes/ceph.rb
+++ b/cookbooks/bcpc/attributes/ceph.rb
@@ -12,6 +12,7 @@ default['bcpc']['ceph']['pgp_auto_adjust'] = false
 # Need to review...
 default['bcpc']['ceph']['pgs_per_node'] = 1024
 default['bcpc']['ceph']['max_pgs_per_osd'] = 300
+default['bcpc']['ceph']['osd_scrub_load_threshold'] = 0.5
 # Set to 0 to disable. See http://tracker.ceph.com/issues/8103
 default['bcpc']['ceph']['pg_warn_max_obj_skew'] = 10
 # Journal size could be 10GB or higher in some cases

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -36,6 +36,7 @@
     osd mount options xfs = noexec,nodev,noatime,nodiratime,barrier=0,discard
     osd crush update on start = false
     osd client op priority = 63
+    osd scrub load threshold = <%= @node['bcpc']['ceph']['osd_scrub_load_threshold'] %>
 <% if @node["bcpc"]["ceph"]["rebalance"] %>
     osd recovery max active = 1
     osd max backfills  = 1


### PR DESCRIPTION
This fixes a longstanding issue where scrubs on OSDs on many machines would never happen, because the load threshold is set at a very low 0.5. This makes the threshold configurable.