### PR TITLE
Do not automatically remove Ceph OSDs/mons

### DIFF
--- a/cookbooks/bcpc/recipes/ceph-head.rb
+++ b/cookbooks/bcpc/recipes/ceph-head.rb
@@ -66,7 +66,7 @@ ruby_block "wait-for-mon-quorum" do
         status = { 'state' => '' }
         until %w{leader peon}.include?(status['state']) do
             if clock >= timeout
-              fail "Exceeded quorum wait timeout of #{timeout} seconds, check Ceph status with ceph -s and ceph health detail" 
+              fail "Exceeded quorum wait timeout of #{timeout} seconds, check Ceph status with ceph -s and ceph health detail"
             end
             Chef::Log.warn("Waiting for ceph-mon to get quorum...")
             status = JSON.parse(%x[ceph --admin-daemon /var/run/ceph/ceph-mon.#{node['hostname']}.asok mon_status])
@@ -90,18 +90,6 @@ template "/etc/sudoers.d/monstatus" do
     user "root"
     group "root"
     mode 00440
-end
-
-ruby_block "reap-dead-ceph-mon-servers" do
-    block do
-        head_names = get_head_nodes.collect { |x| x['hostname'] }
-        status = JSON.parse(%x[ceph --admin-daemon /var/run/ceph/ceph-mon.#{node['hostname']}.asok mon_status])
-        status['monmap']['mons'].collect { |x| x['name'] }.each do |server|
-            if not head_names.include?(server)
-                %x[ ceph mon remove #{server} ]
-            end
-        end
-    end
 end
 
 bash "initialize-ceph-admin-and-osd-config" do
@@ -240,10 +228,10 @@ end
 end
 
 %w{noscrub nodeep-scrub}.each do |flag|
-  if node['bcpc']['ceph']['rebalance'] 
+  if node['bcpc']['ceph']['rebalance']
     execute "ceph-osd-set-#{flag}" do
       command "ceph osd set #{flag}"
-      only_if "ceph health"    
+      only_if "ceph health"
     end
   else
     execute "ceph-osd-unset-#{flag}" do

--- a/cookbooks/bcpc/recipes/ceph-osd.rb
+++ b/cookbooks/bcpc/recipes/ceph-osd.rb
@@ -21,23 +21,6 @@ execute "trigger-osd-startup" do
     command "udevadm trigger --subsystem-match=block --action=add"
 end
 
-ruby_block "reap-ceph-disks-from-dead-servers" do
-    block do
-        storage_ips = search_nodes("recipe", "ceph-osd").collect { |x| x['bcpc']['storage']['ip'] }
-        status = JSON.parse(%x[ceph osd dump --format=json])
-        status['osds'].select { |x| x['up']==0 && x['in']==0 }.each do |osd|
-            osd_ip = osd['public_addr'][/[^:]*/]
-            if osd_ip != "" and not storage_ips.include?(osd_ip)
-                %x[
-                    ceph osd crush remove osd.#{osd['osd']}
-                    ceph osd rm osd.#{osd['osd']}
-                    ceph auth del osd.#{osd['osd']}
-                ]
-            end
-        end
-    end
-end
-
 template '/etc/init/ceph-osd-renice.conf' do
   source 'ceph-upstart.ceph-osd-renice.conf.erb'
   mode 00644


### PR DESCRIPTION
@mihalis68 and I had talked about this previously and agreed that this was undesirable behavior. A Chef run should not do anything destructive, particularly regarding storage systems. This PR removes the auto-reap behavior for both OSDs and monitors to avoid the possibility of something bad happening if Chef gets a bit weird.