### PR TITLE
Always roll up Graphite metrics to next archive

### DIFF
--- a/cookbooks/bcpc/templates/default/carbon-storage-aggregation.conf.erb
+++ b/cookbooks/bcpc/templates/default/carbon-storage-aggregation.conf.erb
@@ -34,5 +34,5 @@ aggregationMethod = sum
 
 [default_average]
 pattern = .*
-xFilesFactor = 0.5
+xFilesFactor = 0
 aggregationMethod = average


### PR DESCRIPTION
We want Graphite metrics to always roll up to next archive level even if data points received is less than 50% of expected precision. Existing metrics need to be either resized or recreated for the new `xFilesFactor` setting to apply. For testing purporses, remove `/opt/graphite/storage/whisper/Test-Laptop-Vagrant/openstack/nova/security_groups.wsp` and wait up to 15 minutes. When it is recreated, verify the setting in the whisper file.

```
# /opt/graphite/bin/whisper-info.py security_groups.wsp
maxRetention: 86400
xFilesFactor: 0.0
aggregationMethod: average
fileSize: 17308
...
```