### PR TITLE
Indicate destination of do_on_node action in log output

### DIFF
--- a/bootstrap/shared/shared_functions.sh
+++ b/bootstrap/shared/shared_functions.sh
@@ -9,6 +9,7 @@ if [[ $BOOTSTRAP_METHOD == "vagrant" ]]; then
     NODE=$1
     shift
     COMMAND="${*}"
+    echo "EXECUTING on $NODE"
     vagrant ssh $NODE -c "$COMMAND"
   }
 else


### PR DESCRIPTION
Very minor change... I've always found it difficult to determine upon which host a build would fail. This is useful for jenkins jobs, etc...