### PR TITLE
raising kernel.pid_max to the maximum allowable setting

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1288,8 +1288,8 @@ default['bcpc']['mysql-head']['max_connections'] = 0
 # Use this to *add* more reserved ports; i.e. modify value of
 # net.ipv4.ip_local_reserved_ports
 default['bcpc']['system']['additional_reserved_ports'] = []
-# Any other sysctl parameters
-default['bcpc']['system']['parameters'] = {}
+# Any other sysctl parameters (register under parameters)
+default['bcpc']['system']['parameters']['kernel.pid_max'] = 4194303
 
 ###########################################
 #


### PR DESCRIPTION
Ceph and QEMU both spawn a lot of threads. Per http://www.spinics.net/lists/ceph-users/msg16373.html (ceph-users discussion), just raise `kernel.pid_max` to the maximum value possible.