### PR TITLE
Do not automatically remove RabbitMQ cluster nodes

### DIFF
--- a/cookbooks/bcpc/recipes/rabbitmq.rb
+++ b/cookbooks/bcpc/recipes/rabbitmq.rb
@@ -194,18 +194,6 @@ template "/etc/xinetd.d/amqpchk" do
     notifies :restart, "service[xinetd]", :immediately
 end
 
-ruby_block "reap-dead-rabbitmq-servers" do
-    block do
-        head_names = get_head_nodes.collect { |x| x['hostname'] }
-        status = %x[ rabbitmqctl cluster_status | grep nodes | grep disc ].strip
-        status.scan(/(?:'rabbit@([a-zA-Z0-9-]+)',?)+?/).each do |server|
-            if not head_names.include?(server[0])
-                %x[ rabbitmqctl forget_cluster_node rabbit@#{server[0]} ]
-            end
-        end
-    end
-end
-
 template "/etc/sudoers.d/rabbitmqctl" do
     source "sudoers-rabbitmqctl.erb"
     user "root"


### PR DESCRIPTION
Similar to #890, this removes the behavior that could cause a head node's RabbitMQ instance to be reaped automatically if something went wrong with node search.