### PR TITLE
Add node maintenance flag

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -40,6 +40,15 @@ default['bcpc']['s3_ssl_intermediate_certificate'] = nil
 
 ###########################################
 #
+#  Maintenance attribute for nodes
+#
+###########################################
+# Use this attribute to mark a node as in maintenance
+# (don't set it in the environment!)
+default['bcpc']['in_maintenance'] = false
+
+###########################################
+#
 #  Flags to enable/disable BCPC cluster features
 #
 ###########################################
@@ -630,13 +639,21 @@ default['bcpc']['flavors'] = {
 ###########################################
 
 default['bcpc']['host_aggregates'] = {
-    "general_compute" => {
-      "general_compute" => "yes"
-    },
-    "ephemeral_compute" => {
-      "general_compute" => "no",
-      "ephemeral_compute" => "yes"
-    }
+  "general_compute" => {
+    "ephemeral_compute" => "no",
+    "general_compute" => "yes",
+    "maintenance" => "no"
+  },
+  "ephemeral_compute" => {
+    "ephemeral_compute" => "yes",
+    "general_compute" => "no",
+    "maintenance" => "no"
+  },
+  "maintenance" => {
+    "general_compute" => "no",
+    "ephemeral_compute" => "no",
+    "maintenance" => "yes"
+  }
 }
 
 default['bcpc']['aggregate_membership'] = []

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -266,3 +266,11 @@ def generate_vrrp_vrid()
     raise "Unable to generate unique VRID" if results.empty?
     results.first
 end
+
+def join_aggregate_action
+  node['bcpc']['in_maintenance'] ? :depart : :member
+end
+
+def maintenance_action
+  node['bcpc']['in_maintenance'] ? :member : :depart
+end

--- a/cookbooks/bcpc/providers/host_aggregate.rb
+++ b/cookbooks/bcpc/providers/host_aggregate.rb
@@ -24,8 +24,8 @@ def whyrun_supported?
 end
 
 def openstack_cli
-  args =  ["openstack", 
-           "--os-tenant-name", node['bcpc']['admin_tenant'], 
+  args =  ["openstack",
+           "--os-tenant-name", node['bcpc']['admin_tenant'],
            "--os-username", get_config('keystone-admin-user'),
            "--os-auth-url", "#{node['bcpc']['protocol']['keystone']}://openstack.#{node['bcpc']['cluster_domain']}:5000/v2.0/",
            "--os-region-name", node['bcpc']['region_name'],
@@ -33,49 +33,65 @@ def openstack_cli
 end
 
 action :create do
-  stdout, stderr, status = Open3.capture3(*(openstack_cli + 
+  stdout, stderr, status = Open3.capture3(*(openstack_cli +
   	                                    ["aggregate", "show",
                                              @new_resource.name, "-f", "json" ]))
-  
-  if not status.success? 
+
+  if not status.success?
     converge_by("Creating host aggregate #{new_resource.name}") do
       args = ["aggregate", "create", @new_resource.name , "-f", "json"]
-      args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil? 
-      stdout, status = Open3.capture2( *(openstack_cli + args +  
-     		                         @new_resource.metadata.collect {|k , v| ["--property", k.to_s + "=" + v.to_s ] }.flatten ))	         
-      Chef::Log.error "Failed to create to host aggregate" unless status.success?
+      args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil?
+      stdout, status = Open3.capture2( *(openstack_cli + args +
+     		                         @new_resource.metadata.collect {|k , v| ["--property", k.to_s + "=" + v.to_s ] }.flatten ))
+      Chef::Log.error "Failed to create host aggregate" unless status.success?
     end
-  else  	
+  else
     ha_fields = JSON.parse(stdout)
     current_properties = ha_fields.select {|x| x['Field'] == "properties"}[0]["Value"]
-    
+
     # update metadata if needed
     new_properties = current_properties.clone
     @new_resource.metadata.each { |k,v| new_properties[k.to_s] = v.to_s }
     if new_properties != current_properties
       converge_by ("Update properties") do
 	args = ["aggregate", "set", @new_resource.name]
-	args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil? 
-	stdout, status = Open3.capture2( *(openstack_cli + 
+	args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil?
+	stdout, status = Open3.capture2( *(openstack_cli +
     	 		 	           args + new_properties.collect {|k , v| ["--property", k + "=" + v ] }.flatten ))
-	Chef::Log.error "Failed to update to host aggregate" unless status.success?
-      end			
-    end	
+	Chef::Log.error "Failed to update host aggregate" unless status.success?
+      end
+    end
   end
 end
 
 action :member do
-  # Adds the current host to the host aggregate 
-  stdout, stderr, status = Open3.capture3(*(openstack_cli + 
+  # Adds the current host to the host aggregate
+  stdout, stderr, status = Open3.capture3(*(openstack_cli +
   	                                    ["aggregate", "show", @new_resource.name, "-f", "json" ]))
-  raise "Unable to find host aggreate #{@new_resource.name}" unless status.success? 
-  
+  raise "Unable to find host aggregate #{@new_resource.name}" unless status.success?
+
   ha_fields = JSON.parse(stdout)
-  current_hosts = ha_fields.select {|x| x['Field'] == "hosts"}[0]["Value"]	
+  current_hosts = ha_fields.select {|x| x['Field'] == "hosts"}[0]["Value"]
   if not current_hosts.include?(node['hostname'])
     converge_by ("Adding host") do
-      stdout, stderr, status = Open3.capture3(*(openstack_cli + 
+      stdout, stderr, status = Open3.capture3(*(openstack_cli +
   			                        ["aggregate", "add", "host", @new_resource.name, node['hostname'] ]))
+    end
+  end
+end
+
+action :depart do
+  # Removes the current host from the host aggregate
+  stdout, stderr, status = Open3.capture3(*(openstack_cli +
+  	                                    ["aggregate", "show", @new_resource.name, "-f", "json" ]))
+  raise "Unable to find host aggregate #{@new_resource.name}" unless status.success?
+
+  ha_fields = JSON.parse(stdout)
+  current_hosts = ha_fields.select {|x| x['Field'] == "hosts"}[0]["Value"]
+  if current_hosts.include?(node['hostname'])
+    converge_by ("Removing host") do
+      stdout, stderr, status = Open3.capture3(*(openstack_cli +
+  			                        ["aggregate", "remove", "host", @new_resource.name, node['hostname'] ]))
     end
   end
 end

--- a/cookbooks/bcpc/resources/host_aggregate.rb
+++ b/cookbooks/bcpc/resources/host_aggregate.rb
@@ -18,7 +18,7 @@
 #
 
 
-actions :create, :member
+actions :create, :depart, :member
 default_action :create
 
 attribute :name, :name_attribute => true, :kind_of => String, :required => true


### PR DESCRIPTION
This PR adds the boolean flag **bcpc.in_maintenance**, which is intended to be set on individual nodes to control their aggregate memberships. Setting it to **true** on a node will remove the node from its availability zone and compute aggregate (either ephemeral or general) and place it into the maintenance aggregate, which is created by this PR. Reverting the change should perform the opposite action.

*NOTE*: if you have created a maintenance host aggregate already, please remove it prior to applying this PR if the maintenance host aggregate has an associated zone†. OpenStack allows a single host to be in multiple host aggregates, but only in one host aggregate that has an associated zone. Since the order of trying to join/unjoin host aggregates is the same each time, it's possible to get into a situation that would require 2 Chef runs to fully apply/unapply a change to the maintenance flag (since the first run might try to add the node to a second zone and silently fail, then remove it from the maintenance zone or availability zone, and then would be able to add it to the intended zone on the second Chef run).

† Horizon has a bug where it requires any host aggregates created through it to have an associated zone. This is not actually an OpenStack requirement, but can lead people to believe that creating a maintenance aggregate also requires creating a maintenance zone.