### PR TITLE
Add ability to use vip instead of domain name for VNC proxy

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -559,3 +559,12 @@ default['bcpc']['quota'] = {
 #
 ###########################################
 default['bcpc']['getty']['ttys'] = %w( ttyS0 ttyS1 )
+###########################################
+#
+#  VNC settings
+#
+###########################################
+#
+# VNC uses cluster domain name by default
+# for proxy base url. Set to 'true' to use vip
+default['bcpc']['vnc']['proxy_use_vip'] = false

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -85,7 +85,11 @@ ssl_only=false
 key=/etc/nova/ssl-bcpc.key
 cert=/etc/nova/ssl-bcpc.pem
 novnc_enabled=True
+<% if node['bcpc']['vnc']['proxy_use_vip'] %>
+novncproxy_base_url=https://<%=node['bcpc']['management']['vip']%>:6080/vnc_auto.html
+<% else %>
 novncproxy_base_url=https://openstack.<%=node['bcpc']['cluster_domain']%>:6080/vnc_auto.html
+<% end %>
 vncserver_proxyclient_address=<%=node['bcpc']['management']['ip']%>
 novncproxy_host=<%=node['bcpc']['management']['ip']%>
 vncserver_listen=<%=node['bcpc']['management']['ip']%>


### PR DESCRIPTION
This solves an issue when cluster domain name can not be resolved (for example local installations)