### PR TITLE
Only allow LVM to scan whitelisted physical disks

### DIFF
--- a/cookbooks/bcpc/recipes/lvm.rb
+++ b/cookbooks/bcpc/recipes/lvm.rb
@@ -18,21 +18,34 @@
 #
 
 if node['bcpc']['nova']['ephemeral']
-  package 'lvm2'
+  package 'lvm2' do
+    action :upgrade
+  end
+
+  # LVM watches its configuration file and will reload automatically
+  template '/etc/lvm/lvm.conf' do
+    source 'lvm.conf.erb'
+    owner  'root'
+    group  'root'
+    mode   00644
+    variables(
+      :lvm_whitelist => node['bcpc']['nova']['ephemeral_disks'].map { |dev| "\"a|^#{dev}$|\", " }
+    )
+  end
 
   bash "setup-lvm-pv" do
     user "root"
     code <<-EOH
-    pvcreate #{ node['bcpc']['nova']['ephemeral_disks'].join(' ') }
-  EOH
+      pvcreate #{ node['bcpc']['nova']['ephemeral_disks'].join(' ') }
+    EOH
     not_if "pvdisplay | grep '/dev'"
   end
 
   bash "setup-lvm-lv" do
     user "root"
     code <<-EOH
-    vgcreate nova_disk  #{ node['bcpc']['nova']['ephemeral_disks'].join(' ') }
-  EOH
+      vgcreate nova_disk  #{ node['bcpc']['nova']['ephemeral_disks'].join(' ') }
+    EOH
     not_if "vgdisplay nova_disk"
   end
 

