### PR TITLE
Enable compatibility with newer Chef versions

### DIFF
--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-client.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-client.yml
@@ -44,17 +44,24 @@
     become: no
     when: bootstrap_node_enrolled.rc == 100
 
-  - name: Install knife-acl gem
-    become: yes
-    command: /opt/opscode/embedded/bin/gem install {{ bootstrap_files_dir }}/{{ chef_bcpc_version }}/knife-acl-0.0.12.gem
-
-  - name: Create Chef actor map
+  - name: Determine if previous version of knife-acl (0.0.12) is installed
+    command: /opt/opscode/embedded/bin/gem list -i knife-acl -v 0.0.12
     become: no
-    command: /opt/opscode/embedded/bin/knife actor map
+    ignore_errors: yes
+    register: old_knife_acl_installed
+
+  - name: Remove previous version of knife-acl
+    become: yes
+    command: /opt/opscode/embedded/bin/gem uninstall knife-acl -v 0.0.12
+    when: old_knife_acl_installed.stdout.find('true')
+
+  - name: Install knife-acl 1.0.2
+    become: yes
+    command: /opt/opscode/embedded/bin/gem install {{ bootstrap_files_dir }}/{{ chef_bcpc_version }}/knife-acl-1.0.2.gem
 
   - name: Make bootstrap node an admin in the Chef server
     become: no
-    command: /opt/opscode/embedded/bin/knife group add actor admins {{ hostfqdn.stdout }}
+    command: /opt/opscode/embedded/bin/knife group add client {{ hostfqdn.stdout }} admins
 
   - name: Assign hardware and bootstrap role to bootstrap node
     become: no

--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-server.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-server.yml
@@ -1,6 +1,7 @@
 ---
   - name: Install Chef Server 12
     apt: deb={{ bootstrap_files_dir }}/{{ chef_bcpc_version }}/{{ chef_server_deb }}
+    register: chef_server_installation
     tags:
       - chef
 
@@ -28,9 +29,30 @@
     tags:
       - chef
 
+  - name: Run Chef Server upgrade
+    become: yes
+    command: chef-server-ctl upgrade -y
+    when: chef_server_installation.changed
+    tags:
+      - chef
+
   - name: Run Chef Server configuration
     become: yes
     command: chef-server-ctl reconfigure
+    tags:
+      - chef
+
+  - name: Restart Chef Server components after upgrade
+    sudo: yes
+    command: chef-server-ctl restart
+    when: chef_server_installation.changed
+    tags:
+      - chef
+
+  - name: Magic sleep after Chef Server restart
+    become: no
+    pause: seconds=10
+    when: chef_server_installation.changed
     tags:
       - chef
 

--- a/bootstrap/shared/shared_configure_chef.sh
+++ b/bootstrap/shared/shared_configure_chef.sh
@@ -62,7 +62,7 @@ fi
 
 # install the knife-acl plugin into embedded knife, rsync the Chef repository into the non-root user
 # (vagrant)'s home directory, and add the dependency cookbooks from the file cache
