### PR TITLE
Disable selection of compute host in functional check

### DIFF
--- a/cookbooks/bcpc/files/default/checks/nova
+++ b/cookbooks/bcpc/files/default/checks/nova
@@ -96,14 +96,16 @@ class TestNovaCompute(object):
         #
         if 'host' in self.config:
             availability_zone = self.config["cluster"] + ':' + self.config["host"]
+            server = self.client.servers.create(self.instance_name,
+                                                images[0],
+                                                flavors[0],
+                                                availability_zone=availability_zone,
+                                               )
         else:
-            availability_zone = self.config["cluster"]
-
-        server = self.client.servers.create(self.instance_name,
-                                        images[0],
-                                        flavors[0],
-                                        availability_zone=availability_zone,
-                                        )
+            server = self.client.servers.create(self.instance_name,
+                                                images[0],
+                                                flavors[0]
+                                               )
 
         if self._wait_for_statechange(server, "ACTIVE"):
             self._associate_floating_ip(server)

--- a/cookbooks/bcpc/templates/default/checks/nova.yml.erb
+++ b/cookbooks/bcpc/templates/default/checks/nova.yml.erb
@@ -5,4 +5,3 @@ password: '<%="#{get_config('keystone-admin-password')}"%>'
 auth_url: https://<%="#{node[:bcpc][:management][:vip]}"%>:5000/v2.0/
 timeout: 300
 cluster: <%=@node['bcpc']['region_name']%>
-host: <%=@node['hostname']%>


### PR DESCRIPTION
This should make the check more representative of actual usage. When applied, the `check nova` cron job will create VMs every 10 minutes on only `bcpc-vm2`, since it is the only host in `general_compute` aggregate. Verifiable by querying `nova.instances` tables, i.e. `select created_at, deleted_at, display_name, host from instances order by created_at desc;`