### PR TITLE
Make swap size configurable for VMs

### DIFF
--- a/bootstrap/config/bootstrap_config.sh.defaults
+++ b/bootstrap/config/bootstrap_config.sh.defaults
@@ -66,6 +66,9 @@ export BOOTSTRAP_APT_MIRROR=
 # Valid range is 0-3 (default 0).
 export MONITORING_NODES=0
 
+# Sets the size of the swapfile allocated (in MiB) to created VMs
+export VM_SWAP_SIZE=8192
+
 # These directories are where the repository and file cache will be mounted via
 # shared folders inside each VM.
 export REPO_MOUNT_POINT=/chef-bcpc-host

--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -152,17 +152,19 @@ EOH
 $add_swap_script = <<-EOH
   #!/bin/bash
   swap_path='/swap'
+  swap_size="#{ENV['VM_SWAP_SIZE'] ||= 8192}M"
   # This could be a re-provision
-  if grep -w "^${swap_path}" /proc/swaps ; then
-    swapoff "${swap_path}"
+  if grep -qw "^${swap_path}" /proc/swaps ; then
+    swapoff "$swap_path"
   fi
-  fallocate -l 8192M /swap
-  chmod 600 /swap
-  mkswap -f "${swap_path}"
+  fallocate -l $swap_size "$swap_path"
+  truncate -s $swap_size "$swap_path"
+  chmod 600 "$swap_path"
+  mkswap -f "$swap_path"
   /bin/sync
-  swapon "${swap_path}"
-  if ! grep -w "^${swap_path}" /etc/fstab ; then
-    echo "${swap_path} none swap defaults 0 0" | tee -a /etc/fstab
+  swapon "$swap_path"
+  if ! grep -qw "^${swap_path}" /etc/fstab ; then
+    echo "$swap_path none swap defaults 0 0" | tee -a /etc/fstab
   fi
 EOH
 

--- a/bootstrap/vagrant_scripts/dump_config.sh
+++ b/bootstrap/vagrant_scripts/dump_config.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Simply dumps the config
+hash -r
+
+export PATH=/bin:/usr/bin
+DIR="$( cd ${0%/*} && pwd -P )"
+confdir="$(cd "$DIR/../config" &&  pwd -P)"
+
+# Relocate and set me
+defaults="$confdir/bootstrap_config.sh.defaults"
+override="$confdir/bootstrap_config.sh.overrides"
+
+env - /bin/bash -c "export -n PWD SHLVL  ; source $defaults && source $override && printenv | \
+    sed '/^_=/d' | sort"

--- a/bootstrap/vagrant_scripts/dump_config.sh
+++ b/bootstrap/vagrant_scripts/dump_config.sh
@@ -10,5 +10,6 @@ confdir="$(cd "$DIR/../config" &&  pwd -P)"
 defaults="$confdir/bootstrap_config.sh.defaults"
 override="$confdir/bootstrap_config.sh.overrides"
 
-env - /bin/bash -c "export -n PWD SHLVL  ; source $defaults && source $override && printenv | \
-    sed '/^_=/d' | sort"
+env -i HOME="$HOME" /bin/bash -c \
+    "export -n PWD SHLVL ; source $defaults && source $override && printenv | \
+        sed -E '/^(_|HOME)=/d' | sort"


### PR DESCRIPTION
 - Closes #851.
 - Also adds config dumping util.

Also fixes a subtle bug with re-provisions. If the swapfile size has been decreased, the configured swap would not shrink correspondingly as that larger quantity would have already been `fallocate`'d; hence the call to `truncate`. A good testing command (for re-provisions) is:

```
 vagrant provision vm1 --provision-with add-swap-space && vagrant ssh vm1 -c 'ls -l --si /swap; cat /etc/fstab ; cat /proc/swaps'
```

It can also be seen that if only `truncate` is used, then growing the swap file will also not work as the file will be sparse and the provisioner will complain:

```
==> vm1: Running provisioner: add-swap-space (shell)...
    vm1: Running: inline script
==> vm1: Setting up swapspace version 1, size = 450556 KiB
==> vm1: no label, UUID=37d5b221-5486-40e1-a799-0a19468c9af3
==> vm1: swapon:
==> vm1: /swap: skipping - it appears to have holes.
```