### PR TITLE
Make the EC2 compatibility APIs work

### DIFF
--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -39,7 +39,7 @@ ec2_listen = <%= node['bcpc']['management']['ip'] %>
 ec2_host = <%= node['bcpc']['management']['vip'] %>
 ec2_workers = <%= node['bcpc']['nova']['workers'] %>
 ec2_private_dns_show_ip = True
-keystone_ec2_url = <%=node['bcpc']['protocol']['keystone']%>://openstack.<%=node['bcpc']['cluster_domain']%>:5000/v2.0/ec2tokens
+keystone_ec2_url = <%=node['bcpc']['protocol']['keystone']%>://openstack.<%=node['bcpc']['cluster_domain']%>:<%= node['bcpc']['catalog']['identity']['ports']['public'] %>/<%= node['bcpc']['catalog']['identity']['uris']['public'] %>/ec2tokens
 
 <% if node['bcpc']['nova']['notifications']['enabled'] %>
 # Nova notification settings

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -19,9 +19,6 @@ memcached_servers=<%=@servers.map{|x| x['bcpc']['management']['ip'] + ":11211"}.
 auth_strategy=keystone
 api_paste_config=/etc/nova/api-paste.ini
 s3_host=<%=node['bcpc']['management']['vip']%>
-ec2_listen=<%= node['bcpc']['management']['ip'] %>
-ec2_host=<%=node['bcpc']['management']['vip']%>
-ec2_workers=<%=node['bcpc']['nova']['workers']%>
 osapi_compute_listen=<%= node['bcpc']['management']['ip'] %>
 osapi_compute_workers=<%=node['bcpc']['nova']['workers']%>
 metadata_listen=169.254.169.254
@@ -36,6 +33,13 @@ enabled_apis=metadata
 <% if not node["bcpc"]["vendordata_driver"].nil? %>
 vendordata_driver = <%=node["bcpc"]["vendordata_driver"] %>
 <% end %>
+
+# EC2 compatibility API settings
+ec2_listen = <%= node['bcpc']['management']['ip'] %>
+ec2_host = <%= node['bcpc']['management']['vip'] %>
+ec2_workers = <%= node['bcpc']['nova']['workers'] %>
+ec2_private_dns_show_ip = True
+keystone_ec2_url = <%=node['bcpc']['protocol']['keystone']%>://openstack.<%=node['bcpc']['cluster_domain']%>:5000/v2.0/ec2tokens
 
 <% if node['bcpc']['nova']['notifications']['enabled'] %>
 # Nova notification settings
@@ -123,7 +127,6 @@ state_path=/var/lib/nova
 rootwrap_config=/etc/nova/rootwrap.conf
 verbose=<%= node['bcpc']['nova']['verbose'] %>
 debug=<%= node['bcpc']['nova']['debug'] %>
-ec2_private_dns_show_ip=True
 <% if not node['bcpc']['nova']['default_log_levels'].nil? %>
 default_log_levels="<%= node['bcpc']['nova']['default_log_levels'] %>"
 <% end %>

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -81,6 +81,7 @@ my_ip=<%=node['bcpc']['management']['ip']%>
 routing_source_ip=<%=node['bcpc']['floating']['ip']%>
 dhcp_domain=<%=node['bcpc']['cluster_domain']%>
 default_availability_zone=
+default_floating_pool = <%= node['bcpc']['region_name'] %>
 
 # Nova Compute settings
 compute_driver=libvirt.LibvirtDriver


### PR DESCRIPTION
Due to the unintentional exclusion of **keystone_ec2_url** from our Nova configuration, the EC2 endpoint never worked (it tried to hit localhost and failed because Keystone listens on the management IP only). This fixes that by adding **keystone_ec2_url** and configuring it appropriately (I reorganized `nova.conf` slightly to keep the EC2-related stuff in one place).

Testing
---
Without this applied, any request to the EC2 API to do something will fail with HTTP 400, and `/var/log/nova/nova-api.log` will have an error in it. Increasing the log level will show that it's trying to talk to Keystone and failing.

With this applied, the EC2 API will become functional and can be tested using the following boto3 script which creates a keypair and launches a Cirros instance using that keypair, then prints out all running instances (replace the access key and secret key with credentials generated via `keystone ec2-credentials-create`).

NOTE: boto 2 does not seem to work correctly with self-signed SSL and will eventually fail. boto3 works as expected.

```
import boto3

c = boto3.client(
    'ec2',
    region_name='blorp',
    verify=False,
    endpoint_url='https://openstack.bcpc.example.com:8773/services/Cloud',
    aws_access_key_id='99c024d044dc487b9452f0c8fdc88756',
    aws_secret_access_key='0e2195825a204a2298691c6231355b70')

key_resp = c.create_key_pair(KeyName='testkey')

image_resp = c.describe_images()
cirros_image_id = image_resp['Images'][0]['ImageId']

launch_resp = c.run_instances(
    ImageId=cirros_image_id,
    MinCount=1,
    MaxCount=1,
    KeyName='testkey',
    InstanceType='m1.tiny')

c.describe_instances()
```