### PR TITLE
Provider for creating Zabbix client auto-registration actions

### DIFF
--- a/cookbooks/bcpc/libraries/zabbix.rb
+++ b/cookbooks/bcpc/libraries/zabbix.rb
@@ -41,3 +41,13 @@ def zbx_api(auth, method, params)
 
   zbx_res['result']
 end
+
+def zbx_auth
+  params = {
+    :user     => get_config('zabbix-admin-user'),
+    :password => get_config('zabbix-admin-password')
+  }
+  auth = zbx_api(nil, 'user.login', params)
+  raise 'Zabbix authentication failed' if auth.nil?
+  auth
+end

--- a/cookbooks/bcpc/providers/zbx_autoreg.rb
+++ b/cookbooks/bcpc/providers/zbx_autoreg.rb
@@ -1,0 +1,95 @@
+
+# Cookbook Name:: bcpc
+# Provider:: zbx_autoreg
+#
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  auth = zbx_auth
+  # Checks for existence of auto-registration action
+  params = {
+    :name => @new_resource.name + ' auto registration'
+  }
+
+  if zbx_api(auth, 'action.exists', params) == false
+    Chef::Log.info("Action #{@new_resource.name} does not exist")
+
+    # Determine if template exists
+    params = {
+      :filter => {
+        :host => @new_resource.template
+      }
+    }
+    result = zbx_api(auth, 'template.get', params)
+    raise "Template #{@new_resource.template} does not exist" if result.length < 1
+
+    templates = []
+    result.map{ |t| templates.push({ :templateid => t['templateid'] }) }
+
+    # Determine if hostgroup exists
+    params = {
+      :filter => {
+        :name => @new_resource.hostgroup
+      }
+    }
+    result = zbx_api(auth, 'hostgroup.get', params)
+    raise "Hostgroup #{@new_resource.hostgroup} does not exist" if result.length < 1
+
+    hostgroups = []
+    result.map{ |h| hostgroups.push({ :operationid => 1, :groupid => h['groupid'] }) }
+
+    # If template and hostgroup exist, create registration action
+    params = {
+      :name => @new_resource.name + ' auto registration',
+      :eventsource => 2,
+      :status => 0,
+      :esc_period => 0,
+      :filter => {
+        :evaltype => 0,
+        :conditions => [
+          {
+            :conditiontype => 24,
+            :operator => 2,
+            :value => @new_resource.metadata
+          }
+        ]
+      },
+      :operations => [
+        {
+          :esc_step_from => 1,
+          :esc_period => 0,
+          :optemplate => templates,
+          :operationtype => 6,
+          :esc_step_to => 1
+        },
+        {
+          :esc_step_from => 1,
+          :esc_period => 0,
+          :opgroup => hostgroups,
+          :operationtype => 4,
+          :esc_step_to => 1
+        }
+      ]
+    }
+    converge_by "create auto-registration action #{@new_resource.name}" do
+      result = zbx_api(auth, 'action.create', params)
+      raise "Unable to create action #{@new_resource.name}: #{result}" if result.nil?
+    end
+  end
+end

--- a/cookbooks/bcpc/recipes/zabbix-server.rb
+++ b/cookbooks/bcpc/recipes/zabbix-server.rb
@@ -228,6 +228,12 @@ if node['bcpc']['enabled']['monitoring'] then
         end
     end
 
+    %w{ Bootstrap EphemeralWorknode Headnode Monitoring Worknode }.each do |metadata|
+        bcpc_zbx_autoreg "BCPC-#{metadata}" do
+            action :create
+        end
+    end
+
     template "/usr/share/zabbix/zabbix-api-auto-discovery" do
         source "zabbix_api_auto_discovery.erb"
         owner "root"

--- a/cookbooks/bcpc/resources/zbx_autoreg.rb
+++ b/cookbooks/bcpc/resources/zbx_autoreg.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook Name:: bcpc
+# Resource:: zbx_autoreg
+#
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+actions :create
+default_action :create
+
+# Name of the action
+attribute :name, :name_attribute => true, :kind_of => String, :required => true
+# Zabbix metadata
+attribute :metadata, :kind_of => String, :default => lazy { |x| x.name }
+# Zabbix template
+attribute :template, :kind_of => [String, Array], :default => lazy { |x| x.name }
+# Zabbix hostgroup
+attribute :hostgroup, :kind_of => [String, Array], :default => lazy { |x| x.name }

