### PR TITLE
Parameterize max_concurrent_builds in nova.conf and reduce default to 4

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -403,6 +403,9 @@ default['bcpc']['nova']['reserved_host_memory_mb'] = 1024
 default['bcpc']['nova']['cpu_allocation_ratio'] = 2.0
 # select from between this many equally optimal hosts when launching an instance
 default['bcpc']['nova']['scheduler_host_subset_size'] = 3
+# maximum number of builds to allow the scheduler to run simultaneously
+# (setting too high may cause Three Stooges Syndrome, particularly on RBD-intensive operations)
+default['bcpc']['nova']['max_concurrent_builds'] = 4
 # "workers" parameters in nova are set to number of CPUs
 # available by default. This provides an override.
 default['bcpc']['nova']['workers'] = 5

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -51,6 +51,7 @@ ram_allocation_ratio=<%=node['bcpc']['nova']['ram_allocation_ratio']%>
 reserved_host_memory_mb=<%=node['bcpc']['nova']['reserved_host_memory_mb']%>
 cpu_allocation_ratio=<%=node['bcpc']['nova']['cpu_allocation_ratio']%>
 scheduler_host_subset_size=<%= node['bcpc']['nova']['scheduler_host_subset_size'] %>
+max_concurrent_builds=<%= node['bcpc']['nova']['max_concurrent_builds'] %>
 
 # Nova Network settings
 network_manager=nova.network.manager.VlanManager


### PR DESCRIPTION
Per our discovery that Ceph really doesn't like it if somebody tries to launch 40 instances at once from a volume snapshot (which because of #964 will cause 40 volume flatten operations to take place), this parameterizes `max_concurrent_buids` and sets it to **4**, down from the default of **10**. This appears to be a better balance point than 10 for reducing the aggressiveness of the scheduler when under duress, such as executing operations that may cause high load on Ceph.