### PR TITLE
Parameterize sync_power_state_interval and resume_guests_state_on_host_boot

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -313,6 +313,10 @@ default['bcpc']['nova']['scheduler_host_subset_size'] = 3
 default['bcpc']['nova']['workers'] = 5
 # Patch toggle for https://github.com/bloomberg/chef-bcpc/pull/493
 default['bcpc']['nova']['live_migration_patch'] = false
+# frequency of syncing power states between hypervisor and database
+default['bcpc']['nova']['sync_power_state_interval'] = 600
+# automatically restart guests that were running when hypervisor was rebooted
+default['bcpc']['nova']['resume_guests_state_on_host_boot'] = false
 # Verbose logging (level INFO)
 default['bcpc']['nova']['verbose'] = false
 # Nova debug toggle

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -74,8 +74,8 @@ default_availability_zone=
 compute_driver=libvirt.LibvirtDriver
 use_cow_images=True
 #snapshot_image_format=qcow2
-#start_guests_on_host_boot=True
-#resume_guests_state_on_host_boot=True
+sync_power_state_interval=<%= node['bcpc']['nova']['sync_power_state_interval'] %>
+resume_guests_state_on_host_boot=<%= node['bcpc']['nova']['resume_guests_state_on_host_boot'] %>
 
 # Nova Volume settings
 volume_api_class=nova.volume.cinder.API


### PR DESCRIPTION
This parameterizes these two options in `nova.conf` so that we can tune them for user friendliness prior to hypervisor reboots; their settings in `attributes/default.rb` correspond to the defaults for Nova. (I also removed the commented-out line that mentioned `start_guests_on_host_boot`, which is not a real option according to the `nova.conf` documentation at http://docs.openstack.org/kilo/config-reference/content/list-of-compute-config-options.html).