### PR TITLE
Ignore DHCP clients we don't know on bootstrap node

### DIFF
--- a/cookbooks/bcpc/recipes/cobbler.rb
+++ b/cookbooks/bcpc/recipes/cobbler.rb
@@ -55,6 +55,7 @@ template "/etc/cobbler/dhcp.template" do
         :subnet => node['bcpc']['bootstrap']['dhcp_subnet']
     )
     notifies :restart, "service[cobbler]", :delayed
+    notifies :run, "bash[run-cobbler-sync]", :immediately
 end
 
 template "/var/lib/cobbler/kickstarts/bcpc_ubuntu_host.preseed" do
@@ -75,18 +76,18 @@ bash "import-ubuntu-distribution-cobbler" do
         mount -o loop -o ro /tmp/ubuntu-14.04-mini.iso /mnt
         cobbler import --name=ubuntu-14.04-mini --path=/mnt --breed=ubuntu --os-version=trusty --arch=x86_64
         umount /mnt
-        cobbler sync
     EOH
     not_if "cobbler distro list | grep ubuntu-14.04-mini"
+    notifies :run, "bash[run-cobbler-sync]", :immediately
 end
 
 bash "import-bcpc-profile-cobbler" do
     user "root"
     code <<-EOH
         cobbler profile add --name=bcpc_host --distro=ubuntu-14.04-mini-x86_64 --kickstart=/var/lib/cobbler/kickstarts/bcpc_ubuntu_host.preseed --kopts="interface=auto"
-        cobbler sync
     EOH
     not_if "cobbler profile list | grep bcpc_host"
+    notifies :run, "bash[run-cobbler-sync]", :immediately
 end
 
 service "isc-dhcp-server" do
@@ -95,4 +96,9 @@ end
 
 service "cobbler" do
     action [:enable, :start]
+end
+
+bash "run-cobbler-sync" do
+  code "cobbler sync"
+  action :nothing
 end

--- a/cookbooks/bcpc/templates/default/cobbler.dhcp.template.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.dhcp.template.erb
@@ -31,6 +31,7 @@ subnet <%= @subnet %> netmask <%=node['bcpc']['management']['netmask']%> {
      default-lease-time         21600;
      max-lease-time             43200;
      next-server                $next_server;
+     deny                       unknown-clients;
 }
 
 #for dhcp_tag in $dhcp_tags.keys():
@@ -65,4 +66,3 @@ group {
         #end for
 }
 #end for
-


### PR DESCRIPTION
This is a courtesy change to make us politer in a shared lab situation. `deny unknown-clients;` will prevent our DHCP server from handing out leases to clients it doesn't recognize.