### PR TITLE
Parameterize bcpc.preseed.kernel

### DIFF
--- a/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
@@ -50,7 +50,7 @@ d-i     clock-setup/ntp boolean true
 d-i     clock-setup/ntp-server  string <%= @node['ntp']['servers'].first %>
 # This will install the base 12.04 kernel image.  If you comment out the
 # following line, it will install the upgraded kernel LTS stack.
-d-i     base-installer/kernel/image     string linux-server
+d-i     base-installer/kernel/image     string <%= @node['bcpc']['preseed']['kernel'] %>
 d-i     passwd/root-login       boolean false
 d-i     passwd/make-user        boolean true
 d-i     passwd/user-fullname    string ubuntu
@@ -95,14 +95,11 @@ d-i     debian-installer/exit/poweroff  boolean false
 d-i     pkgsel/include string openssh-server
 
 d-i     preseed/late_command string true && \
-        wget "http://$http_server:$http_port/cblr/svc/op/nopxe/system/$system_name" -O /dev/null ;\
-        <% if @node['bcpc']['preseed'] && @node['bcpc']['preseed']['kernel'] %>
-        in-target apt-get install -y <%= @node['bcpc']['preseed']['kernel'] %> ;\
-        <% else %>
-        true ;\
+        <% unless node.default['bcpc']['preseed']['kernel'] == node['bcpc']['preseed']['kernel'] %>
+        in-target apt-get -y install <%= node['bcpc']['preseed']['kernel'].gsub('linux-image', 'linux-image-extra') %> ;\
         <% end %>
-        wget "http://$http_server:$http_port/cblr/svc/op/nopxe/system/$system_name" -O /dev/null ;\
         in-target env no_proxy=$http_server wget "http://$http_server:$http_port/cobbler/pub/scripts/get-ssh-keys" -O /root/get-ssh-keys ;\
         in-target chmod 0755 /root/get-ssh-keys ; in-target install -d -m0600 /root/.ssh ;\
         in-target env no_proxy=$http_server /root/get-ssh-keys root -o /root/.ssh/authorized_keys ;\
-        echo -e "\n<%=@bootstrap_node['bcpc']['bootstrap'] && @bootstrap_node['bcpc']['bootstrap']['server']%>\t<%=@bootstrap_node['fqdn']%>\n" >> /target/etc/hosts
+        echo -e "\n<%=@bootstrap_node['bcpc']['bootstrap'] && @bootstrap_node['bcpc']['bootstrap']['server']%>\t<%=@bootstrap_node['fqdn']%>\n" >> /target/etc/hosts ;\
+        wget "http://$http_server:$http_port/cblr/svc/op/nopxe/system/$system_name" -O /dev/null ;

--- a/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
@@ -95,8 +95,9 @@ d-i     debian-installer/exit/poweroff  boolean false
 d-i     pkgsel/include string openssh-server
 
 d-i     preseed/late_command string true && \
-        <% unless node.default['bcpc']['preseed']['kernel'] == node['bcpc']['preseed']['kernel'] %>
-        in-target apt-get -y install <%= node['bcpc']['preseed']['kernel'].gsub('linux-image', 'linux-image-extra') %> ;\
+        <%# known meta packages that automatically pull in linux-image-extra are linux-server, linux-image-generic-lts-*, linux-image-generic %>
+        <% unless ['linux-server', 'linux-image-generic'].include?(@node['bcpc']['preseed']['kernel']) or @node['bcpc']['preseed']['kernel'].start_with?('linux-image-generic-lts-') %>
+        in-target apt-get -y install <%= @node['bcpc']['preseed']['kernel'].gsub('linux-image', 'linux-image-extra') %> ;\
         <% end %>
         in-target env no_proxy=$http_server wget "http://$http_server:$http_port/cobbler/pub/scripts/get-ssh-keys" -O /root/get-ssh-keys ;\
         in-target chmod 0755 /root/get-ssh-keys ; in-target install -d -m0600 /root/.ssh ;\


### PR DESCRIPTION
- also install linux-image-extra if a particular kernel version is being
  tracked
- remove redundant wget from late_command
- move success signal to Cobbler to end of late_command