### PR TITLE
Improve RabbitMQ resilience in the face of failures

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -158,6 +158,8 @@ default['bcpc']['ceph']['mon_niceness'] = -10
 default['bcpc']['rabbitmq']['durable_queues'] = true
 # ulimits for RabbitMQ server
 default['bcpc']['rabbitmq']['ulimit']['nofile'] = 4096
+# Heartbeat timeout to detect dead RabbitMQ brokers
+default['bcpc']['rabbitmq']['heartbeat'] = 60
 
 ###########################################
 #

--- a/cookbooks/bcpc/templates/default/ceilometer.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceilometer.conf.erb
@@ -340,7 +340,7 @@ amqp_durable_queues=<%=node['bcpc']['rabbitmq']['durable_queues']%>
 #rabbit_port=5672
 
 # RabbitMQ HA cluster host:port pairs (list value)
-rabbit_hosts=<%=get_shuffled_servers(@servers).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
+rabbit_hosts=<%=get_shuffled_servers(@servers, prefer_local=true).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
 
 # connect over SSL for RabbitMQ (boolean value)
 #rabbit_use_ssl=false
@@ -861,5 +861,3 @@ signing_dir = /var/lib/ceilometer
 
 # Password for Redis server. (optional) (string value)
 #password=<None>
-
-

--- a/cookbooks/bcpc/templates/default/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder.conf.erb
@@ -51,7 +51,7 @@ quota_<%=key%> = <%= value %>
 [oslo_messaging_rabbit]
 # Rabbit message queue settings
 #rabbit_host=<%=node['bcpc']['management']['vip']%>
-rabbit_hosts=<%=get_shuffled_servers(@servers).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
+rabbit_hosts=<%=get_shuffled_servers(@servers, prefer_local=true).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
 rabbit_password=<%=get_config('rabbitmq-password')%>
 rabbit_ha_queues=True
 heartbeat_timeout_threshold=<%=node['bcpc']['rabbitmq']['heartbeat']%>

--- a/cookbooks/bcpc/templates/default/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder.conf.erb
@@ -54,6 +54,7 @@ quota_<%=key%> = <%= value %>
 rabbit_hosts=<%=get_shuffled_servers(@servers).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
 rabbit_password=<%=get_config('rabbitmq-password')%>
 rabbit_ha_queues=True
+heartbeat_timeout_threshold=<%=node['bcpc']['rabbitmq']['heartbeat']%>
 amqp_durable_queues=<%=node['bcpc']['rabbitmq']['durable_queues']%>
 
 [oslo_concurrency]

--- a/cookbooks/bcpc/templates/default/glance-api.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-api.conf.erb
@@ -156,7 +156,7 @@ lock_path = /var/lock/glance/
 # Configuration options if sending notifications via rabbitmq (these are
 # the defaults)
 #rabbit_host = <%=node['bcpc']['management']['vip']%>
-rabbit_hosts=<%=get_shuffled_servers(@servers).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
+rabbit_hosts=<%=get_shuffled_servers(@servers, prefer_local=true).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
 rabbit_port = 5672
 rabbit_use_ssl = false
 rabbit_userid = guest

--- a/cookbooks/bcpc/templates/default/glance-api.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-api.conf.erb
@@ -164,6 +164,7 @@ rabbit_password = <%=get_config('rabbitmq-password')%>
 rabbit_virtual_host = /
 rabbit_notification_exchange = glance
 rabbit_notification_topic = notifications
+heartbeat_timeout_threshold=<%=node['bcpc']['rabbitmq']['heartbeat']%>
 amqp_durable_queues = <%=node['bcpc']['rabbitmq']['durable_queues']%>
 
 # =============== Database Options =================================

--- a/cookbooks/bcpc/templates/default/heat.conf.erb
+++ b/cookbooks/bcpc/templates/default/heat.conf.erb
@@ -1004,6 +1004,8 @@ rabbit_password=<%=get_config('rabbitmq-password')%>
 # value)
 rabbit_ha_queues=True
 
+# Number of seconds after which the Rabbit broker is considered down if heartbeat's keep-alive fails (0 disables the heartbeat, >0 enables it.
+heartbeat_timeout_threshold=<%=node['bcpc']['rabbitmq']['heartbeat']%>
 
 [keystone_authtoken]
 # cafile = /etc/ssl/certs/ssl-bcpc.pem

--- a/cookbooks/bcpc/templates/default/heat.conf.erb
+++ b/cookbooks/bcpc/templates/default/heat.conf.erb
@@ -972,7 +972,7 @@ workers=<%= node['bcpc']['heat']['workers'] %>
 #rabbit_port=5672
 
 # RabbitMQ HA cluster host:port pairs (list value)
-rabbit_hosts=<%=get_shuffled_servers(@servers).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
+rabbit_hosts=<%=get_shuffled_servers(@servers, prefer_local=true).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
 
 # connect over SSL for RabbitMQ (boolean value)
 #rabbit_use_ssl=false

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -135,6 +135,7 @@ lock_path=/var/lock/nova
 rabbit_hosts=<%=get_shuffled_servers(@servers).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
 rabbit_password=<%=get_config('rabbitmq-password')%>
 rabbit_ha_queues=True
+heartbeat_timeout_threshold=<%=node['bcpc']['rabbitmq']['heartbeat']%>
 amqp_durable_queues=<%=node['bcpc']['rabbitmq']['durable_queues']%>
 
 [database]

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -132,7 +132,7 @@ lock_path=/var/lock/nova
 [oslo_messaging_rabbit]
 # Rabbit message queue settings
 #rabbit_host=<%=node['bcpc']['management']['vip']%>
