### PR TITLE
Openstack quota bump fixes

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -657,7 +657,9 @@ default['bcpc']['rgw_quota'] = {
 default['bcpc']['quota'] = {
     'nova' => {
         'AdminTenant' => {
-           'cores' => -1
+           'cores'        => -1,
+           'ram'          => -1,
+           'floating_ips' => -1
         }
     }
 }

--- a/cookbooks/bcpc/files/default/set-os-quota.py
+++ b/cookbooks/bcpc/files/default/set-os-quota.py
@@ -87,8 +87,8 @@ class OSQuota(object):
                               % component)
                 raise Exception("Unrecognized component %s" % component)
 
-        quota_cmd.append('--' + string.replace(resource, '_', '-'))
-        quota_cmd.append(str(limit))
+            quota_cmd.append('--' + string.replace(resource, '_', '-'))
+            quota_cmd.append(str(limit))
 
         # Force nova quota reductions regardless of current usage
         # Cinder quota reductions do not validate current usages by default
@@ -101,8 +101,8 @@ class OSQuota(object):
         for component in config:
             for project in config[component]:
                 tenant_id = self._get_tenant_id(project)
-                current_quota = self._get_current_quota(component, tenant_id)
-                conf_quota = self._parse_conf_quota(config[component][project])
+                current_quota = sorted(self._get_current_quota(component, tenant_id))
+                conf_quota = sorted(self._parse_conf_quota(config[component][project]))
                 # If defined quota does not match in-effect quota, apply update
                 if cmp(current_quota, conf_quota) != 0:
                     quota_cmd = self._construct_quota_cmd(component,


### PR DESCRIPTION
Remove `ram` and `floating_ips` quota limits for AdminTenant. The current reduced limit can break `check nova` on clusters with >= 5 head nodes. This also includes fix to apply quotas correctly and attempts to prevent re-running `nova quota-update...` when they are already defined in Openstack.

When cheffed in, the AdminTenant quota will be:
```
root@bcpc-vm1:~# nova quota-show --tenant <AdminTenant project ID>
+-----------------------------+-------+
| Quota                       | Limit |
+-----------------------------+-------+
| instances                   | -1    |
| cores                       | -1    |
| ram                         | -1    |
| floating_ips                | -1    |
```

In syslog:
```Mar  3 20:47:31 bcpc-vm1 set-os-quota.py: Updated nova quota for AdminTenant: [('cores', -1), ('floating_ips', -1), ('ram', -1)]```

Re-running `/usr/local/bin/set-os-quota.py` should not yield another log entry.