### PR TITLE
Parameterize rbd_flatten_volume_from_snapshot/rbd_max_clone_depth

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -1023,6 +1023,10 @@ default['bcpc']['nova']['policy'] = {
 default['bcpc']['cinder']['verbose'] = false
 default['bcpc']['cinder']['workers'] = 5
 default['bcpc']['cinder']['allow_az_fallback'] = true
+default['bcpc']['cinder']['rbd_flatten_volume_from_snapshot'] = true
+# NOTE: rbd_max_clone_depth is not honored in Kilo
+# see https://bugs.launchpad.net/cinder/+bug/1477706
+default['bcpc']['cinder']['rbd_max_clone_depth'] = 5
 default['bcpc']['cinder']['quota'] = {
   "volumes" => -1,
   "quota_snapshots" => 10,

--- a/cookbooks/bcpc/templates/default/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder.conf.erb
@@ -89,8 +89,8 @@ volume_backend_name=<%= type.upcase %>
 rbd_user=cinder
 rbd_pool=<%="#{node['bcpc']['ceph']['volumes']['name']}-#{type}"%>
 rbd_secret_uuid=<%=get_config('libvirt-secret-uuid')%>
-rbd_flatten_volume_from_snapshot=False
-rbd_max_clone_depth=5
+rbd_flatten_volume_from_snapshot=<%= node['bcpc']['cinder']['rbd_flatten_volume_from_snapshot'] %>
+rbd_max_clone_depth=<%= node['bcpc']['cinder']['rbd_max_clone_depth'] %>
 rbd_store_chunk_size = 4
 rados_connect_timeout = -1
 glance_api_version = 2


### PR DESCRIPTION
This parameterizes `rbd_flatten_volume_from_snapshot` and `rbd_max_clone_depth` and changes the default setting of `rbd_flatten_volume_from_snapshot` from **False** to **true**.

NOTE: `rbd_flatten_volume_from_snapshot` does not behave exactly like what you would expect. The name implies that if you create **vol1**, then snapshot it to **snap1**, then create **vol2**, **vol2** will be flattened and independent at creation time. In reality, it appears to only flatten **vol2** if you snapshot it. Note below that only when the second snapshot is created is the parent link broken:
```
vagrant@bcpc-vm1:~$ cinder create --display-name source-vol-3 10
+---------------------+--------------------------------------+
|       Property      |                Value                 |
+---------------------+--------------------------------------+
|     attachments     |                  []                  |
|  availability_zone  |                                      |
|       bootable      |                false                 |
|      created_at     |      2016-01-07T15:05:10.694306      |
| display_description |                 None                 |
|     display_name    |             source-vol-3             |
|      encrypted      |                False                 |
|          id         | bff2db87-9ac3-4807-a3e8-80bc730fbd5b |
|       metadata      |                  {}                  |
|     multiattach     |                false                 |
|         size        |                  10                  |
|     snapshot_id     |                 None                 |
|     source_volid    |                 None                 |
|        status       |               creating               |
|     volume_type     |                 None                 |
+---------------------+--------------------------------------+

vagrant@bcpc-vm1:~$ rbd ls -l volumes-ssd
NAME                                                                                        SIZE PARENT                                                                                                FMT PROT LOCK 
volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b                                               10240M                                                                                                         2           

vagrant@bcpc-vm1:~$ cinder snapshot-create --display-name source-vol-3-snap-1 bff2db87-9ac3-4807-a3e8-80bc730fbd5b
+---------------------+--------------------------------------+
|       Property      |                Value                 |
+---------------------+--------------------------------------+
|      created_at     |      2016-01-07T15:05:22.938627      |
| display_description |                 None                 |
|     display_name    |         source-vol-3-snap-1          |
|          id         | dd977c32-332d-475c-9784-8574942ff148 |
|       metadata      |                  {}                  |
|         size        |                  10                  |
|        status       |               creating               |
|      volume_id      | bff2db87-9ac3-4807-a3e8-80bc730fbd5b |
+---------------------+--------------------------------------+

vagrant@bcpc-vm1:~$ rbd ls -l volumes-ssd
NAME                                                                                        SIZE PARENT                                                                                                FMT PROT LOCK 
volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b                                               10240M                                                                                                         2           
volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b@snapshot-dd977c32-332d-475c-9784-8574942ff148 10240M                                                                                                         2 yes       

vagrant@bcpc-vm1:~$ cinder create --snapshot-id dd977c32-332d-475c-9784-8574942ff148 --display-name source-vol-3-snap-1-vol 10
+---------------------+--------------------------------------+
|       Property      |                Value                 |
+---------------------+--------------------------------------+
|     attachments     |                  []                  |
|  availability_zone  |                                      |
|       bootable      |                false                 |
|      created_at     |      2016-01-07T15:05:50.102991      |
| display_description |                 None                 |
|     display_name    |       source-vol-3-snap-1-vol        |
|      encrypted      |                False                 |
|          id         | 6288d7b2-de8d-459a-a75f-cb1dba2cb3f8 |
|       metadata      |                  {}                  |
|     multiattach     |                false                 |
|         size        |                  10                  |
|     snapshot_id     | dd977c32-332d-475c-9784-8574942ff148 |
|     source_volid    |                 None                 |
|        status       |               creating               |
|     volume_type     |                 None                 |
+---------------------+--------------------------------------+

vagrant@bcpc-vm1:~$ rbd ls -l volumes-ssd
NAME                                                                                        SIZE PARENT                                                                                                FMT PROT LOCK 
volume-6288d7b2-de8d-459a-a75f-cb1dba2cb3f8                                               10240M volumes-ssd/volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b@snapshot-dd977c32-332d-475c-9784-8574942ff148   2           
volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b                                               10240M                                                                                                         2           
volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b@snapshot-dd977c32-332d-475c-9784-8574942ff148 10240M                                                                                                         2 yes       

vagrant@bcpc-vm1:~$ cinder snapshot-create --display-name source-vol-3-snap-1-vol-snap-2 6288d7b2-de8d-459a-a75f-cb1dba2cb3f8
+---------------------+--------------------------------------+
|       Property      |                Value                 |
+---------------------+--------------------------------------+
|      created_at     |      2016-01-07T15:06:15.824497      |
| display_description |                 None                 |
|     display_name    |    source-vol-3-snap-1-vol-snap-2    |
|          id         | d4321071-c0a2-46ac-9940-91966e95e65d |
|       metadata      |                  {}                  |
|         size        |                  10                  |
|        status       |               creating               |
|      volume_id      | 6288d7b2-de8d-459a-a75f-cb1dba2cb3f8 |
+---------------------+--------------------------------------+

vagrant@bcpc-vm1:~$ rbd ls -l volumes-ssd
NAME                                                                                        SIZE PARENT                                                                                                FMT PROT LOCK 
volume-6288d7b2-de8d-459a-a75f-cb1dba2cb3f8                                               10240M                                                                                                         2           
volume-6288d7b2-de8d-459a-a75f-cb1dba2cb3f8@snapshot-d4321071-c0a2-46ac-9940-91966e95e65d 10240M                                                                                                         2 yes       
volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b                                               10240M                                                                                                         2           
volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b@snapshot-dd977c32-332d-475c-9784-8574942ff148 10240M                                                                                                         2 yes       

vagrant@bcpc-vm1:~$ cinder create --snapshot-id d4321071-c0a2-46ac-9940-91966e95e65d --display-name source-vol-3-snap-1-vol-snap-2-vol 10
+---------------------+--------------------------------------+
|       Property      |                Value                 |
+---------------------+--------------------------------------+
|     attachments     |                  []                  |
|  availability_zone  |                                      |
|       bootable      |                false                 |
|      created_at     |      2016-01-07T15:06:36.185164      |
| display_description |                 None                 |
|     display_name    |  source-vol-3-snap-1-vol-snap-2-vol  |
|      encrypted      |                False                 |
|          id         | 56f7eb89-9ce3-4fac-87eb-0fb664609767 |
|       metadata      |                  {}                  |
|     multiattach     |                false                 |
|         size        |                  10                  |
|     snapshot_id     | d4321071-c0a2-46ac-9940-91966e95e65d |
|     source_volid    |                 None                 |
|        status       |               creating               |
|     volume_type     |                 None                 |
+---------------------+--------------------------------------+

vagrant@bcpc-vm1:~$ rbd ls -l volumes-ssd
NAME                                                                                        SIZE PARENT                                                                                                FMT PROT LOCK 
volume-56f7eb89-9ce3-4fac-87eb-0fb664609767                                               10240M volumes-ssd/volume-6288d7b2-de8d-459a-a75f-cb1dba2cb3f8@snapshot-d4321071-c0a2-46ac-9940-91966e95e65d   2           
volume-6288d7b2-de8d-459a-a75f-cb1dba2cb3f8                                               10240M                                                                                                         2           
volume-6288d7b2-de8d-459a-a75f-cb1dba2cb3f8@snapshot-d4321071-c0a2-46ac-9940-91966e95e65d 10240M                                                                                                         2 yes       
volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b                                               10240M                                                                                                         2           
volume-bff2db87-9ac3-4807-a3e8-80bc730fbd5b@snapshot-dd977c32-332d-475c-9784-8574942ff148 10240M                                                                                                         2 yes       
```