### PR TITLE
Rework Keystone endpoint/service creation

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -235,52 +235,10 @@ default['bcpc']['horizon']['disable_panels'] = ['containers']
 
 ###########################################
 #
-#  Keystone Settings
+# Service catalog (API versions/endpoints)
 #
 ###########################################
-#
-# Defaut log file
-default['bcpc']['keystone']['log_file'] = '/var/log/keystone/keystone.log'
-# Eventlet server is deprecated in Kilo, so by default we
-# serve Keystone via Apache now.
-default['bcpc']['keystone']['eventlet_server'] = false
-# Turn caching via memcached on or off.
-default['bcpc']['keystone']['enable_caching'] = true
-# Enable debug logging (also caching debug logging).
-default['bcpc']['keystone']['debug'] = false
-# Enable verbose logging.
-default['bcpc']['keystone']['verbose'] = false
-# Set the timeout for how long we will wait for Keystone to become operational
-# before failing (configures timeout on the wait-for-keystone-to-be-operational
-# spinlock guard).
-default['bcpc']['keystone']['wait_for_keystone_timeout'] = 120
-# Set the number of Keystone WSGI processes and threads to use by default on the
-# public API (experimentally threads > 1 may cause problems with the service
-# catalog, for now we recommend scaling only in the processes dimension)
-default['bcpc']['keystone']['wsgi']['processes'] = 5
-default['bcpc']['keystone']['wsgi']['threads'] = 1
-# The driver section below allows either 'sql' or 'ldap' (or 'templated' for catalog)
-# Note that not all drivers may support SQL/LDAP, only tinker if you know what you're getting into
-default['bcpc']['keystone']['drivers']['assignment'] = 'sql'
-default['bcpc']['keystone']['drivers']['catalog'] = 'sql'
-default['bcpc']['keystone']['drivers']['credential'] = 'sql'
-default['bcpc']['keystone']['drivers']['domain_config'] = 'sql'
-default['bcpc']['keystone']['drivers']['endpoint_filter'] = 'sql'
-default['bcpc']['keystone']['drivers']['endpoint_policy'] = 'sql'
-default['bcpc']['keystone']['drivers']['federation'] = 'sql'
-default['bcpc']['keystone']['drivers']['identity'] = 'sql'
-default['bcpc']['keystone']['drivers']['identity_mapping'] = 'sql'
-default['bcpc']['keystone']['drivers']['oauth1'] = 'sql'
-default['bcpc']['keystone']['drivers']['policy'] = 'sql'
-default['bcpc']['keystone']['drivers']['revoke'] = 'sql'
-default['bcpc']['keystone']['drivers']['role'] = 'sql'
-default['bcpc']['keystone']['drivers']['trust'] = 'sql'
-# Notifications driver
-default['bcpc']['keystone']['drivers']['notification'] = 'log'
-# Notifications format. See: http://docs.openstack.org/developer/keystone/event_notifications.html
-default['bcpc']['keystone']['notification_format'] = 'cadf'
-# OpenStack API service/endpoint matrix
-default['bcpc']['keystone']['api_matrix'] = {
+default['bcpc']['catalog'] = {
   'identity' => {
     'name' => 'keystone',
     'project' => 'keystone',
@@ -372,6 +330,53 @@ default['bcpc']['keystone']['api_matrix'] = {
     }
   }
 }
+
+###########################################
+#
+#  Keystone Settings
+#
+###########################################
+#
+# Default log file
+default['bcpc']['keystone']['log_file'] = '/var/log/keystone/keystone.log'
+# Eventlet server is deprecated in Kilo, so by default we
+# serve Keystone via Apache now.
+default['bcpc']['keystone']['eventlet_server'] = false
+# Turn caching via memcached on or off.
+default['bcpc']['keystone']['enable_caching'] = true
+# Enable debug logging (also caching debug logging).
+default['bcpc']['keystone']['debug'] = false
+# Enable verbose logging.
+default['bcpc']['keystone']['verbose'] = false
+# Set the timeout for how long we will wait for Keystone to become operational
+# before failing (configures timeout on the wait-for-keystone-to-be-operational
+# spinlock guard).
+default['bcpc']['keystone']['wait_for_keystone_timeout'] = 120
+# Set the number of Keystone WSGI processes and threads to use by default on the
+# public API (experimentally threads > 1 may cause problems with the service
+# catalog, for now we recommend scaling only in the processes dimension)
+default['bcpc']['keystone']['wsgi']['processes'] = 5
+default['bcpc']['keystone']['wsgi']['threads'] = 1
+# The driver section below allows either 'sql' or 'ldap' (or 'templated' for catalog)
+# Note that not all drivers may support SQL/LDAP, only tinker if you know what you're getting into
+default['bcpc']['keystone']['drivers']['assignment'] = 'sql'
+default['bcpc']['keystone']['drivers']['catalog'] = 'sql'
+default['bcpc']['keystone']['drivers']['credential'] = 'sql'
+default['bcpc']['keystone']['drivers']['domain_config'] = 'sql'
+default['bcpc']['keystone']['drivers']['endpoint_filter'] = 'sql'
+default['bcpc']['keystone']['drivers']['endpoint_policy'] = 'sql'
+default['bcpc']['keystone']['drivers']['federation'] = 'sql'
+default['bcpc']['keystone']['drivers']['identity'] = 'sql'
+default['bcpc']['keystone']['drivers']['identity_mapping'] = 'sql'
+default['bcpc']['keystone']['drivers']['oauth1'] = 'sql'
+default['bcpc']['keystone']['drivers']['policy'] = 'sql'
+default['bcpc']['keystone']['drivers']['revoke'] = 'sql'
+default['bcpc']['keystone']['drivers']['role'] = 'sql'
+default['bcpc']['keystone']['drivers']['trust'] = 'sql'
+# Notifications driver
+default['bcpc']['keystone']['drivers']['notification'] = 'log'
+# Notifications format. See: http://docs.openstack.org/developer/keystone/event_notifications.html
+default['bcpc']['keystone']['notification_format'] = 'cadf'
 
 # LDAP credentials used by Keystone
 default['bcpc']['ldap']['admin_user'] = nil

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -279,6 +279,100 @@ default['bcpc']['keystone']['drivers']['trust'] = 'sql'
 default['bcpc']['keystone']['drivers']['notification'] = 'log'
 # Notifications format. See: http://docs.openstack.org/developer/keystone/event_notifications.html
 default['bcpc']['keystone']['notification_format'] = 'cadf'
+# OpenStack API service/endpoint matrix
+default['bcpc']['keystone']['api_matrix'] = {
+  'identity' => {
+    'name' => 'keystone',
+    'project' => 'keystone',
+    'description' => 'OpenStack Identity',
+    'ports' => {
+      'admin' => 35357,
+      'internal' => 5000,
+      'public' => 5000
+    },
+    'uris' => {
+      'admin' => 'v2.0',
+      'internal' => 'v2.0',
+      'public' => 'v2.0'
+    }
+  },
+  'compute' => {
+    'name' => 'Compute Service',
+    'project' => 'nova',
+    'description' => 'OpenStack Compute Service',
+    'ports' => {
+      'admin' => 8774,
+      'internal' => 8774,
+      'public' => 8774
+    },
+    'uris' => {
+      'admin' => 'v1.1/$(tenant_id)s',
+      'internal' => 'v1.1/$(tenant_id)s',
+      'public' => 'v1.1/$(tenant_id)s'
+    }
+  },
+  'ec2' => {
+    'name' => 'EC2 Service',
+    'project' => 'nova',
+    'description' => 'OpenStack EC2 Service',
+    'ports' => {
+      'admin' => 8773,
+      'internal' => 8773,
+      'public' => 8773
+    },
+    'uris' => {
+      'admin' => 'services/Admin',
+      'internal' => 'services/Cloud',
+      'public' => 'services/Cloud'
+    }
+  },
+  'volume' => {
+    'name' => 'Volume Service',
+    'project' => 'cinder',
+    'description' => 'OpenStack Volume Service',
+    'ports' => {
+      'admin' => 8776,
+      'internal' => 8776,
+      'public' => 8776
+    },
+    'uris' => {
+      'admin' => 'v1/$(tenant_id)s',
+      'internal' => 'v1/$(tenant_id)s',
+      'public' => 'v1/$(tenant_id)s'
+    }
+  },
+  'volumev2' => {
+    'name' => 'cinderv2',
+    'project' => 'cinder',
+    'description' => 'OpenStack Volume Service V2',
+    'ports' => {
+      'admin' => 8776,
+      'internal' => 8776,
+      'public' => 8776
+    },
+    'uris' => {
+      'admin' => 'v2/$(tenant_id)s',
+      'internal' => 'v2/$(tenant_id)s',
+      'public' => 'v2/$(tenant_id)s'
+    }
+  },
+  'image' => {
+    'name' => 'Image Service',
+    'project' => 'glance',
+    'description' => 'OpenStack Image Service',
+    'ports' => {
+      'admin' => 9292,
+      'internal' => 9292,
+      'public' => 9292
+    },
+    'uris' => {
+      'admin' => 'v2',
+      'internal' => 'v2',
+      'public' => 'v2'
+    }
+  }
+}
+
 # LDAP credentials used by Keystone
 default['bcpc']['ldap']['admin_user'] = nil
 default['bcpc']['ldap']['admin_pass'] = nil

--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -246,19 +246,19 @@ bash "keystone-create-admin-user-role" do
 end
 
 # create services and endpoints
-node['bcpc']['keystone']['api_matrix'].each do |svc, svcprops|
+node['bcpc']['catalog'].each do |svc, svcprops|
   ruby_block "keystone-create-#{svc}-service" do
     block do
       %x[
         export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['keystone']['api_matrix']['identity']['ports']['admin']}/#{node['bcpc']['keystone']['api_matrix']['identity']['uris']['admin']}/";
+        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['catalog']['identity']['ports']['admin']}/#{node['bcpc']['catalog']['identity']['uris']['admin']}/";
         openstack service create --name '#{svcprops['name']}' --description '#{svcprops['description']}' #{svc}
       ]
     end
     only_if {
       services_raw = %x[
         export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['keystone']['api_matrix']['identity']['ports']['admin']}/#{node['bcpc']['keystone']['api_matrix']['identity']['uris']['admin']}/\";
+        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['catalog']['identity']['ports']['admin']}/#{node['bcpc']['catalog']['identity']['uris']['admin']}/\";
         openstack service list -f json
       ]
       services = JSON.parse(services_raw)
