### PR TITLE
Route VNC traffic through Haproxy to prevent SSL certificate issues

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -177,7 +177,7 @@ default['bcpc']['management']['interface-parent'] = nil
 # list of TCP ports that should be open on the management interface
 # (generally stuff served via HAProxy)
 default['bcpc']['management']['firewall_tcp_ports'] = [
-  80,443,8088,7480,5000,35357,9292,8776,8773,8774,8004,8000,8777
+  80,443,8088,7480,5000,35357,9292,8776,8773,8774,8004,8000,8777,6080
 ]
 
 default['bcpc']['metadata']['ip'] = "169.254.169.254"
@@ -324,7 +324,7 @@ default['bcpc']['keystone']['verbose'] = false
 # before failing (configures timeout on the wait-for-keystone-to-be-operational
 # spinlock guard).
 default['bcpc']['keystone']['wait_for_keystone_timeout'] = 120
-# Set the number of Keystone WSGI processes and threads to use by default on the 
+# Set the number of Keystone WSGI processes and threads to use by default on the
 # public API (experimentally threads > 1 may cause problems with the service
 # catalog, for now we recommend scaling only in the processes dimension)
 default['bcpc']['keystone']['wsgi']['processes'] = 5

--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -68,6 +68,7 @@ iptables-restore <<EOH
 # Allow external access to some VIP services
 ## apache 80, 443
 ## keystone 5000 35357
+## vnc console 6080
 ## glance 9292
 ## cinder 8776
 ## nova-api-ec2 8773

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -151,6 +151,16 @@ listen ceilometer-api
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8777 check inter 5s rise 1 fall 1" %>
 <% end -%>
 
+listen novnc
+  bind <%=node['bcpc']['management']['vip']%>:6080 ssl crt /etc/haproxy/haproxy.pem
+  balance source
+  option tcplog
+  option httpchk GET /
+  http-check expect status 200
+<% @servers.each do |server| -%>
+  <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:6080 check inter 5s rise 1 fall 1" %>
+<% end -%>
+
 frontend http
   bind <%=node['bcpc']['management']['vip']%>:80
   option tcplog

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -81,13 +81,14 @@ use_cow_images=True
 volume_api_class=nova.volume.cinder.API
 
 # Nova VNC settings
-ssl_only=True
+ssl_only=false
 key=/etc/nova/ssl-bcpc.key
 cert=/etc/nova/ssl-bcpc.pem
 novnc_enabled=True
-novncproxy_base_url=https://<%=node['bcpc']['management']['ip']%>:6080/vnc_auto.html
-vncserver_proxyclient_address=127.0.0.1
+novncproxy_base_url=https://openstack.<%=node['bcpc']['cluster_domain']%>:6080/vnc_auto.html
+vncserver_proxyclient_address=<%=node['bcpc']['management']['ip']%>
 novncproxy_host=<%=node['bcpc']['management']['ip']%>
+vncserver_listen=<%=node['bcpc']['management']['ip']%>
 
 # Glance settings
 image_service=nova.image.glance.GlanceImageService


### PR DESCRIPTION
VNC traffic goes through Haproxy that does SSL termination with proper cert (hence no ssl warning in horizon).