### PR TITLE
Bump version spec for rabbitmq to 3.6.0-1

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -45,7 +45,7 @@ default['bcpc']['ceph']['version_number'] = '0.94.5'
 default['bcpc']['erlang']['version'] = '1:17.5.3'
 default['bcpc']['haproxy']['version'] = '1.5.15-1ppa1~trusty'
 default['bcpc']['kibana']['version'] = '4.0.2'
-default['bcpc']['rabbitmq']['version'] = '3.5.7-1'
+default['bcpc']['rabbitmq']['version'] = '3.6.0-1'
 
 ###########################################
 #


### PR DESCRIPTION
Aggressive: https://www.rabbitmq.com/news.html#2015-12-22T18:00:00+0300. Some breaking changes according to https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v3_6_0, but we don't seem to be affected.