### PR TITLE
Parameterize and increase Zabbix check timeouts

### DIFF
--- a/cookbooks/bcpc/attributes/monitoring.rb
+++ b/cookbooks/bcpc/attributes/monitoring.rb
@@ -81,6 +81,11 @@ default['bcpc']['zabbix']['php_settings'] = {
 # Zabbix severities to notify about.
 # https://www.zabbix.com/documentation/2.4/manual/api/reference/usermedia/object
 default['bcpc']['zabbix']['severity'] = 63
+# Timeout for Zabbix agentd
+default['bcpc']['zabbix']['agentd_timeout'] = 10
+# Timeout for Zabbix server. It is slightly higher than agentd to better detect
+# cause of timeout.
+default['bcpc']['zabbix']['server_timeout'] = node['bcpc']['zabbix']['agentd_timeout'] + 1
 
 ###########################################
 #

--- a/cookbooks/bcpc/templates/default/zabbix_agentd.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_agentd.conf.erb
@@ -215,6 +215,7 @@ HostMetadata=BCPC-Worknode
 # Range: 1-30
 # Default:
 # Timeout=3
+Timeout=<%= node['bcpc']['zabbix']['agentd_timeout'] %>
 
 ### Option: Include
 #   You may include individual files or all files in a directory in the configuration file.

--- a/cookbooks/bcpc/templates/default/zabbix_server.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_server.conf.erb
@@ -350,6 +350,7 @@ ListenIP=<%=node['bcpc']['monitoring']['vip']%>
 # Range: 1-30
 # Default:
 # Timeout=3
+Timeout=<%= node['bcpc']['zabbix']['server_timeout'] %>
 
 ### Option: TrapperTimeout
 #   Specifies how many seconds trapper may spend processing new data.


### PR DESCRIPTION
Zabbix's default timeout of 3 seconds is a little short for some of our checks, such as the ephemeral functional test. Parameterize and increase it to 10.