### PR TITLE
Parameterize and add configuration for Nova notification system

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -316,6 +316,12 @@ default['bcpc']['nova']['default_log_levels'] = nil
 # Nova scheduler default filters
 default['bcpc']['nova']['scheduler_default_filters'] = ['AggregateInstanceExtraSpecsFilter', 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter']
 
+# configure optional Nova notification system
+default['bcpc']['nova']['notifications']['enabled'] = false
+default['bcpc']['nova']['notifications']['notification_topics'] = 'notifications'
+default['bcpc']['nova']['notifications']['notification_driver'] = 'messagingv2'
+default['bcpc']['nova']['notifications']['notify_on_state_change'] = 'vm_state'
+
 # settings pertaining to ephemeral storage via mdadm/LVM
 # (software RAID settings are here for logical grouping)
 default['bcpc']['software_raid']['enabled'] = false

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -37,6 +37,13 @@ enabled_apis=metadata
 vendordata_driver = <%=node["bcpc"]["vendordata_driver"] %>
 <% end %>
 
+<% if node['bcpc']['nova']['notifications']['enabled'] %>
+# Nova notification settings
+notification_topics=<%= node['bcpc']['nova']['notifications']['notification_topics'] %>
+notification_driver=<%= node['bcpc']['nova']['notifications']['notification_driver'] %>
+notify_on_state_change=<%= node['bcpc']['nova']['notifications']['notify_on_state_change'] %>
+<% end %>
+
 # Nova Scheduler
 scheduler_driver=nova.scheduler.filter_scheduler.FilterScheduler
 scheduler_default_filters=<%=node['bcpc']['nova']['scheduler_default_filters'].join(',')%>


### PR DESCRIPTION
This adds parameters for the Nova notification system. It is off by default because nothing consumes from the **notifications.info** queue that is written to by the **nova** exchange. To test, flip **bcpc.nova.notifications.enabled**, rechef, then launch an instance and enjoy the message spew.