### PR TITLE
Rename Vagrant-built bootstrap node

### DIFF
--- a/bootstrap/shared/shared_configure_chef.sh
+++ b/bootstrap/shared/shared_configure_chef.sh
@@ -36,7 +36,7 @@ else
     CHEF_CLIENT_INSTALL_CMD="sudo dpkg -i \$(find $FILECACHE_MOUNT_POINT/ -name chef_\*deb -not -name \*downloaded | tail -1)"
 fi
 unset debpath
-do_on_node bootstrap "$CHEF_SERVER_INSTALL_CMD \
+do_on_node vm-bootstrap "$CHEF_SERVER_INSTALL_CMD \
   && sudo sh -c \"echo nginx[\'non_ssl_port\'] = 4000 > /etc/opscode/chef-server.rb\" \
   && sudo chef-server-ctl reconfigure \
   && sudo chef-server-ctl user-create admin admin admin admin@localhost.com welcome --filename /etc/opscode/admin.pem \
@@ -45,7 +45,7 @@ do_on_node bootstrap "$CHEF_SERVER_INSTALL_CMD \
   && $CHEF_CLIENT_INSTALL_CMD"
 
 # configure knife on the bootstrap node and perform a knife bootstrap to create the bootstrap node in Chef
-do_on_node bootstrap "mkdir -p \$HOME/.chef && echo -e \"chef_server_url 'https://bcpc-bootstrap.$BCPC_HYPERVISOR_DOMAIN/organizations/bcpc'\\\nvalidation_client_name 'bcpc-validator'\\\nvalidation_key '/etc/opscode/bcpc-validator.pem'\\\nnode_name 'admin'\\\nclient_key '/etc/opscode/admin.pem'\\\nknife['editor'] = 'vim'\\\ncookbook_path [ \\\"#{ENV['HOME']}/chef-bcpc/cookbooks\\\" ]\" > \$HOME/.chef/knife.rb \
+do_on_node vm-bootstrap "mkdir -p \$HOME/.chef && echo -e \"chef_server_url 'https://bcpc-vm-bootstrap.$BCPC_HYPERVISOR_DOMAIN/organizations/bcpc'\\\nvalidation_client_name 'bcpc-validator'\\\nvalidation_key '/etc/opscode/bcpc-validator.pem'\\\nnode_name 'admin'\\\nclient_key '/etc/opscode/admin.pem'\\\nknife['editor'] = 'vim'\\\ncookbook_path [ \\\"#{ENV['HOME']}/chef-bcpc/cookbooks\\\" ]\" > \$HOME/.chef/knife.rb \
   && $KNIFE ssl fetch \
   && $KNIFE bootstrap -x vagrant -P vagrant --sudo 10.0.100.3"
 
@@ -62,21 +62,21 @@ fi
 
 # install the knife-acl plugin into embedded knife, rsync the Chef repository into the non-root user
 # (vagrant)'s home directory, and add the dependency cookbooks from the file cache
