### PR TITLE
Update vagrant_create.sh

### DIFF
--- a/bootstrap/vagrant_scripts/vagrant_create.sh
+++ b/bootstrap/vagrant_scripts/vagrant_create.sh
@@ -28,7 +28,7 @@ function remove_DHCPservers {
 
     VBoxManage list dhcpservers | grep -E "^NetworkName:\s+HostInterfaceNetworking" | awk '{print $2}' |
     while read -r network_name; do
-      [[ -n $existing_nets_reg_ex ]] && ! egrep -q $existing_nets_reg_ex <<< $network_name && continue
+      [[ -n $existing_nets_reg_ex ]] && ! egrep -q "$existing_nets_reg_ex" <<< $network_name && continue
       remove_DHCPservers $network_name
     done
   else


### PR DESCRIPTION
Not escaped `$existing_nets_reg_ex` var results in:

==> bootstrap: VM not created. Moving on...
Starting local Vagrant cluster...
egrep: ^vboxnet1$: No such file or directory
egrep: ^vboxnet1$: No such file or directory
egrep: ^vboxnet1$: No such file or directory
egrep: ^vboxnet1$: No such file or directory