@@ -270,7 +270,7 @@ node['bcpc']['keystone']['api_matrix'].each do |svc, svcprops|
     block do
       %x[
         export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['keystone']['api_matrix']['identity']['ports']['admin']}/#{node['bcpc']['keystone']['api_matrix']['identity']['uris']['admin']}/";
+        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['catalog']['identity']['ports']['admin']}/#{node['bcpc']['catalog']['identity']['uris']['admin']}/";
         openstack endpoint create \
             --region '#{node['bcpc']['region_name']}' \
             --publicurl '#{node['bcpc']['protocol'][svcprops['project']]}://openstack.#{node['bcpc']['cluster_domain']}:#{svcprops['ports']['public']}/#{svcprops['uris']['public']}' \
@@ -282,7 +282,7 @@ node['bcpc']['keystone']['api_matrix'].each do |svc, svcprops|
     only_if {
       endpoints_raw = %x[
         export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['keystone']['api_matrix']['identity']['ports']['admin']}/#{node['bcpc']['keystone']['api_matrix']['identity']['uris']['admin']}/\";
+        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['catalog']['identity']['ports']['admin']}/#{node['bcpc']['catalog']['identity']['uris']['admin']}/\";
         openstack endpoint list -f json
       ]
       endpoints = JSON.parse(endpoints_raw)

