### PR TITLE
updates to address Ansible 2.0 issues/deprecation warnings

### DIFF
--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-server.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-server.yml
@@ -29,7 +29,7 @@
       - chef
 
   - name: Run Chef Server configuration
-    sudo: yes
+    become: yes
     command: chef-server-ctl reconfigure
     tags:
       - chef
@@ -48,7 +48,7 @@
       - chef
 
   - name: Check for BCPC organization in Chef Server
-    sudo: yes
+    become: yes
     command: chef-server-ctl org-show bcpc
     ignore_errors: true
     register: chef_org_result
@@ -56,7 +56,7 @@
       - chef
 
   - name: create BCPC chef organisation
-    sudo: yes
+    become: yes
     command: chef-server-ctl org-create bcpc "BCPC" --association admin --filename /etc/opscode/bcpc-validator.pem
     when: chef_org_result.rc != 0
     tags:

--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-package-serving.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-package-serving.yml
@@ -1,6 +1,6 @@
 ---
   - name: Perform synchronization of local bootstrap files
-    synchronize: src={{ controlnode_files_dir }}/ dest={{ bootstrap_files_dir }}/
+    synchronize: src={{ controlnode_files_dir }}/ dest={{ bootstrap_files_dir }}/ owner=no group=no
     tags:
       - synchronize
 
@@ -11,7 +11,7 @@
 
   # leave / on the end of src path so rsync doesn't put the mirror dir inside the dest dir!
   - name: Perform synchronization of local apt mirror (can take a long while)
-    synchronize: src={{ controlnode_apt_mirror_dir }}/ dest={{ bootstrap_apt_mirror_dir }}
+    synchronize: src={{ controlnode_apt_mirror_dir }}/ dest={{ bootstrap_apt_mirror_dir }} owner=no group=no
     become: no
     when: not apt_mirror_via_vboxsf
     tags:
@@ -104,7 +104,7 @@
     # VirtualBox shared folder done
 
   - name: Perform synchronization of local bootstrap files
-    synchronize: src={{ controlnode_files_dir }}/ dest={{ bootstrap_files_dir }}/
+    synchronize: src={{ controlnode_files_dir }}/ dest={{ bootstrap_files_dir }}/ owner=no group=no
     become: no
     tags:
       - synchronize

--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-package-serving.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-package-serving.yml
@@ -12,6 +12,7 @@
   # leave / on the end of src path so rsync doesn't put the mirror dir inside the dest dir!
   - name: Perform synchronization of local apt mirror (can take a long while)
     synchronize: src={{ controlnode_apt_mirror_dir }}/ dest={{ bootstrap_apt_mirror_dir }}
+    become: no
     when: not apt_mirror_via_vboxsf
     tags:
       - synchronize
@@ -101,6 +102,12 @@
     lineinfile: dest=/etc/rc.local insertbefore='exit 0' state=present line='mount apt-mirror'
     when: apt_mirror_via_vboxsf and hardware_type == "Virtual" and apt_mirror_shared_folder_configured.rc != 0
     # VirtualBox shared folder done
+
+  - name: Perform synchronization of local bootstrap files
+    synchronize: src={{ controlnode_files_dir }}/ dest={{ bootstrap_files_dir }}/
+    become: no
+    tags:
+      - synchronize
 
   - name: Create directory to serve package mirrors from for Apache
     file: path={{ bootstrap_mirror_root_dir }} state=directory owner=root group=root mode=0755

--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-create-directory-structure.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-create-directory-structure.yml
@@ -15,8 +15,8 @@
   - name: Mount the /bcpc directory
     mount: name=/bcpc src=/dev/sdc fstype=ext4 state=mounted
 
-  - name: Create staging directories
-    file: path={{ item }} state=directory owner=operations group=operators mode=0775
+  - name: Create various staging areas
+    file: path={{ item }} state=directory owner=operations group=operators mode=0775 recurse=yes
     with_items:
       - "{{ bootstrap_files_dir }}"
       - "{{ bootstrap_git_staging_dir }}"

--- a/bootstrap/ansible_scripts/software_deployment/tasks-prepare-deployed.yml
+++ b/bootstrap/ansible_scripts/software_deployment/tasks-prepare-deployed.yml
@@ -3,11 +3,13 @@
 ---
 - name: Perform synchronization of Git staging
   synchronize: src={{ controlnode_git_staging_dir }}/ dest={{ bootstrap_git_staging_dir }}/
+  become: no
   tags:
     - synchronize
 
 - name: Perform synchronization of local bootstrap files
   synchronize: src={{ controlnode_files_dir }}/ dest={{ bootstrap_files_dir }}/
+  become: no
   tags:
     - synchronize
 
