### PR TITLE
Remove default instance quota

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -327,7 +327,7 @@ default['bcpc']['nova']['quota'] = {
   "cores" => 4,
   "floating_ips" => 10,
   "gigabytes"=> 1000,
-  "instances" => 10,
+  "instances" => -1,
   "ram" => 8192
 }
 # load a custom vendor driver,


### PR DESCRIPTION
Do not impose quota on number of instances tenants can launch. Tenants should be limited by other quota on resources like vcpu and ram.