--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -245,199 +245,48 @@ bash "keystone-create-admin-user-role" do
     not_if ". /root/keystonerc; . /root/adminrc; keystone user-role-list --user  $OS_USERNAME  --tenant '#{node['bcpc']['admin_tenant']}'   | grep '#{node['bcpc']['admin_role']}'"
 end
 
-ruby_block "keystone-create-identity-service" do
-  block do
-  %x[
+# create services and endpoints
+node['bcpc']['keystone']['api_matrix'].each do |svc, svcprops|
+  ruby_block "keystone-create-#{svc}-service" do
+    block do
+      %x[
         export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack service create --name 'keystone' --description 'OpenStack Identity' identity;
-  ]
-  end
-  not_if { system "export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-                   export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-                   openstack service list -f json | jq '.[] | .Type==\"identity\"' | grep '^true$'"
-  }
-end
-
-ruby_block "keystone-create-compute-service" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack service create --name 'Compute Service' --description 'OpenStack Compute Service' compute
-  ]
-  end
-  not_if { system "
+        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['keystone']['api_matrix']['identity']['ports']['admin']}/#{node['bcpc']['keystone']['api_matrix']['identity']['uris']['admin']}/";
+        openstack service create --name '#{svcprops['name']}' --description '#{svcprops['description']}' #{svc}
+      ]
+    end
+    only_if {
+      services_raw = %x[
         export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack service list -f json | jq '.[] | .Type==\"compute\"' | grep '^true$';" }
-end
-
-ruby_block "keystone-create-ec2-service" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack service create --name 'EC2 Service' --description 'OpenStack EC2 Service' ec2
-  ]
+        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['keystone']['api_matrix']['identity']['ports']['admin']}/#{node['bcpc']['keystone']['api_matrix']['identity']['uris']['admin']}/\";
+        openstack service list -f json
+      ]
+      services = JSON.parse(services_raw)
+      services.select { |s| s['Type'] == svc }.length.zero?
+    }
   end
