### PR TITLE
Fixes to allow upgrading OpenStack in place to 2015.1.2

### DIFF
--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -28,8 +28,11 @@ ruby_block "initialize-glance-config" do
     end
 end
 
-package "glance" do
+%w{glance glance-api glance-registry}.each do |pkg|
+  package pkg do 
     action :upgrade
+    options "-o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'"
+  end
 end
 
 %w{glance-api glance-registry}.each do |svc|

--- a/cookbooks/bcpc/recipes/heat.rb
+++ b/cookbooks/bcpc/recipes/heat.rb
@@ -28,13 +28,17 @@ if node['bcpc']['enabled']['heat']
       end
   end
 
-  %w{heat-api heat-api-cfn heat-engine}.each do |pkg|
-      package pkg do
-          action :upgrade
-      end
-      service pkg do
-          action [:enable, :start]
-      end
+  %w{heat-common heat-api heat-api-cfn heat-engine}.each do |pkg|
+    package pkg do
+      action :upgrade
+      options "-o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'"
+    end
+  end
+
+  %w{heat-api heat-api-cfn heat-engine}.each do |svc|
+    service svc do
+      action [:enable, :start]
+    end
   end
 
   service "heat-api" do

--- a/cookbooks/bcpc/recipes/horizon.rb
+++ b/cookbooks/bcpc/recipes/horizon.rb
@@ -29,9 +29,18 @@ ruby_block "initialize-horizon-config" do
     end
 end
 
+# this resource exists as a little trick to ensure the upgrade goes
+# smoothly even if the dashboard Apache configuration is in the old
+# place that blows up the postinst script
+file "/etc/apache2/conf-available/openstack-dashboard.conf" do
+  action :create_if_missing
+end
+
+# options specified to keep dpkg from complaining that the config file exists already
 package "openstack-dashboard" do
-    action :upgrade
-    notifies :run, "bash[dpkg-reconfigure-openstack-dashboard]", :delayed
+  action :upgrade
+  options "-o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'"
+  notifies :run, "bash[dpkg-reconfigure-openstack-dashboard]", :delayed
 end
 
 #  _   _  ____ _  __   __  ____   _  _____ ____ _   _


### PR DESCRIPTION
This can stand alone but can and should also be tested in conjunction with #875. I tested this both standalone and combined on local builds, and merged it with #875 when deploying on lab hardware to upgrade from the current production cluster configuration to the most recent Kilo patch release.

I wouldn't recommend merging it until we're ready to cut another major release.