### PR TITLE
adding Vim to default package installations

### DIFF
--- a/cookbooks/bcpc/recipes/developer.rb
+++ b/cookbooks/bcpc/recipes/developer.rb
@@ -21,3 +21,4 @@
 #
 
 package "emacs24-nox"
+package "vim"


### PR DESCRIPTION
Because I don't like emacs and am tired of seeing this:
```
# vim blah
The program 'vim' can be found in the following packages:
 * vim
 * vim-gnome
 * vim-tiny
 * vim-athena
 * vim-gtk
 * vim-nox
```