--- a/cookbooks/bcpc/templates/default/zabbix_api_auto_discovery.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_api_auto_discovery.erb
@@ -4,7 +4,6 @@ import requests
 import json
 
 headers = {'content-type': 'application/json'}
-roles = ['BCPC-Headnode', 'BCPC-Worknode', 'BCPC-EphemeralWorknode', 'BCPC-Monitoring', 'BCPC-Bootstrap']
 zabbix_url = 'http://<%= node['bcpc']['management']['ip'] %>:7777/api_jsonrpc.php'
 
 login_api = {
@@ -17,102 +16,6 @@ login_api = {
 
 status = requests.post(zabbix_url, data=json.dumps(login_api), verify=False, headers=headers)
 api_login = status.json()['result']
-
-for role in roles:
-    # Determine if action exists
-    exists_api = {
-        "jsonrpc": "2.0",
-        "method": "action.exists",
-        "params": {
-            "name": role + " auto registration"
-        },
-        "auth": api_login,
-        "id": 1 }
-
-    status = requests.post(zabbix_url, data=json.dumps(exists_api), verify=False, headers=headers)
-
-    if not status.json()['result']:
-        # Determine if template exists
-        template_api = {
-            "jsonrpc": "2.0",
-            "method": "template.get",
-            "params": {
-                "filter": {
-                    "host": [
-                        role
-                    ]
-                }
-            },
-            "auth": api_login,
-            "id": 1
-        }
-        response = requests.post(zabbix_url, data=json.dumps(template_api), verify=False, headers=headers)
-        if not response.json()['result']:
-            raise Exception("Missing template: " + role)
-        templateid = response.json()['result'][0]['templateid']
-
-        # Determine if hostgroup exists
-        hostgroup_api = {
-            "jsonrpc": "2.0",
-            "method": "hostgroup.get",
-            "params": {
-                "filter": {
-                    "name": [
-                        role
-                    ]
-                }
-            },
-            "auth": api_login,
-            "id": 1
-        }
-        response = requests.post(zabbix_url, data=json.dumps(hostgroup_api), verify=False, headers=headers)
-        if not response.json()['result']:
-            raise Exception("Missing hostgroup: " + role)
-        hostgroupid = response.json()['result'][0]['groupid']
-
-        # If required template and hostgroup exist, create discovery action
-        create_api = {
-            "jsonrpc": "2.0",
-            "method": "action.create",
-            "params": {
-                "name": role + " auto registration",
-                "eventsource": 2,
-                "status": 0,
-                "esc_period": 0,
-                "filter": {
-                    "evaltype": 0,
-                    "conditions": [
-                        {
-                            "conditiontype": 24,
-                            "operator": 2,
-                            "value": role
-                        }
-                    ]
-                },
-                "operations": [
-                    {
-                        "esc_step_from": 1,
-                        "esc_period": 0,
-                        "optemplate": [ { "templateid": templateid } ],
-                        "operationtype": 6,
-                        "esc_step_to": 1
-                    },
-                    {
-                        "esc_step_from": 1,
-                        "esc_period": 0,
-                        "opgroup": [ { "operationid": "1", "groupid": hostgroupid } ],
-                        "operationtype": 4,
-                        "esc_step_to": 1
-                    }
-                ]
-            },
-            "auth": api_login,
-            "id": 1
-        }
-
-        status = requests.post(zabbix_url, data=json.dumps(create_api), verify=False, headers=headers)
-        if not status.json()['result']:
-            raise Exception("Unable to create discovery action: " + role)
 
 # Create discovery rules
 for drule in <%=node['bcpc']['zabbix']['discovery']['ip_ranges']%>:


### PR DESCRIPTION
Replaces functionality in `zabbix_api_auto_discovery.erb` which creates Zabbix client auto-registration actions. This also now permits user-defined Zabbix metadata/templates/hostgroups that each action should associate registered clients with.

For testing purpose, delete the listed actions via https://10.0.100.6/zabbix/actionconf.php?&eventsource=2 and rechef monitoring host. The actions should reappear in the UI.