### PR TITLE
Add log output to ephemeral test script and name LV with UUID

### DIFF
--- a/cookbooks/bcpc/files/default/ephemeral_functional_test.sh
+++ b/cookbooks/bcpc/files/default/ephemeral_functional_test.sh
@@ -3,22 +3,39 @@
 # in order to detect problems with LVM or the underlying RAID 0 device
 # (mdadm does not indicate problems with the array even when drives drop out).
 
+LOG_TAG="`basename $0`"
+
+function log {
+	logger -t $LOG_TAG $1
+}
+
 if [[ "$1" == "" ]]; then
 	echo "You must provide the path of a LVM volume group." >&2
 	exit 100
 fi
 
 FAILED=0
-LV_NAME=EphemeralFunctionalTest_$(date +%s)
+START_TIME=$(date +%s.%N)
+log "Beginning ephemeral functional test at ${START_TIME}"
+LV_NAME=EphemeralFunctionalTest_$(uuidgen)
+log "Creating LV ${LV_NAME} in VG $1"
 # create a 4MB logical volume in the given volume group
-LV_CREATION_OUTPUT=$(/sbin/lvcreate $1 -n $LV_NAME -L 4M 2>&1)
+LV_CREATION_OUTPUT=$(/sbin/lvcreate $1 -n ${LV_NAME} -L 4M 2>&1)
+CREATION_TIME=$(date +%s.%N)
+log "LV ${LV_NAME} created in $(echo "${CREATION_TIME}-${START_TIME}" | bc -l) seconds"
 
-if echo $LV_CREATION_OUTPUT | egrep -q '(Input/output error|failed)'; then
+if echo ${LV_CREATION_OUTPUT} | egrep -q '(Input/output error|failed)'; then
 	FAILED=1
 fi
 
+log "Ephemeral functional test result: ${LV_CREATION_OUTPUT}"
+
 # attempt to clean up LV
-/sbin/lvremove -f /dev/$1/$LV_NAME >/dev/null 2>&1
+/sbin/lvremove -f /dev/$1/${LV_NAME} >/dev/null 2>&1
+END_TIME=$(date +%s.%N)
+log "LV ${LV_NAME} removed in $(echo "${END_TIME}-${CREATION_TIME}" | bc -l) seconds"
+log "Duration of test: $(echo "${END_TIME}-${START_TIME}" | bc -l) seconds"
+log "Completed ephemeral functional test at ${END_TIME}"
 
 # according to kelvk, need to echo something here for Zabbix trigger expression to evaluate
 echo $FAILED


### PR DESCRIPTION
This adds logging to the ephemeral functional test script. Additionally, it now uses `uuidgen` to generate a randomized name for the test LV so that multiple copies of the script can run simultaneously without colliding with one another.

Expected log output:
```
Mar 22 15:08:24 vagrant-ubuntu-trusty-64 ephfunctest: Beginning ephemeral functional test at 1458659304.514574524
Mar 22 15:08:24 vagrant-ubuntu-trusty-64 ephfunctest: Creating LV EphemeralFunctionalTest_dd52df1c-ddab-47f1-9deb-1a2120c4dec3 in VG nova_disk
Mar 22 15:08:24 vagrant-ubuntu-trusty-64 kernel: [ 3378.951384] bio: create slab <bio-2> at 2
Mar 22 15:08:24 vagrant-ubuntu-trusty-64 ephfunctest: Ephemeral functional test result:   Logical volume "EphemeralFunctionalTest_dd52df1c-ddab-47f1-9deb-1a2120c4dec3" created
Mar 22 15:08:24 vagrant-ubuntu-trusty-64 ephfunctest: Completed ephemeral functional test at 1458659304.588907638
Mar 22 15:08:24 vagrant-ubuntu-trusty-64 ephfunctest: Duration of test: .074333114 seconds
```