### PR TITLE
Add ability to suppress ceph 'pg max obj skew' warning

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -102,6 +102,8 @@ default['bcpc']['ceph']['pgp_auto_adjust'] = false
 # Need to review...
 default['bcpc']['ceph']['pgs_per_node'] = 1024
 default['bcpc']['ceph']['max_pgs_per_osd'] = 300
+# Set to 0 to disable. See http://tracker.ceph.com/issues/8103 
+default['bcpc']['ceph']['pg_warn_max_obj_skew'] = 10
 # Journal size could be 10GB or higher in some cases
 default['bcpc']['ceph']['journal_size'] = 2048
 # The 'portion' parameters should add up to ~100 across all pools

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -14,8 +14,9 @@
     keyring = /etc/ceph/$cluster.$name.keyring
     mon host = <%= @servers.map{|s| s["bcpc"]["storage"]["ip"] + ":6789"}.join(', ') %>
     mon_pg_warn_max_per_osd = <%= @node['bcpc']['ceph']['max_pgs_per_osd'] %>
+    mon pg warn max object skew = <%= @node['bcpc']['ceph']['pg_warn_max_obj_skew'] %>
 <% if @node["bcpc"]["ceph"]["rebalance"] %>
-    paxos_propose_interval = 60 
+    paxos_propose_interval = 60
 <% end %>
 
 [mon]
@@ -35,7 +36,7 @@
     osd mount options xfs = noexec,nodev,noatime,nodiratime,barrier=0,discard
     osd crush update on start = false
     osd client op priority = 63
-<% if @node["bcpc"]["ceph"]["rebalance"] %> 
+<% if @node["bcpc"]["ceph"]["rebalance"] %>
     osd recovery max active = 1
     osd max backfills  = 1
     osd op threads = 10
@@ -45,9 +46,9 @@
 
 [client.admin]
     # dont want the admin client creating sockets/logs
-    admin socket = 
+    admin socket =
     log file =
-    
+
 [client.cinder]
     rbd cache = true
     rbd cache writethrough until flush = true
@@ -61,7 +62,7 @@
     admin socket = /var/run/ceph/guests/$cluster-$type.$id.$pid.$cctid.asok # must be writable by QEMU and allowed by SELinux or AppArmor
     log file = /var/log/qemu/qemu-guest-$pid.log
     rbd concurrent management ops = 20
-    
+
 [client.radosgw.gateway]
     host = <%=node['hostname']%>
     keyring = /var/lib/ceph/radosgw/$cluster-$id/keyring


### PR DESCRIPTION
Adds ability to control ceph 'pg max objects skew' warning threshold, or disable it by setting to 0.
Ceph default is 10, so this PR is no-op unless attribute is changed\overridden.