### PR TITLE
Add structures to support SSL key distribution from Ansible

### DIFF
--- a/bootstrap/ansible_scripts/common_playbooks/validate_environment.yml
+++ b/bootstrap/ansible_scripts/common_playbooks/validate_environment.yml
@@ -64,6 +64,15 @@
   - fail: msg="Directory {{ controlnode_apt_mirror_dir }} does not exist"
     when: not apt_mirror_dir_stat.stat.exists
 
+  - name: check for presence of local SSH keys directory
+    local_action: stat path={{ controlnode_ssl_key_dir }}
+    register: ssl_key_dir_stat
+    become: no
+    run_once: true
+
+  - fail: msg="Directory {{ controlnode_ssl_key_dir }} does not exist"
+    when: not ssl_key_dir_stat.stat.exists
+
   - name: check for presence of chef-bcpc ZIP file
     local_action: stat path={{ controlnode_git_staging_dir }}/chef-bcpc-{{ chef_bcpc_version }}.zip
     register: chef_bcpc_stat

--- a/bootstrap/ansible_scripts/group_vars/vars.template
+++ b/bootstrap/ansible_scripts/group_vars/vars.template
@@ -48,6 +48,12 @@ controlnode_files_dir: /set/to/a/real/path
 # (this is passed to rsync with an / appended to the end)
 controlnode_apt_mirror_dir: /set/to/a/real/path
 
+# directory that contains SSL keys for the cluster
+# keys from this directory to use in a particular cluster are listed
+# in ssl_key_list in SSL KEYS section below
+# (this is passed to rsync with an / appended to the end)
+controlnode_ssl_key_dir: /set/to/a/real/path
+
 # set this variable here for all clusters or in group_vars for an
 # individual cluster to seek out prebuilt binaries instead of building
 # on the bootstrap node
@@ -61,6 +67,17 @@ use_prebuilt_binaries: false
 
 #revoked_users:
 #- username: xxx
+
+################################################
+# SSL KEYS
+################################################
+# a list of SSL keys to be individually copied to the bootstrap node
+# these file names must match the ones given in the Chef environment
+# list the full names of SSL keys for the cluster, e.g.:
+# ssl_key_list:
+# - openstack.bcpc.example.com.key
+# - s3.bcpc.example.com.key
+ssl_key_list: []
 
 ################################################
 # COOKBOOK CONFIGURATIONS

--- a/bootstrap/ansible_scripts/software_deployment/tasks-prepare-deployed.yml
+++ b/bootstrap/ansible_scripts/software_deployment/tasks-prepare-deployed.yml
@@ -66,6 +66,10 @@
   command: tar xvzf {{ bootstrap_files_dir }}/{{ chef_bcpc_version }}/cookbooks/{{ item.cookbook }}-{{ item.version }}.tar.gz -C {{ bootstrap_deployed_dir }}/cookbooks/
   with_items: "{{ dependency_cookbooks }}"
 
+- name: Copy named SSL keys into bcpc cookbook
+  copy: src={{ controlnode_ssl_key_dir }}/{{ item }} dest={{ bootstrap_deployed_dir }}/cookbooks/bcpc/files/default/{{ item }} owner={{ ansible_ssh_user }} mode=0644 validate='openssl rsa -in %s -noout'
+  with_items: "{{ ssl_key_list }}"
+
 - name: Copy prebuilt binaries into bcpc cookbook
   shell: mkdir -p {{ bootstrap_deployed_dir }}/cookbooks/bcpc/files/default/bins && cp -r {{ bootstrap_files_dir }}/{{ chef_bcpc_version }}-prebuilt/* {{ bootstrap_deployed_dir }}/cookbooks/bcpc/files/default/bins
   when: use_prebuilt_binaries


### PR DESCRIPTION
This adds a mechanism for distributing SSL keys to a cluster without requiring them to be part of chef-bcpc-prop.