### PR TITLE
Fixes error introduced by #1036 that causes failure to converge

### DIFF
--- a/cookbooks/bcpc/recipes/lvm.rb
+++ b/cookbooks/bcpc/recipes/lvm.rb
@@ -29,7 +29,7 @@ if node['bcpc']['nova']['ephemeral']
     group  'root'
     mode   00644
     variables(
-      :lvm_whitelist => node['bcpc']['nova']['ephemeral_disks'].map { |dev| "\"a|^#{dev}$|\", " }
+      :lvm_whitelist => node['bcpc']['nova']['ephemeral_disks'].map { |dev| "\"a|^#{dev}$|\", " }.join
     )
   end
 


### PR DESCRIPTION
#1036 introduced a stupid bug that will cause a convergence failure on ephemeral disk nodes due to an invalid LVM configuration being generated. Without this bugfix in place, convergence will fail due to a filter in `lvm.conf` that resembles the following:
```
filter = [ ["\"a|^/dev/md/md0$|\", "] "a|^/dev/md127$|", "r|.*|" ]
```
This bugfix adds a `#join` method call to the result of the map so that the syntactically correct form will be output:
```
filter = [ "a|^/dev/md/md0$|",  "a|^/dev/md127$|", "r|.*|" ]
```