### PR TITLE
Remove deprecated services from hup_openstack

### DIFF
--- a/cookbooks/bcpc/templates/default/hup_openstack.erb
+++ b/cookbooks/bcpc/templates/default/hup_openstack.erb
@@ -10,21 +10,15 @@ echo
 echo "################################"
 echo "# HEAD NODE SERVICES"
 for i in apache2 \
-         glance-api \
-         glance-registry \
          cinder-api \
          cinder-scheduler \
          cinder-volume \
+         glance-api \
+         glance-registry \
          nova-cert \
          nova-conductor \
          nova-consoleauth \
-         nova-scheduler \
-         heat-api \
-         heat-api-cfn \
-         heat-engine \
-         ceilometer-api \
-         ceilometer-agent-central \
-         ceilometer-collector
+         nova-scheduler
 do
     service $i restart
 done
@@ -36,8 +30,7 @@ echo "# WORK NODE SERVICES"
 for i in nova-api \
          nova-compute \
          nova-network \
-         nova-novncproxy \
-         ceilometer-agent-compute
+         nova-novncproxy
 do
     service $i restart
 done


### PR DESCRIPTION
As per title. Minor fix should remove `unrecognized service` warning for `ceilometer-*` and `heat-*` services when running `hup_openstack`