### PR TITLE
Tighten RabbitMQ partitioning check

### DIFF
--- a/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
+++ b/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
@@ -4699,7 +4699,7 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{BCPC-Headnode:rabbitmq.partition.last()}&lt;&gt;1</expression>
+            <expression>{BCPC-Headnode:rabbitmq.partition.last()}=1</expression>
             <name>RabbitMQ Partitioning detected</name>
             <url/>
             <status>0</status>

--- a/cookbooks/bcpc/templates/default/zabbix_openstack.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_openstack.conf.erb
@@ -12,4 +12,4 @@ UserParameter=ceph.total.usage[*],HOME=/var/lib/zabbix rados df | egrep "total u
 UserParameter=ceph.total.space[*],HOME=/var/lib/zabbix rados df | egrep "total space" | awk '{}{print $$3}' | tr -d '\n'
 UserParameter=ceph.total.objects[*],HOME=/var/lib/zabbix rados df | egrep "total used" | awk '{}{print $$4}' | tr -d '\n'
 UserParameter=rabbitmq.fd_usage,HOME=/var/lib/zabbix sudo -u rabbitmq /usr/sbin/rabbitmqctl status 2>/dev/null | egrep -o 'total_used,[0-9]{1,}' | awk -F',' '{print $2}'
-UserParameter=rabbitmq.partition,HOME=/var/lib/zabbix sudo -u rabbitmq /usr/sbin/rabbitmqctl cluster_status 2>/dev/null | egrep -c '{partitions,\[\]}'
+UserParameter=rabbitmq.partition,HOME=/var/lib/zabbix sudo -u rabbitmq /usr/sbin/rabbitmqctl cluster_status 2>/dev/null | egrep -c '{partitions,\[\{'


### PR DESCRIPTION
When a clustered RabbitMQ node is stopped, `rabbitmqctl cluster_status` does not return `{partitions,[]}`, thereby triggering a RabbitMQ partition alert in Zabbix. This fix updates the trigger to check for non-empty list in `partitions`.

On existing cluster, the old trigger needs to be removed from `BCPC-Headnode` template. As the check's return output is now swapped (`0` for OK instead of `1`), changes should be applied in following order to avoid false alerts:

1. Remove old trigger
2. Rechef all heads
3. Rechef all monitoring nodes