-  not_if { system "
-        export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack service list -f json | jq '.[] | .Type==\"ec2\"' | grep '^true$';" }
-end
 
-ruby_block "keystone-create-volume-service" do
-  block do
-  %x[
+  ruby_block "keystone-create-#{svc}-endpoint" do
+    block do
+      %x[
         export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack service create --name 'Volume Service' --description 'OpenStack Volume Service' volume
-  ]
-  end
-  not_if { system "
-        export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack service list -f json | jq '.[] | .Type==\"volume\"' | grep '^true$';" }
-end
-
-ruby_block "keystone-create-volumeV2-service" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack service create --name 'cinderv2' --description 'OpenStack Volume Service V2' volumev2
-  ]
-  end
-  not_if { system "
-        export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack service list -f json | jq '.[] | .Type==\"volumev2\"' | grep '^true$';" }
-end
-
-ruby_block "keystone-create-image-service" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack service create --name 'Image Service' --description 'OpenStack Image Service' image
-  ]
-  end
-  not_if { system "
-        export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack service list -f json | jq '.[] | .Type==\"image\"' | grep '^true$';" }
-end
-
-ruby_block "keystone-create-identity-endpoint" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
+        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['keystone']['api_matrix']['identity']['ports']['admin']}/#{node['bcpc']['keystone']['api_matrix']['identity']['uris']['admin']}/";
         openstack endpoint create \
             --region '#{node['bcpc']['region_name']}' \
-            --publicurl '#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:5000/v2.0' \
-            --adminurl '#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0' \
-            --internalurl '#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:5000/v2.0' \
-            identity;
-  ]
-  end
-  not_if { system "
+            --publicurl '#{node['bcpc']['protocol'][svcprops['project']]}://openstack.#{node['bcpc']['cluster_domain']}:#{svcprops['ports']['public']}/#{svcprops['uris']['public']}' \
+            --adminurl '#{node['bcpc']['protocol'][svcprops['project']]}://openstack.#{node['bcpc']['cluster_domain']}:#{svcprops['ports']['admin']}/#{svcprops['uris']['admin']}' \
+            --internalurl '#{node['bcpc']['protocol'][svcprops['project']]}://openstack.#{node['bcpc']['cluster_domain']}:#{svcprops['ports']['internal']}/#{svcprops['uris']['internal']}' \
+            #{svc}
+      ]
+    end
+    only_if {
+      endpoints_raw = %x[
         export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack endpoint list -f json | jq '.[] | .[\"Service Type\"]==\"identity\"' | grep '^true$';" }
-end
-
-ruby_block "keystone-create-compute-endpoint" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack endpoint create \
-            --region '#{node['bcpc']['region_name']}' \
-            --publicurl '#{node['bcpc']['protocol']['nova']}://openstack.#{node['bcpc']['cluster_domain']}:8774/v1.1/$(tenant_id)s' \
-            --adminurl '#{node['bcpc']['protocol']['nova']}://openstack.#{node['bcpc']['cluster_domain']}:8774/v1.1/$(tenant_id)s' \
-            --internalurl '#{node['bcpc']['protocol']['nova']}://openstack.#{node['bcpc']['cluster_domain']}:8774/v1.1/$(tenant_id)s' \
-            compute;
-  ]
+        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:#{node['bcpc']['keystone']['api_matrix']['identity']['ports']['admin']}/#{node['bcpc']['keystone']['api_matrix']['identity']['uris']['admin']}/\";
+        openstack endpoint list -f json
+      ]
+      endpoints = JSON.parse(endpoints_raw)
+      endpoints.select { |e| e['Service Type'] == svc }.length.zero?
+    }
   end
