### PR TITLE
radosgw backend switching

### DIFF
--- a/cookbooks/bcpc/recipes/ceph-rgw.rb
+++ b/cookbooks/bcpc/recipes/ceph-rgw.rb
@@ -111,11 +111,22 @@ template "/etc/apache2/sites-available/radosgw.conf" do
     notifies :restart, "service[apache2]", :delayed
 end
 
-bash "apache-enable-radosgw" do
-    user "root"
-    code "a2ensite radosgw"
-    not_if "test -r /etc/apache2/sites-enabled/radosgw"
-    notifies :restart, "service[apache2]", :immediately
+# Handle radosgw apache site
+case node['bcpc']['ceph']['frontend']
+when "civitweb"
+    bash "apache-disable-radosgw" do
+        user "root"
+        code "a2dissite radosgw"
+        only_if "test -r /etc/apache2/sites-enabled/radosgw.conf"
+        notifies :restart, "service[apache2]", :immediately
+    end
+else
+    bash "apache-enable-radosgw" do
+        user "root"
+        code "a2ensite radosgw"
+        not_if "test -r /etc/apache2/sites-enabled/radosgw.conf"
+        notifies :restart, "service[apache2]", :immediately
+    end
 end
 # End apache configs
 

--- a/cookbooks/bcpc/templates/default/apache-000-default.erb
+++ b/cookbooks/bcpc/templates/default/apache-000-default.erb
@@ -4,7 +4,6 @@
 #
 ################################################
 
-NameVirtualHost <%=node['bcpc']['management']['ip']%>:80
 Listen 127.0.0.1:80
 
 <VirtualHost <%=node['bcpc']['management']['ip']%>:80>

--- a/cookbooks/bcpc/templates/default/apache-radosgw.conf.erb
+++ b/cookbooks/bcpc/templates/default/apache-radosgw.conf.erb
@@ -4,9 +4,6 @@
 #
 ################################################
 
-NameVirtualHost <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw']}"%>
-
-
 Listen <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw']}"%>
 Listen <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw_https']}"%>
 
@@ -41,8 +38,6 @@ FastCgiExternalServer /var/www/s3gw.fcgi -socket /var/lib/ceph/radosgw/rgw_fcgi.
         CustomLog /var/log/apache2/rgw_access.log  "%h %l %u %t \"%r\" %>s %I/%O [%D] \"%{Referer}i\" \"%{User-Agent}i\""
         ServerSignature Off
 </VirtualHost>
-
-NameVirtualHost <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw_https']}"%>
 
 <VirtualHost  <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw_https']}"%> >
         ServerName <%="s3.#{node['bcpc']['cluster_domain']}"%>

--- a/cookbooks/bcpc/templates/default/apache-radosgw.conf.erb
+++ b/cookbooks/bcpc/templates/default/apache-radosgw.conf.erb
@@ -11,7 +11,7 @@ FastCgiExternalServer /var/www/s3gw.fcgi -socket /var/lib/ceph/radosgw/rgw_fcgi.
 
 <VirtualHost  <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw']}"%> >
         ServerName <%="s3.#{node['bcpc']['cluster_domain']}"%>
-        ServerAlias <%=node['hostname']%>
+        ServerAlias <%=node['fqdn']%>
         ServerAlias <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw']}"%>
         ServerAdmin <%=node['bcpc']['admin_email']%>
         DocumentRoot /var/www
@@ -41,7 +41,7 @@ FastCgiExternalServer /var/www/s3gw.fcgi -socket /var/lib/ceph/radosgw/rgw_fcgi.
 
 <VirtualHost  <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw_https']}"%> >
         ServerName <%="s3.#{node['bcpc']['cluster_domain']}"%>
-        ServerAlias <%=node['hostname']%>
+        ServerAlias <%=node['fqdn']%>
         ServerAlias <%="#{node['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw_https']}"%>
         ServerAdmin <%=node['bcpc']['admin_email']%>
         DocumentRoot /var/www

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -70,8 +70,9 @@
     rgw enable ops log = false
     rgw enable usage log = false
     rgw print continue = false
+<% case @node['bcpc']['ceph']['frontend'] %>
+<% when "civetweb" %>
     rgw socket path = /var/lib/ceph/radosgw/rgw.sock
-<% if @node['bcpc']['ceph']['frontend'] %>
     rgw frontends = civetweb port=<%=node['bcpc']['ports']['civetweb']['radosgw']%>
 <% else %>
     # For Apache

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -214,5 +214,10 @@ backend radosgw-http-backend
   http-check expect status 200
   source <%=node['bcpc']['floating']['vip']%>
 <% @all_servers.each do |server| -%>
-  <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['radosgw']} check inter 5s rise 1 fall 1 observe layer7" %>
+  <% case node['bcpc']['ceph']['frontend'] %>
+  <%   when "civitweb" %>
+  <%=    "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['radosgw']} check inter 5s rise 1 fall 1 observe layer7" %>
+  <%   else %>
+  <%=    "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['apache']['radosgw']} check inter 5s rise 1 fall 1 observe layer7" %>
+  <% end %>
 <% end -%>


### PR DESCRIPTION
This was an attempt to actually implement the ability to switch radosgw backends. This was given rise to by the observation that even when civetweb is configured as the backend, apache will listen gratuitously on floating ip at 80/tcp, 443/tcp. 

The expected output: https://gist.github.com/kamidzi/142b575260f6a8ed92b6

Ultimately though, this is a duplication of efforts in #885, which should be preferred.