-do_on_node vm-bootstrap "sudo /opt/opscode/embedded/bin/gem install $FILECACHE_MOUNT_POINT/knife-acl-0.0.12.gem \
+do_on_node vm-bootstrap "sudo /opt/opscode/embedded/bin/gem install $FILECACHE_MOUNT_POINT/knife-acl-1.0.2.gem \
   && rsync -a $REPO_MOUNT_POINT/* \$HOME/chef-bcpc \
   && cp $FILECACHE_MOUNT_POINT/cookbooks/*.tar.gz \$HOME/chef-bcpc/cookbooks \
   && cd \$HOME/chef-bcpc/cookbooks && ls -1 *.tar.gz | xargs -I% tar xvzf %"
@@ -105,10 +105,10 @@ do_on_node vm-bootstrap "$KNIFE node run_list set bcpc-vm-bootstrap.$BCPC_HYPERV
   && $KNIFE node run_list set bcpc-vm2.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Worknode]' \
   && $KNIFE node run_list set bcpc-vm3.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-EphemeralWorknode]'"
 
-# generate actor map and set bootstrap, vm1 and mon vms (if any) as admins so that they can write into the data bag
-ADMIN_SET="cd \$HOME && $KNIFE actor map && "
+# set bootstrap, vm1 and mon vms (if any) as admins so that they can write into the data bag
+ADMIN_SET="true && "
 for vm in vm-bootstrap vm1 $mon_vms; do
-  ADMIN_SET="$ADMIN_SET $KNIFE group add actor admins bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN && "
+  ADMIN_SET="$ADMIN_SET $KNIFE group add client bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN admins && "
 done
 ADMIN_SET="$ADMIN_SET :"
 do_on_node vm-bootstrap $ADMIN_SET

--- a/bootstrap/shared/shared_prereqs.sh
+++ b/bootstrap/shared/shared_prereqs.sh
@@ -57,8 +57,8 @@ BOX=trusty-server-cloudimg-amd64-vagrant-disk1.box
 download_file $BOX http://cloud-images.ubuntu.com/vagrant/trusty/current/$BOX
 
 # Obtain Chef client and server DEBs.
-CHEF_CLIENT_DEB=${CHEF_CLIENT_DEB:-chef_12.3.0-1_amd64.deb}
-CHEF_SERVER_DEB=${CHEF_SERVER_DEB:-chef-server-core_12.0.8-1_amd64.deb}
+CHEF_CLIENT_DEB=${CHEF_CLIENT_DEB:-chef_12.9.41-1_amd64.deb}
+CHEF_SERVER_DEB=${CHEF_SERVER_DEB:-chef-server-core_12.6.0-1_amd64.deb}
 download_file $CHEF_CLIENT_DEB https://packages.chef.io/stable/ubuntu/10.04/$CHEF_CLIENT_DEB
 download_file $CHEF_SERVER_DEB https://packages.chef.io/stable/ubuntu/14.04/$CHEF_SERVER_DEB
 

--- a/bootstrap/shared/shared_prereqs.sh
+++ b/bootstrap/shared/shared_prereqs.sh
@@ -74,7 +74,7 @@ download_file cookbooks/hostsfile-2.4.5.tar.gz https://supermarket.chef.io/api/v
 download_file cookbooks/concat-0.3.0.tar.gz https://supermarket.chef.io/api/v1/cookbooks/concat/versions/0.3.0/download
 
 # Pull knife-acl gem.
-download_file knife-acl-0.0.12.gem https://rubygems.global.ssl.fastly.net/gems/knife-acl-0.0.12.gem
+download_file knife-acl-1.0.2.gem https://rubygems.global.ssl.fastly.net/gems/knife-acl-1.0.2.gem
 
 # Pull needed gems for fpm.
 GEMS=( arr-pm-0.0.10 backports-3.6.4 cabin-0.7.1 childprocess-0.5.6 clamp-0.6.5 ffi-1.9.8

--- a/cookbooks/bcpc/recipes/ceph-common.rb
+++ b/cookbooks/bcpc/recipes/ceph-common.rb
@@ -78,6 +78,10 @@ directory "/var/run/ceph/" do
   mode  "0755"
 end
 
+package 'libvirt-bin' do
+  action :upgrade
+end
+
 directory "/var/run/ceph/guests/" do
   owner "libvirt-qemu"
   group "libvirtd"
@@ -88,7 +92,6 @@ directory "/var/log/qemu/" do
   owner "libvirt-qemu"
   group "libvirtd"
   mode  "0755"
-
 end
 
 bcpc_cephconfig 'paxos_propose_interval' do


### PR DESCRIPTION
- add libvirt-bin to ceph-common to work around newly introduced
  ordering issue with libvirt-qemu user being absent (not sure
  how this ever worked actually)
- require upgrade to knife-acl 1.0.2 for compatibility with Chef 12.8.x
  (newer gem is compatible with older Chef versions, but command format
  has changed from 0.0.12)
- update `knife group add` commands and remove actor map references
- add logic to Ansible playbooks to upgrade Chef Server and knife-acl
  in place (not done for local builds, you will need to upgrade Chef
  client/server/gems manually if you want to uplift an existing local build)