### PR TITLE
Make bcpc_cephconfig provider idempotent

### DIFF
--- a/cookbooks/bcpc/providers/cephconfig.rb
+++ b/cookbooks/bcpc/providers/cephconfig.rb
@@ -27,7 +27,10 @@ action :set do
     next
   end
 
-  sockets = ::Dir.glob(::File.join(@new_resource.path, @new_resource.target) + ".asok")
+  sockets = ::Dir.glob(::File.join(@new_resource.path, @new_resource.target) + ".asok").select do |file|
+    ::File.socket? file
+  end
+
   sockets.each do |socket_path|
     cmd = Mixlib::ShellOut.new("ceph daemon #{socket_path} config get #{@new_resource.name}").run_command
     begin


### PR DESCRIPTION
This rewrites the cephconfig provider in the following ways:
- makes it idempotent by correctly comparing the value
- flattens out the pyramid of ifs by adding a few nexts
- drops some error handling that was not likely to ever be reached