### PR TITLE
Toggle to disable Heat

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -76,6 +76,8 @@ default['bcpc']['enabled']['tpm'] = false
 default['bcpc']['enabled']['secure_fixed_networks'] = true
 # Toggle to enable/disable swap memory
 default['bcpc']['enabled']['swap'] = true
+# Toggle to enable/disable Heat (OpenStack Cloud Formation)
+default['bcpc']['enabled']['heat'] = false
 
 # If radosgw_cache is enabled, default to 20MB max file size
 default['bcpc']['radosgw']['cache_max_file_size'] = 20000000

--- a/cookbooks/bcpc/recipes/heat.rb
+++ b/cookbooks/bcpc/recipes/heat.rb
@@ -20,70 +20,81 @@
 include_recipe "bcpc::mysql-head"
 include_recipe "bcpc::openstack"
 
-ruby_block "initialize-heat-config" do
-    block do
-        make_config('mysql-heat-user', "heat")
-        make_config('mysql-heat-password', secure_password)
+if node['bcpc']['enabled']['heat']
+  ruby_block "initialize-heat-config" do
+      block do
+          make_config('mysql-heat-user', "heat")
+          make_config('mysql-heat-password', secure_password)
+      end
+  end
+
+  %w{heat-api heat-api-cfn heat-engine}.each do |pkg|
+      package pkg do
+          action :upgrade
+      end
+      service pkg do
+          action [:enable, :start]
+      end
+  end
+
+  service "heat-api" do
+      restart_command "service heat-api restart; sleep 5"
+  end
+
+  template "/etc/heat/heat.conf" do
+      source "heat.conf.erb"
+      owner "heat"
+      group "heat"
+      mode 00600
+      variables(:servers => get_head_nodes)
+      notifies :restart, "service[heat-api]", :delayed
+      notifies :restart, "service[heat-api-cfn]", :delayed
+      notifies :restart, "service[heat-engine]", :delayed
+  end
+
+  template "/etc/heat/policy.json" do
+      source "heat-policy.json.erb"
+      owner "heat"
+      group "heat"
+      mode 00600
+      variables(:policy => JSON.pretty_generate(node['bcpc']['heat']['policy']))
+  end
+
+  directory "/etc/heat/environment.d" do
+      user "heat"
+      group "heat"
+      mode 00755
+  end
+
+  ruby_block "heat-database-creation" do
+      block do
+          %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+              mysql -uroot -e "CREATE DATABASE #{node['bcpc']['dbname']['heat']};"
+              mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['heat']}.* TO '#{get_config('mysql-heat-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-heat-password')}';"
+              mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['heat']}.* TO '#{get_config('mysql-heat-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-heat-password')}';"
+              mysql -uroot -e "FLUSH PRIVILEGES;"
+          ]
+          self.notifies :run, "bash[heat-database-sync]", :immediately
+          self.resolve_notification_references
+      end
+      not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['heat']}\"'|grep \"#{node['bcpc']['dbname']['heat']}\" >/dev/null" }
+  end
+
+  bash "heat-database-sync" do
+      action :nothing
+      user "root"
+      code "heat-manage db_sync"
+      notifies :restart, "service[heat-api]", :immediately
+      notifies :restart, "service[heat-api-cfn]", :immediately
+      notifies :restart, "service[heat-engine]", :immediately
+  end
+else
+  %w{heat-api heat-api-cfn heat-engine}.each do |svc|
+    service svc do
+      action [:disable, :stop]
+      only_if {
+        ::File.exist?(::File.join('/etc','init',"#{svc}.conf"))
+      }
     end
-end
-
-%w{heat-api heat-api-cfn heat-engine}.each do |pkg|
-    package pkg do
-        action :upgrade
-    end
-    service pkg do
-        action [:enable, :start]
-    end
-end
-
-service "heat-api" do
-    restart_command "service heat-api restart; sleep 5"
-end
-
-template "/etc/heat/heat.conf" do
-    source "heat.conf.erb"
-    owner "heat"
-    group "heat"
-    mode 00600
-    variables(:servers => get_head_nodes)
-    notifies :restart, "service[heat-api]", :delayed
-    notifies :restart, "service[heat-api-cfn]", :delayed
-    notifies :restart, "service[heat-engine]", :delayed
-end
-
-template "/etc/heat/policy.json" do
-    source "heat-policy.json.erb"
-    owner "heat"
-    group "heat"
-    mode 00600
-    variables(:policy => JSON.pretty_generate(node['bcpc']['heat']['policy']))
-end
-
-directory "/etc/heat/environment.d" do
-    user "heat"
-    group "heat"
-    mode 00755
-end
-
-ruby_block "heat-database-creation" do
-    block do
-        %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
-            mysql -uroot -e "CREATE DATABASE #{node['bcpc']['dbname']['heat']};"
-            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['heat']}.* TO '#{get_config('mysql-heat-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-heat-password')}';"
-            mysql -uroot -e "GRANT ALL ON #{node['bcpc']['dbname']['heat']}.* TO '#{get_config('mysql-heat-user')}'@'localhost' IDENTIFIED BY '#{get_config('mysql-heat-password')}';"
-            mysql -uroot -e "FLUSH PRIVILEGES;"
-        ]
-        self.notifies :run, "bash[heat-database-sync]", :immediately
-        self.resolve_notification_references
-    end
-    not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \"#{node['bcpc']['dbname']['heat']}\"'|grep \"#{node['bcpc']['dbname']['heat']}\" >/dev/null" }
-end
-
-bash "heat-database-sync" do
-    action :nothing
-    user "root"
-    code "heat-manage db_sync"
-    notifies :restart, "service[heat-api]", :immediately
-    notifies :restart, "service[heat-api-cfn]", :immediately
-    notifies :restart, "service[heat-engine]", :immediately
+  end
 end


### PR DESCRIPTION
This PR adds a toggle to enable/disable Heat and turns Heat off by default, because we do not use it. With **bcpc.enabled.heat** set to **true**, this is a no-op. With it set to **false**, it will either not create anything for Heat, or will stop and disable Heat services if already installed (will not remove any existing Heat configuration or databases).