### PR TITLE
Patch nova-network so unicast DHCP requests are responded to

### DIFF
--- a/cookbooks/bcpc/files/default/nova-network-linux_net-AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-network-linux_net-AFTER.SHASUMS
@@ -1,0 +1,1 @@
+381037089e8322da8f70c7b342ccf280b8a7e770  nova/network/linux_net.py

--- a/cookbooks/bcpc/files/default/nova-network-linux_net-BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-network-linux_net-BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+17269db4ef289599e98f5933575c54a50620274d  nova/network/linux_net.py

--- a/cookbooks/bcpc/files/default/nova-network-linux_net-dnsmasq-AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-network-linux_net-dnsmasq-AFTER.SHASUMS
@@ -1,0 +1,1 @@
+381037089e8322da8f70c7b342ccf280b8a7e770  nova/network/linux_net.py

--- a/cookbooks/bcpc/files/default/nova-network-linux_net-dnsmasq-BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-network-linux_net-dnsmasq-BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+78337cd95c476de57b9eede2350a67dd780fb239  nova/network/linux_net.py

--- a/cookbooks/bcpc/files/default/nova-network-linux_net-dnsmasq.patch
+++ b/cookbooks/bcpc/files/default/nova-network-linux_net-dnsmasq.patch
@@ -1,0 +1,10 @@
+--- a/nova/network/linux_net.py   2016-03-09 23:19:33.045201359 +0000
++++ b/nova/network/linux_net.py   2016-03-11 15:19:48.325374249 +0000
+@@ -1129,6 +1129,7 @@
+            '--dhcp-optsfile=%s' % _dhcp_file(dev, 'opts'),
+            '--listen-address=%s' % network_ref['dhcp_server'],
+            '--except-interface=lo',
++           '--interface=%s' % dev,
+            '--dhcp-range=set:%s,%s,static,%s,%ss' %
+                          (network_ref['label'],
+                           network_ref['dhcp_start'],

--- a/cookbooks/bcpc/files/default/nova-network-linux_net.patch
+++ b/cookbooks/bcpc/files/default/nova-network-linux_net.patch
@@ -1,7 +1,5 @@
-diff --git a/nova/network/linux_net.py b/nova/network/linux_net.py
-index 430da17..465e7ca 100644
---- a/nova/network/linux_net.py
-+++ b/nova/network/linux_net.py
+--- a/nova/network/linux_net.py   2016-03-14 16:17:32.517329066 +0000
++++ b/nova/network/linux_net.py   2016-03-15 15:48:39.712397155 +0000
 @@ -15,6 +15,8 @@
  #    License for the specific language governing permissions and limitations
  #    under the License.
@@ -11,7 +9,15 @@ index 430da17..465e7ca 100644
  """Implements vlans, bridges, and iptables rules using linux utilities."""
  
  import calendar
-@@ -1220,7 +1222,8 @@ def _host_dhcp(fixedip):
+@@ -1127,6 +1129,7 @@
+            '--dhcp-optsfile=%s' % _dhcp_file(dev, 'opts'),
+            '--listen-address=%s' % network_ref['dhcp_server'],
+            '--except-interface=lo',
++           '--interface=%s' % dev,
+            '--dhcp-range=set:%s,%s,static,%s,%ss' %
+                          (network_ref['label'],
+                           network_ref['dhcp_start'],
+@@ -1220,7 +1223,8 @@
      # NOTE(cfb): dnsmasq on linux only supports 64 characters in the hostname
      #            field (LP #1238910). Since the . counts as a character we need
      #            to truncate the hostname to only 63 characters.


### PR DESCRIPTION
We run nova-network in VLAN+multi_host mode and notice that only one out of many tenants' dnsmasq process on a hypervisor responds to unicast `BOOTPREQUESTS`. dhclient on VMs will retry until it eventually gives up and broadcasts the request, which is then responded to. Depending on the timing of the DHCP broadcast request, VMs can briefly lose connectivity as they attempt rebinding.

According to dnsmasq's [changelog](http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commitdiff;h=9380ba70d67db6b69f817d8e318de5ba1e990b12), it seems that passing `--interface` argument, in addition to `--bind-interfaces` is necessary for dnsmasq to work correctly in VLAN mode.

While this has been reported to [upstream nova](https://bugs.launchpad.net/nova/+bug/1554227), it will take some time to merge the commit, and backport, if approved.

#### Test steps:

1. Create two tenants

2. Verify if dnsmasq is already running on hypervisor (in this case, `bcpc-vm2`). If it is, restart it. 
  `stop nova-network && pkill -TERM dnsmasq && start nova-network`

  This may cause a brief connectivity loss for VMs on the hypervisors if they try to renew lease during the restart.

3. Create a VM under each tenant, forcing the VMs to run on a single hypervisor (they will run on `bcpc-vm2` with `m1` flavors). I tested with a vanilla Ubuntu cloud image, but any other image that uses dhclient should also work.

4. On the hypervisor, run `dhcpdump -i <bridge interface>` for each tenant's bridge interface. You should see `BOOTPREPLY` for each `BOOTPREQUEST` unicast reqest.