### PR TITLE
Update nova-network Zabbix trigger

### DIFF
--- a/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
+++ b/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
@@ -4909,7 +4909,7 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{BCPC-Worknode:proc.num[python,nova,,nova-network].last(0)}&lt;&gt;1</expression>
+            <expression>{BCPC-Worknode:proc.num[python,nova,,nova-network].last(0)}&lt;1 or {BCPC-Worknode:proc.num[python,nova,,nova-network].last(0)}&gt;2</expression>
             <name>Service Nova Network down on {HOST.NAME}</name>
             <url/>
             <status>0</status>


### PR DESCRIPTION
`nova-network` periodically forks a child process and that causes false alarms. When cheffed into an existing cluster, the old trigger needs to be removed manually via https://10.0.100.5/zabbix/triggers.php.