### PR TITLE
Do not auto-reap Nova services when removed from Chef

### DIFF
--- a/cookbooks/bcpc/recipes/nova-head.rb
+++ b/cookbooks/bcpc/recipes/nova-head.rb
@@ -51,20 +51,5 @@ end
     end
 end
 
-ruby_block "reap-dead-servers-from-nova" do
-    block do
-        all_hosts = search_nodes("recipe", "nova-work").collect { |x| x['hostname'] }
-        nova_hosts = %x[nova-manage service list 2>/dev/null | awk '{print $2}' | grep -ve "^Host$" | uniq].split
-        nova_hosts.each do |host|
-            if not all_hosts.include?(host)
-                %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
-                    mysql -uroot #{node['bcpc']['dbname']['nova']} -e "DELETE FROM services WHERE host=\\"#{host}\\";"
-                    mysql -uroot #{node['bcpc']['dbname']['nova']} -e "DELETE FROM compute_nodes WHERE hypervisor_hostname=\\"#{host}\\";"
-                ]
-            end
-        end
-    end
-end
-
 include_recipe "bcpc::nova-work"
 include_recipe "bcpc::nova-setup"


### PR DESCRIPTION
I'm slightly more ambivalent about this one than #890 and #891, because removing this would mean we would need to do manual cleanup of Nova services if we undeploy hypervisors from a cluster (a more likely scenario than permanently removing head nodes). However, I do not like that it manually reaches into the database and deletes rows; the same can be accomplished via `nova service-delete` using IDs given by `nova service-list`. At most, this resource should be changed to do that instead of fiddling with the database.