### PR TITLE
Report ceph health details to Zabbix and pagerduty

### DIFF
--- a/cookbooks/bcpc/templates/default/zabbix_openstack.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_openstack.conf.erb
@@ -4,7 +4,7 @@ UserParameter=openstack.cinder.reserved,HOME=/var/lib/zabbix mysql -u<%=get_conf
 UserParameter=openstack.nova.rootusage,HOME=/var/lib/zabbix mysql -u<%=get_config('mysql-nova-user')%> --password=<%=get_config('mysql-nova-password')%> nova  -e 'select coalesce(sum(root_gb),0) from instances where terminated_at is NULL;' | tail -n1
 UserParameter=openstack.nova.quota[*],HOME=/var/lib/zabbix mysql -u<%=get_config('mysql-nova-user')%> --password=<%=get_config('mysql-nova-password')%> nova  -e 'select coalesce(sum(hard_limit),0) from quotas where resource="$1";' | tail -n1
 UserParameter=openstack.nova.quota_usage[*],HOME=/var/lib/zabbix mysql -u<%=get_config('mysql-nova-user')%> --password=<%=get_config('mysql-nova-password')%> nova  -e 'select coalesce(sum(in_use),0) from quota_usages where resource="$1";' | tail -n1
-UserParameter=ceph.health,HOME=/var/lib/zabbix ceph health | cut -d " " -f 1
+UserParameter=ceph.health,HOME=/var/lib/zabbix ceph health | head -1
 UserParameter=ceph.pg_count[*],HOME=/var/lib/zabbix ceph pg dump | egrep "^[0-9a-f]+\.[0-9a-f]*\w" | awk '{}{print $$9}' | grep "$1" | wc -l
 UserParameter=ceph.pool.usage[*],HOME=/var/lib/zabbix rados df | egrep "^$1 " | awk '{}{print $$3}'
 UserParameter=ceph.pool.objects[*],HOME=/var/lib/zabbix rados df | egrep "^$1 " | awk '{}{print $$4}'


### PR DESCRIPTION
Send first 7 lines of 'ceph health detail' to Zabbix (and zabbix pagerduty plugin), instead of just 'HEALTH_{OK,WARN,ERROR}'. This helps identify exact issue quicker and retain a record of event in Zabbix.

testing instructions:
* build cluster with at least 1 monitoring VM (set 'export MONITORING_NODES=1' in bootstrap_config.sh.overrides).
* upset ceph (ceph osd set noout)
* observe ceph health trigger with details in Zabbix