--- a/cookbooks/bcpc/templates/default/lvm.conf.erb
+++ b/cookbooks/bcpc/templates/default/lvm.conf.erb
@@ -1,0 +1,822 @@
+# This is an example configuration file for the LVM2 system.
+# It contains the default settings that would be used if there was no
+# /etc/lvm/lvm.conf file.
+#
+# Refer to 'man lvm.conf' for further information including the file layout.
+#
+# To put this file in a different directory and override /etc/lvm set
+# the environment variable LVM_SYSTEM_DIR before running the tools.
+#
+# N.B. Take care that each setting only appears once if uncommenting
+# example settings in this file.
+
+
+# This section allows you to configure which block devices should
+# be used by the LVM system.
+devices {
+
+    # Where do you want your volume groups to appear ?
+    dir = "/dev"
+
+    # An array of directories that contain the device nodes you wish
+    # to use with LVM2.
+    scan = [ "/dev" ]
+
+    # If set, the cache of block device nodes with all associated symlinks
+    # will be constructed out of the existing udev database content.
+    # This avoids using and opening any inapplicable non-block devices or
+    # subdirectories found in the device directory. This setting is applied
+    # to udev-managed device directory only, other directories will be scanned
+    # fully. LVM2 needs to be compiled with udev support for this setting to
+    # take effect. N.B. Any device node or symlink not managed by udev in
+    # udev directory will be ignored with this setting on.
+    obtain_device_list_from_udev = 1
+
+    # If several entries in the scanned directories correspond to the
+    # same block device and the tools need to display a name for device,
+    # all the pathnames are matched against each item in the following
+    # list of regular expressions in turn and the first match is used.
+    preferred_names = [ ]
+
+    # Try to avoid using undescriptive /dev/dm-N names, if present.
+    # preferred_names = [ "^/dev/mpath/", "^/dev/mapper/mpath", "^/dev/[hs]d" ]
+
+    # A filter that tells LVM2 to only use a restricted set of devices.
+    # The filter consists of an array of regular expressions.  These
+    # expressions can be delimited by a character of your choice, and
+    # prefixed with either an 'a' (for accept) or 'r' (for reject).
+    # The first expression found to match a device name determines if
+    # the device will be accepted or rejected (ignored).  Devices that
+    # don't match any patterns are accepted.
+
+    # Be careful if there there are symbolic links or multiple filesystem
+    # entries for the same device as each name is checked separately against
+    # the list of patterns.  The effect is that if the first pattern in the
+    # list to match a name is an 'a' pattern for any of the names, the device
+    # is accepted; otherwise if the first pattern in the list to match a name
+    # is an 'r' pattern for any of the names it is rejected; otherwise it is
+    # accepted.
+
+    # Don't have more than one filter line active at once: only one gets used.
+
+    # Run vgscan after you change this parameter to ensure that
+    # the cache file gets regenerated (see below).
+    # If it doesn't do what you expect, check the output of 'vgscan -vvvv'.
+
+
+    # By default we accept every block device:
+    #filter = [ "a/.*/" ]
+
+    # chef-bcpc configuration: only accept our ephemeral disks and
+    # /dev/md127 so that a new md device can be used immediately without reboot,
+    # exclude all other devices to avoid picking up LVM configurations inside instances
+    filter = [ <%= @lvm_whitelist %> "a|^/dev/md127$|", "r|.*|" ]
+
+    # Exclude the cdrom drive
+    # filter = [ "r|/dev/cdrom|" ]
+
+    # When testing I like to work with just loopback devices:
+    # filter = [ "a/loop/", "r/.*/" ]
+
+    # Or maybe all loops and ide drives except hdc:
+    # filter =[ "a|loop|", "r|/dev/hdc|", "a|/dev/ide|", "r|.*|" ]
+
+    # Use anchors if you want to be really specific
+    # filter = [ "a|^/dev/hda8$|", "r/.*/" ]
+
+    # Since "filter" is often overriden from command line, it is not suitable
+    # for system-wide device filtering (udev rules, lvmetad). To hide devices
+    # from LVM-specific udev processing and/or from lvmetad, you need to set
+    # global_filter. The syntax is the same as for normal "filter"
+    # above. Devices that fail the global_filter are not even opened by LVM.
+
+    # global_filter = []
+
+    # The results of the filtering are cached on disk to avoid
+    # rescanning dud devices (which can take a very long time).
+    # By default this cache is stored in the /etc/lvm/cache directory
+    # in a file called '.cache'.
+    # It is safe to delete the contents: the tools regenerate it.
+    # (The old setting 'cache' is still respected if neither of
+    # these new ones is present.)
+    # N.B. If obtain_device_list_from_udev is set to 1 the list of
+    # devices is instead obtained from udev and any existing .cache
+    # file is removed.
+    cache_dir = "/run/lvm"
+    cache_file_prefix = ""
+
+    # You can turn off writing this cache file by setting this to 0.
+    write_cache_state = 1
+
+    # Advanced settings.
+
+    # List of pairs of additional acceptable block device types found
+    # in /proc/devices with maximum (non-zero) number of partitions.
+    # types = [ "fd", 16 ]
+
+    # If sysfs is mounted (2.6 kernels) restrict device scanning to
+    # the block devices it believes are valid.
+    # 1 enables; 0 disables.
+    sysfs_scan = 1
+
+    # By default, LVM2 will ignore devices used as component paths
+    # of device-mapper multipath devices.
+    # 1 enables; 0 disables.
+    multipath_component_detection = 1
+
+    # By default, LVM2 will ignore devices used as components of
+    # software RAID (md) devices by looking for md superblocks.
+    # 1 enables; 0 disables.
+    md_component_detection = 1
+
+    # By default, if a PV is placed directly upon an md device, LVM2
+    # will align its data blocks with the md device's stripe-width.
+    # 1 enables; 0 disables.
+    md_chunk_alignment = 1
+
+    # Default alignment of the start of a data area in MB.  If set to 0,
+    # a value of 64KB will be used.  Set to 1 for 1MiB, 2 for 2MiB, etc.
+    # default_data_alignment = 1
+
+    # By default, the start of a PV's data area will be a multiple of
+    # the 'minimum_io_size' or 'optimal_io_size' exposed in sysfs.
+    # - minimum_io_size - the smallest request the device can perform
+    #   w/o incurring a read-modify-write penalty (e.g. MD's chunk size)
+    # - optimal_io_size - the device's preferred unit of receiving I/O
+    #   (e.g. MD's stripe width)
+    # minimum_io_size is used if optimal_io_size is undefined (0).
+    # If md_chunk_alignment is enabled, that detects the optimal_io_size.
+    # This setting takes precedence over md_chunk_alignment.
+    # 1 enables; 0 disables.
+    data_alignment_detection = 1
+
+    # Alignment (in KB) of start of data area when creating a new PV.
+    # md_chunk_alignment and data_alignment_detection are disabled if set.
+    # Set to 0 for the default alignment (see: data_alignment_default)
+    # or page size, if larger.
+    data_alignment = 0
+
+    # By default, the start of the PV's aligned data area will be shifted by
+    # the 'alignment_offset' exposed in sysfs.  This offset is often 0 but
+    # may be non-zero; e.g.: certain 4KB sector drives that compensate for
+    # windows partitioning will have an alignment_offset of 3584 bytes
+    # (sector 7 is the lowest aligned logical block, the 4KB sectors start
+    # at LBA -1, and consequently sector 63 is aligned on a 4KB boundary).
+    # But note that pvcreate --dataalignmentoffset will skip this detection.
+    # 1 enables; 0 disables.
+    data_alignment_offset_detection = 1
+
+    # If, while scanning the system for PVs, LVM2 encounters a device-mapper
+    # device that has its I/O suspended, it waits for it to become accessible.
+    # Set this to 1 to skip such devices.  This should only be needed
+    # in recovery situations.
+    ignore_suspended_devices = 0
+
+    # During each LVM operation errors received from each device are counted.
+    # If the counter of a particular device exceeds the limit set here, no
+    # further I/O is sent to that device for the remainder of the respective
+    # operation. Setting the parameter to 0 disables the counters altogether.
+    disable_after_error_count = 0
+
+    # Allow use of pvcreate --uuid without requiring --restorefile.
+    require_restorefile_with_uuid = 1
+
+    # Minimum size (in KB) of block devices which can be used as PVs.
+    # In a clustered environment all nodes must use the same value.
+    # Any value smaller than 512KB is ignored.
+
+    # Ignore devices smaller than 2MB such as floppy drives.
+    pv_min_size = 2048
+
+    # The original built-in setting was 512 up to and including version 2.02.84.
+    # pv_min_size = 512
+
+    # Issue discards to a logical volumes's underlying physical volume(s) when
+    # the logical volume is no longer using the physical volumes' space (e.g.
+    # lvremove, lvreduce, etc).  Discards inform the storage that a region is
+    # no longer in use.  Storage that supports discards advertise the protocol
+    # specific way discards should be issued by the kernel (TRIM, UNMAP, or
+    # WRITE SAME with UNMAP bit set).  Not all storage will support or benefit
+    # from discards but SSDs and thinly provisioned LUNs generally do.  If set
+    # to 1, discards will only be issued if both the storage and kernel provide
+    # support.
+    # 1 enables; 0 disables.
+    issue_discards = 1
+}
+
+# This section allows you to configure the way in which LVM selects
+# free space for its Logical Volumes.
+allocation {
+
+    # When searching for free space to extend an LV, the "cling"
+    # allocation policy will choose space on the same PVs as the last
+    # segment of the existing LV.  If there is insufficient space and a
+    # list of tags is defined here, it will check whether any of them are
+    # attached to the PVs concerned and then seek to match those PV tags
+    # between existing extents and new extents.
+    # Use the special tag "@*" as a wildcard to match any PV tag.
+
+    # Example: LVs are mirrored between two sites within a single VG.
+    # PVs are tagged with either @site1 or @site2 to indicate where
+    # they are situated.
+
+    # cling_tag_list = [ "@site1", "@site2" ]
+    # cling_tag_list = [ "@*" ]
+
+    # Changes made in version 2.02.85 extended the reach of the 'cling'
+    # policies to detect more situations where data can be grouped
+    # onto the same disks.  Set this to 0 to revert to the previous
+    # algorithm.
+    maximise_cling = 1
+
+    # Set to 1 to guarantee that mirror logs will always be placed on
+    # different PVs from the mirror images.  This was the default
+    # until version 2.02.85.
+    mirror_logs_require_separate_pvs = 0
+
+    # Set to 1 to guarantee that thin pool metadata will always
+    # be placed on different PVs from the pool data.
+    thin_pool_metadata_require_separate_pvs = 0
+}
+
+# This section that allows you to configure the nature of the
+# information that LVM2 reports.
+log {
+
+    # Controls the messages sent to stdout or stderr.
+    # There are three levels of verbosity, 3 being the most verbose.
+    verbose = 0
+
+    # Set to 1 to suppress all non-essential messages from stdout.
+    # This has the same effect as -qq.
+    # When this is set, the following commands still produce output:
+    # dumpconfig, lvdisplay, lvmdiskscan, lvs, pvck, pvdisplay,
+    # pvs, version, vgcfgrestore -l, vgdisplay, vgs.
+    # Non-essential messages are shifted from log level 4 to log level 5
+    # for syslog and lvm2_log_fn purposes.
+    # Any 'yes' or 'no' questions not overridden by other arguments
+    # are suppressed and default to 'no'.
+    silent = 0
+
+    # Should we send log messages through syslog?
+    # 1 is yes; 0 is no.
+    syslog = 1
+
+    # Should we log error and debug messages to a file?
+    # By default there is no log file.
+    #file = "/var/log/lvm2.log"
+
+    # Should we overwrite the log file each time the program is run?
+    # By default we append.
+    overwrite = 0
+
+    # What level of log messages should we send to the log file and/or syslog?
+    # There are 6 syslog-like log levels currently in use - 2 to 7 inclusive.
+    # 7 is the most verbose (LOG_DEBUG).
+    level = 0
+
+    # Format of output messages
+    # Whether or not (1 or 0) to indent messages according to their severity
+    indent = 1
+
+    # Whether or not (1 or 0) to display the command name on each line output
+    command_names = 0
+
+    # A prefix to use before the message text (but after the command name,
+    # if selected).  Default is two spaces, so you can see/grep the severity
+    # of each message.
+    prefix = "  "
+
+    # To make the messages look similar to the original LVM tools use:
+    #   indent = 0
+    #   command_names = 1
+    #   prefix = " -- "
+
+    # Set this if you want log messages during activation.
+    # Don't use this in low memory situations (can deadlock).
+    # activation = 0
+}
+
+# Configuration of metadata backups and archiving.  In LVM2 when we
+# talk about a 'backup' we mean making a copy of the metadata for the
+# *current* system.  The 'archive' contains old metadata configurations.
+# Backups are stored in a human readeable text format.
+backup {
+
+    # Should we maintain a backup of the current metadata configuration ?
+    # Use 1 for Yes; 0 for No.
+    # Think very hard before turning this off!
+    backup = 1
+
+    # Where shall we keep it ?
+    # Remember to back up this directory regularly!
+    backup_dir = "/etc/lvm/backup"
+
+    # Should we maintain an archive of old metadata configurations.
+    # Use 1 for Yes; 0 for No.
+    # On by default.  Think very hard before turning this off.
+    archive = 1
+
+    # Where should archived files go ?
+    # Remember to back up this directory regularly!
+    archive_dir = "/etc/lvm/archive"
+
+    # What is the minimum number of archive files you wish to keep ?
+    retain_min = 10
+
+    # What is the minimum time you wish to keep an archive file for ?
+    retain_days = 30
+}
+
+# Settings for the running LVM2 in shell (readline) mode.
+shell {
+
+    # Number of lines of history to store in ~/.lvm_history
+    history_size = 100
+}
+
+
+# Miscellaneous global LVM2 settings
+global {
+
+    # The file creation mask for any files and directories created.
+    # Interpreted as octal if the first digit is zero.
+    umask = 077
+
+    # Allow other users to read the files
+    #umask = 022
+
+    # Enabling test mode means that no changes to the on disk metadata
+    # will be made.  Equivalent to having the -t option on every
+    # command.  Defaults to off.
+    test = 0
+
+    # Default value for --units argument
+    units = "h"
+
+    # Since version 2.02.54, the tools distinguish between powers of
+    # 1024 bytes (e.g. KiB, MiB, GiB) and powers of 1000 bytes (e.g.
+    # KB, MB, GB).
+    # If you have scripts that depend on the old behaviour, set this to 0
+    # temporarily until you update them.
+    si_unit_consistency = 1
+
+    # Whether or not to communicate with the kernel device-mapper.
+    # Set to 0 if you want to use the tools to manipulate LVM metadata
+    # without activating any logical volumes.
+    # If the device-mapper kernel driver is not present in your kernel
+    # setting this to 0 should suppress the error messages.
+    activation = 1
+
+    # If we can't communicate with device-mapper, should we try running
+    # the LVM1 tools?
+    # This option only applies to 2.4 kernels and is provided to help you
+    # switch between device-mapper kernels and LVM1 kernels.
+    # The LVM1 tools need to be installed with .lvm1 suffices
+    # e.g. vgscan.lvm1 and they will stop working after you start using
+    # the new lvm2 on-disk metadata format.
+    # The default value is set when the tools are built.
+    # fallback_to_lvm1 = 0
+
+    # The default metadata format that commands should use - "lvm1" or "lvm2".
+    # The command line override is -M1 or -M2.
+    # Defaults to "lvm2".
+    # format = "lvm2"
+
+    # Location of proc filesystem
+    proc = "/proc"
+
+    # Type of locking to use. Defaults to local file-based locking (1).
+    # Turn locking off by setting to 0 (dangerous: risks metadata corruption
+    # if LVM2 commands get run concurrently).
+    # Type 2 uses the external shared library locking_library.
+    # Type 3 uses built-in clustered locking.
+    # Type 4 uses read-only locking which forbids any operations that might
+    # change metadata.
+    locking_type = 1
+
+    # Set to 0 to fail when a lock request cannot be satisfied immediately.
+    wait_for_locks = 1
+
+    # If using external locking (type 2) and initialisation fails,
+    # with this set to 1 an attempt will be made to use the built-in
+    # clustered locking.
+    # If you are using a customised locking_library you should set this to 0.
+    fallback_to_clustered_locking = 1
+
+    # If an attempt to initialise type 2 or type 3 locking failed, perhaps
+    # because cluster components such as clvmd are not running, with this set
+    # to 1 an attempt will be made to use local file-based locking (type 1).
+    # If this succeeds, only commands against local volume groups will proceed.
+    # Volume Groups marked as clustered will be ignored.
+    fallback_to_local_locking = 1
+
+    # Local non-LV directory that holds file-based locks while commands are
+    # in progress.  A directory like /tmp that may get wiped on reboot is OK.
+    locking_dir = "/run/lock/lvm"
+
+    # Whenever there are competing read-only and read-write access requests for
+    # a volume group's metadata, instead of always granting the read-only
+    # requests immediately, delay them to allow the read-write requests to be
+    # serviced.  Without this setting, write access may be stalled by a high
+    # volume of read-only requests.
+    # NB. This option only affects locking_type = 1 viz. local file-based
+    # locking.
+    prioritise_write_locks = 1
+
+    # Other entries can go here to allow you to load shared libraries
+    # e.g. if support for LVM1 metadata was compiled as a shared library use
+    #   format_libraries = "liblvm2format1.so"
+    # Full pathnames can be given.
+
+    # Search this directory first for shared libraries.
+    #   library_dir = "/lib/lvm2"
+
+    # The external locking library to load if locking_type is set to 2.
+    #   locking_library = "liblvm2clusterlock.so"
+
+    # Treat any internal errors as fatal errors, aborting the process that
+    # encountered the internal error. Please only enable for debugging.
+    abort_on_internal_errors = 0
+
+    # Check whether CRC is matching when parsed VG is used multiple times.
+    # This is useful to catch unexpected internal cached volume group
+    # structure modification. Please only enable for debugging.
+    detect_internal_vg_cache_corruption = 0
+
+    # If set to 1, no operations that change on-disk metadata will be permitted.
+    # Additionally, read-only commands that encounter metadata in need of repair
+    # will still be allowed to proceed exactly as if the repair had been
+    # performed (except for the unchanged vg_seqno).
+    # Inappropriate use could mess up your system, so seek advice first!
+    metadata_read_only = 0
+
+    # 'mirror_segtype_default' defines which segtype will be used when the
+    # shorthand '-m' option is used for mirroring.  The possible options are:
+    #
+    # "mirror" - The original RAID1 implementation provided by LVM2/DM.  It is
+    # 	         characterized by a flexible log solution (core, disk, mirrored)
+    #		 and by the necessity to block I/O while reconfiguring in the
+    #		 event of a failure.
+    #
+    #		 There is an inherent race in the dmeventd failure handling
+    #		 logic with snapshots of devices using this type of RAID1 that
+    #		 in the worst case could cause a deadlock.
+    #		   Ref: https://bugzilla.redhat.com/show_bug.cgi?id=817130#c10
+    #
+    # "raid1"  - This implementation leverages MD's RAID1 personality through
+    # 	       	 device-mapper.  It is characterized by a lack of log options.
+    #		 (A log is always allocated for every device and they are placed
+    #		 on the same device as the image - no separate devices are
+    #		 required.)  This mirror implementation does not require I/O
+    #		 to be blocked in the kernel in the event of a failure.
+    #		 This mirror implementation is not cluster-aware and cannot be
+    #		 used in a shared (active/active) fashion in a cluster.
+    #
+    # Specify the '--type <mirror|raid1>' option to override this default
+    # setting.
+    mirror_segtype_default = "mirror"
+
+    # The default format for displaying LV names in lvdisplay was changed
+    # in version 2.02.89 to show the LV name and path separately.
+    # Previously this was always shown as /dev/vgname/lvname even when that
+    # was never a valid path in the /dev filesystem.
+    # Set to 1 to reinstate the previous format.
+    #
+    # lvdisplay_shows_full_device_path = 0
+
+    # Whether to use (trust) a running instance of lvmetad. If this is set to
+    # 0, all commands fall back to the usual scanning mechanisms. When set to 1
+    # *and* when lvmetad is running (it is not auto-started), the volume group
+    # metadata and PV state flags are obtained from the lvmetad instance and no
+    # scanning is done by the individual commands. In a setup with lvmetad,
+    # lvmetad udev rules *must* be set up for LVM to work correctly. Without
+    # proper udev rules, all changes in block device configuration will be
+    # *ignored* until a manual 'pvscan --cache' is performed.
+    #
+    # If lvmetad has been running while use_lvmetad was 0, it MUST be stopped
+    # before changing use_lvmetad to 1 and started again afterwards.
+    use_lvmetad = 0
+
+    # Full path of the utility called to check that a thin metadata device
+    # is in a state that allows it to be used.
+    # Each time a thin pool needs to be activated or after it is deactivated
+    # this utility is executed. The activation will only proceed if the utility
+    # has an exit status of 0.
+    # Set to "" to skip this check.  (Not recommended.)
+    # The thin tools are available as part of the device-mapper-persistent-data
+    # package from https://github.com/jthornber/thin-provisioning-tools.
+    #
+    thin_check_executable = "/usr/sbin/thin_check"
+
+    # String with options passed with thin_check command. By default,
+    # option '-q' is for quiet output.
+    thin_check_options = [ "-q" ]
+}
+
+activation {
+    # Set to 1 to perform internal checks on the operations issued to
+    # libdevmapper.  Useful for debugging problems with activation.
+    # Some of the checks may be expensive, so it's best to use this
+    # only when there seems to be a problem.
+    checks = 0
+
+    # Set to 0 to disable udev synchronisation (if compiled into the binaries).
+    # Processes will not wait for notification from udev.
+    # They will continue irrespective of any possible udev processing
+    # in the background.  You should only use this if udev is not running
+    # or has rules that ignore the devices LVM2 creates.
+    # The command line argument --nodevsync takes precedence over this setting.
+    # If set to 1 when udev is not running, and there are LVM2 processes
+    # waiting for udev, run 'dmsetup udevcomplete_all' manually to wake them up.
+    udev_sync = 1
+
+    # Set to 0 to disable the udev rules installed by LVM2 (if built with
+    # --enable-udev_rules). LVM2 will then manage the /dev nodes and symlinks
+    # for active logical volumes directly itself.
+    # N.B. Manual intervention may be required if this setting is changed
+    # while any logical volumes are active.
+    udev_rules = 1
+
+    # Set to 1 for LVM2 to verify operations performed by udev. This turns on
+    # additional checks (and if necessary, repairs) on entries in the device
+    # directory after udev has completed processing its events.
+    # Useful for diagnosing problems with LVM2/udev interactions.
+    verify_udev_operations = 0
+
+    # If set to 1 and if deactivation of an LV fails, perhaps because
+    # a process run from a quick udev rule temporarily opened the device,
+    # retry the operation for a few seconds before failing.
+    retry_deactivation = 1
+
+    # How to fill in missing stripes if activating an incomplete volume.
+    # Using "error" will make inaccessible parts of the device return
+    # I/O errors on access.  You can instead use a device path, in which
+    # case, that device will be used to in place of missing stripes.
+    # But note that using anything other than "error" with mirrored
+    # or snapshotted volumes is likely to result in data corruption.
+    missing_stripe_filler = "error"
+
+    # The linear target is an optimised version of the striped target
+    # that only handles a single stripe.  Set this to 0 to disable this
+    # optimisation and always use the striped target.
+    use_linear_target = 1
+
+    # How much stack (in KB) to reserve for use while devices suspended
+    # Prior to version 2.02.89 this used to be set to 256KB
+    reserved_stack = 64
+
+    # How much memory (in KB) to reserve for use while devices suspended
+    reserved_memory = 8192
+
+    # Nice value used while devices suspended
+    process_priority = -18
+
+    # If volume_list is defined, each LV is only activated if there is a
+    # match against the list.
+    #   "vgname" and "vgname/lvname" are matched exactly.
+    #   "@tag" matches any tag set in the LV or VG.
+    #   "@*" matches if any tag defined on the host is also set in the LV or VG
+    #
+    #volume_list = [ "vg1", "vg2/lvol1", "@tag1", "@*" ]
+    volume_list = [ "nova_disk" ]
+
+    # If auto_activation_volume_list is defined, each LV that is to be
+    # activated is checked against the list while using the autoactivation
+    # option (--activate ay/-a ay), and if it matches, it is activated.
+    #   "vgname" and "vgname/lvname" are matched exactly.
+    #   "@tag" matches any tag set in the LV or VG.
+    #   "@*" matches if any tag defined on the host is also set in the LV or VG
+    #
+    # auto_activation_volume_list = [ "vg1", "vg2/lvol1", "@tag1", "@*" ]
+
+    # If read_only_volume_list is defined, each LV that is to be activated
+    # is checked against the list, and if it matches, it as activated
+    # in read-only mode.  (This overrides '--permission rw' stored in the
+    # metadata.)
+    #   "vgname" and "vgname/lvname" are matched exactly.
+    #   "@tag" matches any tag set in the LV or VG.
+    #   "@*" matches if any tag defined on the host is also set in the LV or VG
+    #
+    # read_only_volume_list = [ "vg1", "vg2/lvol1", "@tag1", "@*" ]
+
+    # Size (in KB) of each copy operation when mirroring
+    mirror_region_size = 512
+
+    # Setting to use when there is no readahead value stored in the metadata.
+    #
+    # "none" - Disable readahead.
+    # "auto" - Use default value chosen by kernel.
+    readahead = "auto"
+
+    # 'raid_fault_policy' defines how a device failure in a RAID logical
+    # volume is handled.  This includes logical volumes that have the following
+    # segment types: raid1, raid4, raid5*, and raid6*.
+    #
+    # In the event of a failure, the following policies will determine what
+    # actions are performed during the automated response to failures (when
+    # dmeventd is monitoring the RAID logical volume) and when 'lvconvert' is
+    # called manually with the options '--repair' and '--use-policies'.
+    #
+    # "warn"	- Use the system log to warn the user that a device in the RAID
+    # 		  logical volume has failed.  It is left to the user to run
+    #		  'lvconvert --repair' manually to remove or replace the failed
+    #		  device.  As long as the number of failed devices does not
+    #		  exceed the redundancy of the logical volume (1 device for
+    #		  raid4/5, 2 for raid6, etc) the logical volume will remain
+    #		  usable.
+    #
+    # "allocate" - Attempt to use any extra physical volumes in the volume
+    # 		  group as spares and replace faulty devices.
+    #
+    raid_fault_policy = "warn"
+
+    # 'mirror_image_fault_policy' and 'mirror_log_fault_policy' define
+    # how a device failure affecting a mirror (of "mirror" segment type) is
+    # handled.  A mirror is composed of mirror images (copies) and a log.
+    # A disk log ensures that a mirror does not need to be re-synced
+    # (all copies made the same) every time a machine reboots or crashes.
+    #
+    # In the event of a failure, the specified policy will be used to determine
+    # what happens. This applies to automatic repairs (when the mirror is being
+    # monitored by dmeventd) and to manual lvconvert --repair when
+    # --use-policies is given.
+    #
+    # "remove" - Simply remove the faulty device and run without it.  If
+    #            the log device fails, the mirror would convert to using
+    #            an in-memory log.  This means the mirror will not
+    #            remember its sync status across crashes/reboots and
+    #            the entire mirror will be re-synced.  If a
+    #            mirror image fails, the mirror will convert to a
+    #            non-mirrored device if there is only one remaining good
+    #            copy.
+    #
+    # "allocate" - Remove the faulty device and try to allocate space on
+    #            a new device to be a replacement for the failed device.
+    #            Using this policy for the log is fast and maintains the
+    #            ability to remember sync state through crashes/reboots.
+    #            Using this policy for a mirror device is slow, as it
+    #            requires the mirror to resynchronize the devices, but it
+    #            will preserve the mirror characteristic of the device.
+    #            This policy acts like "remove" if no suitable device and
+    #            space can be allocated for the replacement.
+    #
+    # "allocate_anywhere" - Not yet implemented. Useful to place the log device
+    #            temporarily on same physical volume as one of the mirror
+    #            images. This policy is not recommended for mirror devices
+    #            since it would break the redundant nature of the mirror. This
+    #            policy acts like "remove" if no suitable device and space can
+    #            be allocated for the replacement.
+
+    mirror_log_fault_policy = "allocate"
+    mirror_image_fault_policy = "remove"
+
+    # 'snapshot_autoextend_threshold' and 'snapshot_autoextend_percent' define
+    # how to handle automatic snapshot extension. The former defines when the
+    # snapshot should be extended: when its space usage exceeds this many
+    # percent. The latter defines how much extra space should be allocated for
+    # the snapshot, in percent of its current size.
+    #
+    # For example, if you set snapshot_autoextend_threshold to 70 and
+    # snapshot_autoextend_percent to 20, whenever a snapshot exceeds 70% usage,
+    # it will be extended by another 20%. For a 1G snapshot, using up 700M will
+    # trigger a resize to 1.2G. When the usage exceeds 840M, the snapshot will
+    # be extended to 1.44G, and so on.
+    #
+    # Setting snapshot_autoextend_threshold to 100 disables automatic
+    # extensions. The minimum value is 50 (A setting below 50 will be treated
+    # as 50).
+
+    snapshot_autoextend_threshold = 100
+    snapshot_autoextend_percent = 20
+
+    # 'thin_pool_autoextend_threshold' and 'thin_pool_autoextend_percent' define
+    # how to handle automatic pool extension. The former defines when the
+    # pool should be extended: when its space usage exceeds this many
+    # percent. The latter defines how much extra space should be allocated for
+    # the pool, in percent of its current size.
+    #
+    # For example, if you set thin_pool_autoextend_threshold to 70 and
+    # thin_pool_autoextend_percent to 20, whenever a pool exceeds 70% usage,
+    # it will be extended by another 20%. For a 1G pool, using up 700M will
+    # trigger a resize to 1.2G. When the usage exceeds 840M, the pool will
+    # be extended to 1.44G, and so on.
+    #
+    # Setting thin_pool_autoextend_threshold to 100 disables automatic
+    # extensions. The minimum value is 50 (A setting below 50 will be treated
+    # as 50).
+
+    thin_pool_autoextend_threshold = 100
+    thin_pool_autoextend_percent = 20
+
+    # While activating devices, I/O to devices being (re)configured is
+    # suspended, and as a precaution against deadlocks, LVM2 needs to pin
+    # any memory it is using so it is not paged out.  Groups of pages that
+    # are known not to be accessed during activation need not be pinned
+    # into memory.  Each string listed in this setting is compared against
+    # each line in /proc/self/maps, and the pages corresponding to any
+    # lines that match are not pinned.  On some systems locale-archive was
+    # found to make up over 80% of the memory used by the process.
+    # mlock_filter = [ "locale/locale-archive", "gconv/gconv-modules.cache" ]
+
+    # Set to 1 to revert to the default behaviour prior to version 2.02.62
+    # which used mlockall() to pin the whole process's memory while activating
+    # devices.
+    use_mlockall = 0
+
+    # Monitoring is enabled by default when activating logical volumes.
+    # Set to 0 to disable monitoring or use the --ignoremonitoring option.
+    monitoring = 0
+
+    # When pvmove or lvconvert must wait for the kernel to finish
+    # synchronising or merging data, they check and report progress
+    # at intervals of this number of seconds.  The default is 15 seconds.
+    # If this is set to 0 and there is only one thing to wait for, there
+    # are no progress reports, but the process is awoken immediately the
+    # operation is complete.
+    polling_interval = 15
+}
+
+
+####################
+# Advanced section #
+####################
+
+# Metadata settings
+#
+# metadata {
+    # Default number of copies of metadata to hold on each PV.  0, 1 or 2.
+    # You might want to override it from the command line with 0
+    # when running pvcreate on new PVs which are to be added to large VGs.
+
+    # pvmetadatacopies = 1
+
+    # Default number of copies of metadata to maintain for each VG.
+    # If set to a non-zero value, LVM automatically chooses which of
+    # the available metadata areas to use to achieve the requested
+    # number of copies of the VG metadata.  If you set a value larger
+    # than the the total number of metadata areas available then
+    # metadata is stored in them all.
+    # The default value of 0 ("unmanaged") disables this automatic
+    # management and allows you to control which metadata areas
+    # are used at the individual PV level using 'pvchange
+    # --metadataignore y/n'.
+
+    # vgmetadatacopies = 0
+
+    # Approximate default size of on-disk metadata areas in sectors.
+    # You should increase this if you have large volume groups or
+    # you want to retain a large on-disk history of your metadata changes.
+
+    # pvmetadatasize = 255
+
+    # List of directories holding live copies of text format metadata.
+    # These directories must not be on logical volumes!
+    # It's possible to use LVM2 with a couple of directories here,
+    # preferably on different (non-LV) filesystems, and with no other
+    # on-disk metadata (pvmetadatacopies = 0). Or this can be in
+    # addition to on-disk metadata areas.
+    # The feature was originally added to simplify testing and is not
+    # supported under low memory situations - the machine could lock up.
+    #
+    # Never edit any files in these directories by hand unless you
+    # you are absolutely sure you know what you are doing! Use
+    # the supplied toolset to make changes (e.g. vgcfgrestore).
+
+    # dirs = [ "/etc/lvm/metadata", "/mnt/disk2/lvm/metadata2" ]
+#}
+
+# Event daemon
+#
+dmeventd {
+    # mirror_library is the library used when monitoring a mirror device.
+    #
+    # "libdevmapper-event-lvm2mirror.so" attempts to recover from
+    # failures.  It removes failed devices from a volume group and
+    # reconfigures a mirror as necessary. If no mirror library is
+    # provided, mirrors are not monitored through dmeventd.
+
+    mirror_library = "libdevmapper-event-lvm2mirror.so"
+
+    # snapshot_library is the library used when monitoring a snapshot device.
+    #
+    # "libdevmapper-event-lvm2snapshot.so" monitors the filling of
+    # snapshots and emits a warning through syslog when the use of
+    # the snapshot exceeds 80%. The warning is repeated when 85%, 90% and
+    # 95% of the snapshot is filled.
+
+    snapshot_library = "libdevmapper-event-lvm2snapshot.so"
+
+    # thin_library is the library used when monitoring a thin device.
+    #
+    # "libdevmapper-event-lvm2thin.so" monitors the filling of
+    # pool and emits a warning through syslog when the use of
+    # the pool exceeds 80%. The warning is repeated when 85%, 90% and
+    # 95% of the pool is filled.
+
+    thin_library = "libdevmapper-event-lvm2thin.so"
+
+    # Full path of the dmeventd binary.
+    #
+    # executable = "/sbin/dmeventd"
+}


### PR DESCRIPTION
Fixes #1035 by only whitelisting the hypervisor's ephemeral volumes and `/dev/md127` (since that is what the MD device is typically recognized as by LVM until the hypervisor is rebooted) and excluding all other block devices from consideration.