-rabbit_hosts=<%=get_shuffled_servers(@servers).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
+rabbit_hosts=<%=get_shuffled_servers(@servers, prefer_local=true).map{|x| x['bcpc']['management']['ip'] + ":5672"}.join(',')%>
 rabbit_password=<%=get_config('rabbitmq-password')%>
 rabbit_ha_queues=True
 heartbeat_timeout_threshold=<%=node['bcpc']['rabbitmq']['heartbeat']%>
@@ -186,7 +186,7 @@ inject_key=false
 inject_partition=-2
 # Set flags for libvirt live migration
 live_migration_flag="VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRATE_LIVE,VIR_MIGRATE_PERSIST_DEST,VIR_MIGRATE_TUNNELLED"
-<% end %> 
+<% end %>
 virt_type=<%=node['bcpc']['virt_type']%>
 use_virtio_for_bridges=True
 hw_disk_discard = unmap
@@ -198,4 +198,3 @@ hw_disk_discard = unmap
 <%=k %>=<%=v %>
 <% end %>
 <% end %>
-

--- a/cookbooks/bcpc/templates/default/rabbitmq.config.erb
+++ b/cookbooks/bcpc/templates/default/rabbitmq.config.erb
@@ -7,5 +7,5 @@
 [
   {kernel,   [{inet_dist_use_interface, {<%=node['bcpc']['management']['ip'].gsub('.',',')%>}}]},
   {rabbitmq_management, [{listener, [{port, 55672}, {ip, "<%=node['bcpc']['management']['ip']%>"}]}, {redirect_old_port, false}]},
-  {rabbit, [{loopback_users, []}, {heartbeat, 60}, {cluster_partition_handling, pause_minority}, {tcp_listeners, [{"<%=node['bcpc']['management']['ip']%>", 5672}]}]}
+  {rabbit, [{loopback_users, []}, {heartbeat, <%=node['bcpc']['rabbitmq']['heartbeat']%>}, {cluster_partition_handling, pause_minority}, {tcp_listeners, [{"<%=node['bcpc']['management']['ip']%>", 5672}]}]}
 ].

--- a/cookbooks/bcpc/templates/default/rabbitmq.config.erb
+++ b/cookbooks/bcpc/templates/default/rabbitmq.config.erb
@@ -6,7 +6,6 @@
 
 [
   {kernel,   [{inet_dist_use_interface, {<%=node['bcpc']['management']['ip'].gsub('.',',')%>}}]},
-  {rabbitmq, [{tcp_listeners, [{"<%=node['bcpc']['management']['ip']%>", 5672}]}]},
   {rabbitmq_management, [{listener, [{port, 55672}, {ip, "<%=node['bcpc']['management']['ip']%>"}]}, {redirect_old_port, false}]},
-  {rabbit, [{loopback_users, []}]}
+  {rabbit, [{loopback_users, []}, {heartbeat, 60}, {cluster_partition_handling, pause_minority}, {tcp_listeners, [{"<%=node['bcpc']['management']['ip']%>", 5672}]}]}
 ].

--- a/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
+++ b/cookbooks/bcpc/templates/default/sysctl-70-bcpc.conf.erb
@@ -33,7 +33,7 @@ net.ipv4.tcp_fin_timeout = 10
 
 # Disable TCP slow start on idle connections
 net.ipv4.tcp_slow_start_after_idle = 0
- 
+
 # If your servers talk UDP, also up these limits
 net.ipv4.udp_rmem_min = 8192
 net.ipv4.udp_wmem_min = 8192
@@ -46,6 +46,11 @@ net.ipv4.tcp_keepalive_time=1800
 
 # Enable binding to non-local IP addresses
 net.ipv4.ip_nonlocal_bind=1
+
+# reduce number of TCP retransmission timeouts required to drop a connection
+# so that connections fall away in ~100 seconds instead of the default of
+# 15, which times out at ~924s
+net.ipv4.tcp_retries2 = 8
 
 # Avoid swapping
 vm.swappiness = 0


### PR DESCRIPTION
This PR changes a few things about RabbitMQ's configuration, and one tunable in the kernel TCP/IP stack, in an attempt to ameliorate failure conditions described in #928. #928 describes a failure situation in which an unresponsive client can stop message processing within the cluster on account of not acknowledging messages on a queue (**conductor** being the most prominent example, though there are likely others). The explicit **heartbeat** setting in this PR and the downward adjustment of **net.ipv4.tcp_retries2** act to more quickly evict failed clients.

Since **net.ipv4.tcp_retries2** is a systemwide setting, please test thoroughly to evaluate for any unintended impacts elsewhere. In practice, since the change of this setting reduces TCP connection termination from ~924 seconds to ~100 seconds (still a very long time), I don't anticipate any actual impact from the change, but you never know.

In addition, this enables **pause_minority** partition handling in order to reduce operational burden after a cluster partition. It is possible that both sides of the cluster may still briefly evolve separately in the event of a network partition, but in testing **pause_minority** avoided Big Red Warnings when healing a cluster after a network partition.

**NOTE**: Versions of RabbitMQ prior to 3.5.5 have a separate bug that can result in failed clients never being evicted, per https://github.com/rabbitmq/rabbitmq-server/issues/224. The presence of this bug has been verified in 3.5.4, which is running on our current production clusters, and it can be determined whether there are stuck processes by running `rabbitmqctl eval 'rabbit_diagnostics:maybe_stuck().'`. Stuck processes will never evict and require the broker to be restarted in order to purge them; attempting to terminate the connection or underlying Erlang process will not succeed.