### PR TITLE
Don't apply flavors recipes on work nodes

### DIFF
--- a/roles/BCPC-Compute.json
+++ b/roles/BCPC-Compute.json
@@ -16,7 +16,6 @@
       "recipe[bcpc::diamond]",
       "recipe[bcpc::fluentd]",
       "recipe[bcpc::tpm]",
-      "recipe[bcpc::flavors]",
       "recipe[bcpc::host-aggregates]",
       "recipe[bcpc::checks-work]",
       "recipe[bcpc::zabbix-agent]",


### PR DESCRIPTION
This is a very small change to remove applying the **flavors** recipe on work nodes; head nodes already handle flavors, and this recipe can take a while to execute, so it will speed up Chef runs on work nodes.