-do_on_node bootstrap "sudo /opt/opscode/embedded/bin/gem install $FILECACHE_MOUNT_POINT/knife-acl-0.0.12.gem \
+do_on_node vm-bootstrap "sudo /opt/opscode/embedded/bin/gem install $FILECACHE_MOUNT_POINT/knife-acl-0.0.12.gem \
   && rsync -a $REPO_MOUNT_POINT/* \$HOME/chef-bcpc \
   && cp $FILECACHE_MOUNT_POINT/cookbooks/*.tar.gz \$HOME/chef-bcpc/cookbooks \
   && cd \$HOME/chef-bcpc/cookbooks && ls -1 *.tar.gz | xargs -I% tar xvzf %"
 
 # build binaries before uploading the bcpc cookbook
 # (this step will change later but using the existing build_bins script for now)
-do_on_node bootstrap "sudo apt-get update \
+do_on_node vm-bootstrap "sudo apt-get update \
   && cd \$HOME/chef-bcpc \
   && sudo bash -c 'export FILECACHE_MOUNT_POINT=$FILECACHE_MOUNT_POINT \
   && source \$HOME/proxy_config.sh && bootstrap/shared/shared_build_bins.sh'"
 
 # upload all cookbooks, roles and our chosen environment to the Chef server
 # (cookbook upload uses the cookbook_path set when configuring knife on the bootstrap node)
-do_on_node bootstrap "$KNIFE cookbook upload -a \
+do_on_node vm-bootstrap "$KNIFE cookbook upload -a \
   && cd \$HOME/chef-bcpc/roles && $KNIFE role from file *.json \
   && cd \$HOME/chef-bcpc/environments && $KNIFE environment from file $BOOTSTRAP_CHEF_ENV.json"
 
@@ -88,43 +88,43 @@ for vm in $vms $mon_vms; do
     echo "Installing latest chef-client found in $vm:$FILECACHE_MOUNT_POINT"
   fi
   do_on_node $vm "$CHEF_CLIENT_INSTALL_CMD"
-  do_on_node bootstrap "$KNIFE bootstrap -x vagrant -P vagrant --sudo 10.0.100.1${i}"
+  do_on_node vm-bootstrap "$KNIFE bootstrap -x vagrant -P vagrant --sudo 10.0.100.1${i}"
   i=`expr $i + 1`
 done
 
 # augment the previously configured nodes with our newly uploaded environments and roles
 ENVIRONMENT_SET=""
-for vm in bootstrap $vms $mon_vms; do
+for vm in vm-bootstrap $vms $mon_vms; do
   ENVIRONMENT_SET="$ENVIRONMENT_SET $KNIFE node environment set bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN $BOOTSTRAP_CHEF_ENV && "
 done
 ENVIRONMENT_SET="$ENVIRONMENT_SET :"
-do_on_node bootstrap $ENVIRONMENT_SET
+do_on_node vm-bootstrap $ENVIRONMENT_SET
 
-do_on_node bootstrap "$KNIFE node run_list set bcpc-bootstrap.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Bootstrap]' \
+do_on_node vm-bootstrap "$KNIFE node run_list set bcpc-vm-bootstrap.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Bootstrap]' \
   && $KNIFE node run_list set bcpc-vm1.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Headnode]' \
   && $KNIFE node run_list set bcpc-vm2.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Worknode]' \
   && $KNIFE node run_list set bcpc-vm3.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-EphemeralWorknode]'"
 
 # generate actor map and set bootstrap, vm1 and mon vms (if any) as admins so that they can write into the data bag
 ADMIN_SET="cd \$HOME && $KNIFE actor map && "
-for vm in bootstrap vm1 $mon_vms; do
+for vm in vm-bootstrap vm1 $mon_vms; do
   ADMIN_SET="$ADMIN_SET $KNIFE group add actor admins bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN && "
 done
 ADMIN_SET="$ADMIN_SET :"
-do_on_node bootstrap $ADMIN_SET
+do_on_node vm-bootstrap $ADMIN_SET
 
 # Clustered monitoring setup (>1 mon VM) requires completely initialized node attributes for chef to run
 # on each node successfully. If we are not converging automatically, set run_list (for mon VMs) and exit.
 # Otherwise, each mon VM needs to complete chef run first before setting the next node's run_list.
 if [[ $BOOTSTRAP_CHEF_DO_CONVERGE -eq 0 ]]; then
   for vm in $mon_vms; do
-    do_on_node bootstrap "$KNIFE node run_list set bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Monitoring]'"
+    do_on_node vm-bootstrap "$KNIFE node run_list set bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Monitoring]'"
   done
   echo "BOOTSTRAP_CHEF_DO_CONVERGE is set to 0, skipping automatic convergence."
   exit 0
 else
   # run Chef on each node
-  do_on_node bootstrap "sudo chef-client"
+  do_on_node vm-bootstrap "sudo chef-client"
   for vm in $vms; do
     do_on_node $vm "sudo chef-client"
   done
@@ -136,7 +136,7 @@ else
   done
   # Run chef on each mon VM before assigning next node for monitoring.
   for vm in $mon_vms; do
-    do_on_node bootstrap "$KNIFE node run_list set bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Monitoring]'"
+    do_on_node vm-bootstrap "$KNIFE node run_list set bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Monitoring]'"
     do_on_node $vm "sudo chef-client"
   done
   # Run chef on each mon VM except the last node to update cluster components

--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -188,12 +188,12 @@ Vagrant.configure("2") do |config|
     # puts "Cluster node count is being overridden to #{cluster_nodes} via CLUSTER_NODE_COUNT_OVERRIDE"
   end
 
-  vms_to_build = ['bootstrap', (1..cluster_nodes).collect {|x| "vm#{x}"}].flatten
+  vms_to_build = ['vm-bootstrap', (1..cluster_nodes).collect {|x| "vm#{x}"}].flatten
 
   vms_to_build.each_with_index do |vm, idx|
     config.vm.define vm do |m|
       # use .3 as the final octet for the bootstrap node, otherwise 11, 12, etc.
-      final_octet = (vm == 'bootstrap' ? 3 : 10+idx)
+      final_octet = (vm == 'vm-bootstrap' ? 3 : 10+idx)
       bootstrap_domain = (ENV['BCPC_HYPERVISOR_DOMAIN'] or "bcpc.example.com")
       m.vm.hostname = "bcpc-#{vm}.#{bootstrap_domain}"
       m.vm.network :private_network, ip: "10.0.100.#{final_octet}", netmask: "255.255.255.0", adapter_ip: "10.0.100.2"
@@ -237,7 +237,7 @@ Vagrant.configure("2") do |config|
 
       # from bootstrap node only: test proxy servers from inside to determine whether
       # everything's set up properly
-      if vm == 'bootstrap'
+      if vm == 'vm-bootstrap'
         m.vm.provision "testing-proxy-servers", type: "shell" do |s|
           s.privileged = false
           s.inline = $testing_proxy_servers_script
@@ -251,7 +251,7 @@ Vagrant.configure("2") do |config|
 
       # configure a hostfile entry with the IP of the bootstrap node (for Chef)
       m.vm.provision "configure-bootstrap-hostfile-entry", type: "shell" do |s|
-        s.inline = "echo -e '10.0.100.3\tbcpc-bootstrap.#{bootstrap_domain}\n' >> /etc/hosts"
+        s.inline = "echo -e '10.0.100.3\tbcpc-vm-bootstrap.#{bootstrap_domain}\n' >> /etc/hosts"
       end
 
       # clean up some packages installed in this image by default
@@ -267,7 +267,7 @@ Vagrant.configure("2") do |config|
       m.vm.box = "trusty64"
       m.vm.box_url = "#{ENV['BOOTSTRAP_CACHE_DIR']}/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
-      if vm == 'bootstrap'
+      if vm == 'vm-bootstrap'
         memory = ( ENV["BOOTSTRAP_VM_MEM"] or "2048" )
         cpus = ( ENV["BOOTSTRAP_VM_CPUS"] or "2" )
       else

--- a/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
+++ b/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
@@ -11,9 +11,9 @@ cd $REPO_ROOT/bootstrap/vagrant_scripts
 
 KNIFE=/opt/opscode/embedded/bin/knife
 # Dump the data bag contents to a variable.
-DATA_BAG=$(vagrant ssh bootstrap -c "$KNIFE data bag show configs $BOOTSTRAP_CHEF_ENV -F yaml")
+DATA_BAG=$(vagrant ssh vm-bootstrap -c "$KNIFE data bag show configs $BOOTSTRAP_CHEF_ENV -F yaml")
 # Get the management VIP.
-MANAGEMENT_VIP=$(vagrant ssh bootstrap -c "$KNIFE environment show $BOOTSTRAP_CHEF_ENV -a override_attributes.bcpc.management.vip | tail -n +2 | awk '{ print \$2 }'")
+MANAGEMENT_VIP=$(vagrant ssh vm-bootstrap -c "$KNIFE environment show $BOOTSTRAP_CHEF_ENV -a override_attributes.bcpc.management.vip | tail -n +2 | awk '{ print \$2 }'")
 
 # this is highly naive for obvious reasons (will break on multi-line keys, spaces)
 # but is sufficient for the items to be extracted here

--- a/cookbooks/bcpc/templates/default/hosts.erb
+++ b/cookbooks/bcpc/templates/default/hosts.erb
@@ -25,7 +25,7 @@ ff02::2 ip6-allrouters
     if @bootstrap_node
       bs_node_ip = ( @bootstrap_node['bcpc']['bootstrap'] && @bootstrap_node['bcpc']['bootstrap']['server'] )
       str = <<-EoF
-#{bs_node_ip}\t#{@bootstrap_node['hostname']}.#{@bootstrap_node['bcpc']['hypervisor_domain']}\t#{@bootstrap_node['fqdn']}
+#{bs_node_ip}\t#{@bootstrap_node['hostname']}.#{@bootstrap_node['bcpc']['hypervisor_domain']}\t#{@bootstrap_node['fqdn']} #{@bootstrap_node['hostname']}
       EoF
     end
 %>


### PR DESCRIPTION
All of our Zabbix templates and hostgroups have names equivalent to Chef roles, i.e. `BCPC-Headnode`. However, Zabbix apparently cannot associate templates with hosts that have the same name. I am proposing that we change the name of Vagrant-built bootstrap node to `bcpc-vm-bootstrap` in order to maintain the Zabbix template/hostgroup naming convention when we implement #835.

The Ansible bootstrap tools seem to use `ansible-bcpc-bootstrap` as the hostname, and the legacy ones are probably due to be deprecated. I can look into extending the PR to these tools if anyone feels it is necessary.

This PR is tested by completely rebuilding from scratch via `BOOT_GO.sh`.