### PR TITLE
Some small bugfixes on the scripts that handle cluster.txt/cluster.yaml

### DIFF
--- a/bootstrap/ansible_scripts/scripts/cluster_yaml_to_inventory.py
+++ b/bootstrap/ansible_scripts/scripts/cluster_yaml_to_inventory.py
@@ -102,6 +102,10 @@ def render_inventory(path, ssh_user):
     f.close()
     cluster = yaml.safe_load(cluster_yaml)
 
+    # if it's a string and not a dict, something not YAML was loaded
+    if type(cluster) != dict:
+        sys.exit("ERROR: %s did not parse as YAML. Exiting." % path)
+
     env = jinja2.Environment(trim_blocks=True, lstrip_blocks=True)
     template = env.from_string(INVENTORY_TEMPLATE)
 
@@ -126,7 +130,9 @@ def render_inventory(path, ssh_user):
     # if None is detected as a hardware_type, the person needs to update
     # the YAML to actually have real hardware types
     if None in hardware_types:
-        sys.exit("null is not a valid hardware type, please fix the YAML")
+        err = "ERROR: null is not a valid hardware type. "
+        err += "Please set valid hardware types."
+        sys.exit(err)
     # if only one hardware type was detected, we can avoid writing it out
     # for each node separately (Ansible doesn't care, but it reduces
     # visual clutter)

--- a/bootstrap/ansible_scripts/scripts/create_random_cluster_txt.py
+++ b/bootstrap/ansible_scripts/scripts/create_random_cluster_txt.py
@@ -44,8 +44,12 @@ def generate_random_cluster_list(
             ["%02x" % random.randint(0, 255) for i in range(0, 6)])
         ip_address = ".".join(
             [str(random.randint(1, 255)) for i in range(0, 4)])
-        ipmi_address = ".".join(
-            [str(random.randint(1, 255)) for i in range(0, 4)])
+        # don't always add an IPMI address, virtual nodes don't have them
+        if random.randint(0,1):
+            ipmi_address = ".".join(
+                [str(random.randint(1, 255)) for i in range(0, 4)])
+        else:
+            ipmi_address = '-'
         role = random.choice(possible_roles)
 
         # hack to avoid multiple bootstrap nodes or too many head nodes


### PR DESCRIPTION
- friendlier error messages if you give it the wrong type of file
  instead of a big ol' Python traceback
- allow the random generator to produce - for IPMI (what we do for
  virtual nodes)
- on the other side, correctly interpret - for IPMI IP as a null value