-  not_if { system "
-        export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack endpoint list -f json | jq '.[] | .[\"Service Type\"]==\"compute\"' | grep '^true$';" }
-end
-
-ruby_block "keystone-create-volume-endpoint" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack endpoint create \
-            --region '#{node['bcpc']['region_name']}' \
-            --publicurl '#{node['bcpc']['protocol']['cinder']}://openstack.#{node['bcpc']['cluster_domain']}:8776/v1/$(tenant_id)s' \
-            --adminurl '#{node['bcpc']['protocol']['cinder']}://openstack.#{node['bcpc']['cluster_domain']}:8776/v1/$(tenant_id)s' \
-            --internalurl '#{node['bcpc']['protocol']['cinder']}://openstack.#{node['bcpc']['cluster_domain']}:8776/v1/$(tenant_id)s' \
-            volume;
-  ]
-  end
-  not_if { system "
-        export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack endpoint list -f json | jq '.[] | .[\"Service Type\"]==\"volume\"' | grep '^true$';" }
-end
-
-ruby_block "keystone-create-volumeV2-endpoint" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack endpoint create \
-            --region '#{node['bcpc']['region_name']}' \
-            --publicurl '#{node['bcpc']['protocol']['cinder']}://openstack.#{node['bcpc']['cluster_domain']}:8776/v2/$(tenant_id)s' \
-            --adminurl '#{node['bcpc']['protocol']['cinder']}://openstack.#{node['bcpc']['cluster_domain']}:8776/v2/$(tenant_id)s' \
-            --internalurl '#{node['bcpc']['protocol']['cinder']}://openstack.#{node['bcpc']['cluster_domain']}:8776/v2/$(tenant_id)s' \
-            volumev2;
-  ]
-  end
-  not_if { system "
-        export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack endpoint list -f json | jq '.[] | .[\"Service Type\"]==\"volumev2\"' | grep '^true$';" }
-end
-
-ruby_block "keystone-create-image-endpoint" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack endpoint create \
-            --region '#{node['bcpc']['region_name']}' \
-            --publicurl '#{node['bcpc']['protocol']['glance']}://openstack.#{node['bcpc']['cluster_domain']}:9292/v2' \
-            --adminurl '#{node['bcpc']['protocol']['glance']}://openstack.#{node['bcpc']['cluster_domain']}:9292/v2' \
-            --internalurl '#{node['bcpc']['protocol']['glance']}://openstack.#{node['bcpc']['cluster_domain']}:9292/v2' \
-            image;
-  ]
-  end
-  not_if { system "
-        export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack endpoint list -f json | jq '.[] | .[\"Service Type\"]==\"image\"' | grep '^true$';" }
-end
-
-ruby_block "keystone-create-ec2-endpoint" do
-  block do
-  %x[
-        export OS_TOKEN="#{get_config('keystone-admin-token')}";
-        export OS_URL="#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/";
-        openstack endpoint create \
-            --region '#{node['bcpc']['region_name']}' \
-            --publicurl '#{node['bcpc']['protocol']['nova']}://openstack.#{node['bcpc']['cluster_domain']}:8773/services/Cloud' \
-            --adminurl '#{node['bcpc']['protocol']['nova']}://openstack.#{node['bcpc']['cluster_domain']}:8773/services/Admin' \
-            --internalurl '#{node['bcpc']['protocol']['nova']}://openstack.#{node['bcpc']['cluster_domain']}:8773/services/Cloud' \
-            ec2;
-  ]
-  end
-  not_if { system "export OS_TOKEN=\"#{get_config('keystone-admin-token')}\";
-        export OS_URL=\"#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:35357/v2.0/\";
-        openstack endpoint list -f json | jq '.[] | .[\"Service Type\"]==\"ec2\"' | grep '^true$';" }
 end


### PR DESCRIPTION
### Overview
This PR revises the Chef resources that converge Keystone endpoints and services in the following ways:
* copied-and-pasted Chef resources have been replaced with generalized resources in an `each` block
* the specification of all metadata for endpoints/services has been moved to a hash in the default attributes
* parsing the JSON output of the `openstack` command via `jq` has been replaced by Ruby's JSON parser

### Rationale
* Testing upgraded API versions has been very confusing because of the number of different places where you have to modify multiple Chef resources to successfully uplift an API version.
* Resources that can be templated should be.

### Testing
* This should be a no-op on an already built cluster and should produce the same results as the previous mechanism on a newly built cluster (the commands being executed are the same).
* The diff on `keystone.rb` is really confusing and I would recommend comparing the old and new versions side by side rather than trying to make sense of the crazy diff.