@@ -32,11 +34,11 @@
   register: staging_location
 
 - name: Decompress chef-bcpc to temporary location
-  command: unzip -d {{ staging_location.path }} {{ bootstrap_git_staging_dir}}/chef-bcpc-{{ chef_bcpc_version }}.zip
+  unarchive: copy=no src={{ bootstrap_git_staging_dir}}/chef-bcpc-{{ chef_bcpc_version }}.zip dest={{ staging_location.path }}
   when: chef_bcpc_deploy_from_dir is not defined
 
 - name: Move chef-bcpc contents from temporary location to deployment directory
-  command: rsync -a {{ staging_location.path }}/chef-bcpc-{{ chef_bcpc_version }}/ {{ bootstrap_deployed_dir }}/
+  command: warn=false rsync -a {{ staging_location.path }}/chef-bcpc-{{ chef_bcpc_version }}/ {{ bootstrap_deployed_dir }}/
   when: chef_bcpc_deploy_from_dir is not defined
 
 - name: Synchronize chef-bcpc deployment directory contents (chef_bcpc_deploy_from_dir is defined)
@@ -44,15 +46,15 @@
   when: chef_bcpc_deploy_from_dir is defined
 
 - name: Decompress chef-bcpc-prop to temporary location
-  command: unzip -d {{ staging_location.path }} {{ bootstrap_git_staging_dir}}/chef-bcpc-prop-{{ chef_bcpc_prop_version }}.zip
+  unarchive: copy=no src={{ bootstrap_git_staging_dir}}/chef-bcpc-prop-{{ chef_bcpc_prop_version }}.zip dest={{ staging_location.path }}
   when: chef_bcpc_prop_version is defined
 
 - name: Overlay chef-bcpc-prop onto chef-bcpc in deployment directory
-  command: rsync -a {{ staging_location.path }}/chef-bcpc-prop-{{ chef_bcpc_prop_version }}/ {{ bootstrap_deployed_dir }}/
+  command: warn=false rsync -a {{ staging_location.path }}/chef-bcpc-prop-{{ chef_bcpc_prop_version }}/ {{ bootstrap_deployed_dir }}/
   when: chef_bcpc_prop_version is defined
 
 - name: Decompress additional internal cookbooks to temporary location
-  command: unzip -d {{ staging_location.path }} {{ bootstrap_git_staging_dir}}/{{ item.cookbook }}-{{ item.version }}.zip
+  unarchive: copy=no src={{ bootstrap_git_staging_dir}}/{{ item.cookbook }}-{{ item.version }}.zip dest={{ staging_location.path }}
   with_items: "{{ internal_cookbooks }}"
 
 - name: Move additional internal cookbooks into deployment directory cookbooks
@@ -70,8 +72,11 @@
   copy: src={{ controlnode_ssl_key_dir }}/{{ item }} dest={{ bootstrap_deployed_dir }}/cookbooks/bcpc/files/default/{{ item }} owner={{ ansible_ssh_user }} mode=0644 validate='openssl rsa -in %s -noout'
   with_items: "{{ ssl_key_list }}"
 
+- name: Create cookbook bins directory
+  file: path={{ bootstrap_deployed_dir }}/cookbooks/bcpc/files/default/bins state=directory owner=operations group=operators
+
 - name: Copy prebuilt binaries into bcpc cookbook
-  shell: mkdir -p {{ bootstrap_deployed_dir }}/cookbooks/bcpc/files/default/bins && cp -r {{ bootstrap_files_dir }}/{{ chef_bcpc_version }}-prebuilt/* {{ bootstrap_deployed_dir }}/cookbooks/bcpc/files/default/bins
+  shell: cp -r {{ bootstrap_files_dir }}/{{ chef_bcpc_version }}-prebuilt/* {{ bootstrap_deployed_dir }}/cookbooks/bcpc/files/default/bins
   when: use_prebuilt_binaries
 
 - name: Check for /chef-bcpc-files
@@ -94,7 +99,7 @@
     FILECACHE_MOUNT_POINT: "{{ bootstrap_files_dir }}/{{ chef_bcpc_version }}"
 
 - name: Fix permissions on {{ bootstrap_deployed_dir }}
-  command: chown -R operations {{ bootstrap_deployed_dir }}
+  file: path={{ bootstrap_deployed_dir }} owner=operations group=operators recurse=yes
 
   # tasks below here must run as operations and not root
 - name: Upload cookbooks to Chef server


### PR DESCRIPTION
(all should be backwards compatible with Ansible 1.9.4)

This should also address the issue originally raised in #911 without needing to override the rsync command to `sudo rsync`, by setting `become: no` and enforcing permissions on the remote end. Note that it is not intended that these playbooks be run as root.