### PR TITLE
Parameterize and change conntrack defaults

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -400,6 +400,8 @@ default['bcpc']['mysql-head']['max_connections'] = 0
 default['bcpc']['system']['additional_reserved_ports'] = []
 # Any other sysctl parameters (register under parameters)
 default['bcpc']['system']['parameters']['kernel.pid_max'] = 4194303
+# Connection tracking table max size
+default['bcpc']['system']['parameters']['net.nf_conntrack_max'] = 262144
 
 ###########################################
 #

--- a/cookbooks/bcpc/recipes/diamond.rb
+++ b/cookbooks/bcpc/recipes/diamond.rb
@@ -117,6 +117,15 @@ if node['bcpc']['enabled']['metrics'] then
         end
     end
 
+    template "/etc/diamond/collectors/ConnTrackCollector.conf" do
+        source "diamond-collector.conf.erb"
+        owner "diamond"
+        group "root"
+        mode 00600
+        notifies :restart, "service[diamond]", :delayed
+        only_if "lsmod | grep -q conntrack"
+    end
+
     directory '/usr/share/diamond/collectors/Cloud/' do
         owner 'root'
         group 'root'

--- a/cookbooks/bcpc/recipes/packages-debugging.rb
+++ b/cookbooks/bcpc/recipes/packages-debugging.rb
@@ -30,6 +30,7 @@ package "tshark"
 package "nmap"
 package "iperf"
 package "curl"
+package "conntrack"
 
 # I/O troubleshooting tools
 package "fio"

--- a/cookbooks/bcpc/recipes/system.rb
+++ b/cookbooks/bcpc/recipes/system.rb
@@ -36,6 +36,13 @@ execute "reload-sysctl" do
     command "sysctl -p /etc/sysctl.d/70-bcpc.conf"
 end
 
+ruby_block "set-nf_conntrack-hashsize" do
+    block do
+        %x[ echo $((#{node['bcpc']['system']['parameters']['net.nf_conntrack_max']}/8)) > /sys/module/nf_conntrack/parameters/hashsize ]
+    end
+    not_if { system "grep -q ^$((#{node['bcpc']['system']['parameters']['net.nf_conntrack_max']}/8))$ /sys/module/nf_conntrack/parameters/hashsize" }
+end
+
 bash "set-deadline-io-scheduler" do
     user "root"
     code <<-EOH


### PR DESCRIPTION
`nf_conntrack: table full, dropping packet` could be observed on busy hypervisors. While it is not exactly known what the breakdown of active sessions or root cause is, increasing the defaults seems like a common operator practice. `conntrack` package is also installed for viewing of connection tracking table.