### PR TITLE
Improve ephemeral test behavior regarding autobackup behavior

### DIFF
--- a/cookbooks/bcpc/files/default/ephemeral_functional_test.sh
+++ b/cookbooks/bcpc/files/default/ephemeral_functional_test.sh
@@ -20,18 +20,18 @@ log "Beginning ephemeral functional test at ${START_TIME}"
 LV_NAME=EphemeralFunctionalTest_$(uuidgen)
 log "Creating LV ${LV_NAME} in VG $1"
 # create a 4MB logical volume in the given volume group
-LV_CREATION_OUTPUT=$(/sbin/lvcreate $1 -n ${LV_NAME} -L 4M 2>&1)
+LV_CREATION_OUTPUT=$(/sbin/lvcreate $1 -n ${LV_NAME} -L 4M -A n 2>&1)
 CREATION_TIME=$(date +%s.%N)
 log "LV ${LV_NAME} created in $(echo "${CREATION_TIME}-${START_TIME}" | bc -l) seconds"
 
-if echo ${LV_CREATION_OUTPUT} | egrep -q '(Input/output error|failed)'; then
+if echo ${LV_CREATION_OUTPUT} | egrep -q '(Input/output error|read failed)'; then
 	FAILED=1
 fi
 
 log "Ephemeral functional test result: ${LV_CREATION_OUTPUT}"
 
 # attempt to clean up LV
-/sbin/lvremove -f /dev/$1/${LV_NAME} >/dev/null 2>&1
+/sbin/lvremove -f /dev/$1/${LV_NAME} -A n >/dev/null 2>&1
 END_TIME=$(date +%s.%N)
 log "LV ${LV_NAME} removed in $(echo "${END_TIME}-${CREATION_TIME}" | bc -l) seconds"
 log "Duration of test: $(echo "${END_TIME}-${START_TIME}" | bc -l) seconds"

--- a/cookbooks/bcpc/recipes/lvm.rb
+++ b/cookbooks/bcpc/recipes/lvm.rb
@@ -18,8 +18,8 @@
 #
 
 if node['bcpc']['nova']['ephemeral']
-  package 'lvm2' 
-  
+  package 'lvm2'
+
   bash "setup-lvm-pv" do
     user "root"
     code <<-EOH
@@ -35,5 +35,11 @@ if node['bcpc']['nova']['ephemeral']
   EOH
     not_if "vgdisplay nova_disk"
   end
-  
+
+  # LVM creates backups of metadata at each operation, clean old ones up
+  cron 'lvm-archive-cleanup' do
+    command '/usr/bin/find /etc/lvm/archive/ -type f -ctime +7 -delete'
+    hour '3'
+    minute '0'
+  end
 end


### PR DESCRIPTION
This PR does 3 things:
* switches off autobackup behavior on `lvcreate` and `lvremove` (this does not stop autobackup completely, but reduces the noise a bit)
* adds a cron job to clean up older autobackup files from  `/etc/lvm/archive` nightly
* adjusts the failure regex to specifically look for the words "read failed" instead of just "failed" to work around an issue where LVM autobackup behavior would collide with an existing autobackup and put the word "failed" in the output, even though the LV creation/deletion was successful