### PR TITLE
Increase proc.num trigger in Zabbix template

### DIFF
--- a/cookbooks/bcpc/files/default/zabbix_linux_active_template.xml
+++ b/cookbooks/bcpc/files/default/zabbix_linux_active_template.xml
@@ -2095,7 +2095,7 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{Template OS Linux-active:proc.num[].last(0)}&gt;850</expression>
+            <expression>{Template OS Linux-active:proc.num[].last(0)}&gt;1200</expression>
             <name>Too many processes on {HOST.NAME}</name>
             <url/>
             <status>0</status>


### PR DESCRIPTION
Increase this to a high-ish number but not too excessively reduce false alerts. The old trigger has to be manually removed from `Template OS Linux-active` when cheffed into an existing cluster.