### PR TITLE
Normalize Diamond CPU collection

### DIFF
--- a/cookbooks/bcpc/attributes/monitoring.rb
+++ b/cookbooks/bcpc/attributes/monitoring.rb
@@ -43,6 +43,9 @@ default['bcpc']['graphite']['max_updates_per_sec'] = '500'
 #
 ###########################################
 #
+# CPU Collector parameters
+default['bcpc']['diamond']['collectors']['CPU']['normalize'] = 'True'
+default['bcpc']['diamond']['collectors']['CPU']['percore'] = 'False'
 # List of queue names separated by whitespace to report on. If nil, report all.
 default['bcpc']['diamond']['collectors']['rabbitmq']['queues'] = nil
 # Regular expression or list of queues to not report on.

--- a/cookbooks/bcpc/recipes/diamond.rb
+++ b/cookbooks/bcpc/recipes/diamond.rb
@@ -81,6 +81,19 @@ if node['bcpc']['enabled']['metrics'] then
         notifies :restart, "service[diamond]", :delayed
     end
 
+    %w{CPU}.each do |collector|
+        template "/etc/diamond/collectors/#{collector}Collector.conf" do
+            source "diamond-collector.conf.erb"
+            owner "diamond"
+            group "root"
+            mode 00600
+            variables(
+                :parameters => node['bcpc']['diamond']['collectors'][collector]
+            )
+            notifies :restart, "service[diamond]", :delayed
+        end
+    end
+
     template "/etc/diamond/collectors/ElasticSearchCollector.conf" do
         source "diamond-collector-elasticsearch.conf.erb"
         owner "diamond"

--- a/cookbooks/bcpc/templates/default/diamond.conf.erb
+++ b/cookbooks/bcpc/templates/default/diamond.conf.erb
@@ -163,9 +163,6 @@ batch = 100
 # Default Poll Interval (seconds)
 interval = 10
 
-[[CPUCollector]]
-enabled = True
-
 [[DiskSpaceCollector]]
 enabled = True
 


### PR DESCRIPTION
Instead of collecting stats for every core, just collect normalized totals.

When cheffed in, the CPU non-totals (`bcpc-vm4:/opt/graphite/storage/whisper/servers/*/cpu/cpu*/*`) will no longer be updated.