### PR TITLE
Fixes #1012: install whois package to provide mkpasswd

### DIFF
--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-create-bootstrap-users.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-create-bootstrap-users.yml
@@ -2,6 +2,10 @@
 - set_fact:
     ubuntu_password_path: /root/UBUNTU_PASSWORD
 
+# whois package provides mkpasswd
+- name: Install whois
+  apt: name=whois state=present
+
 - name: Test if strong password has already been saved on filesystem
   stat: path={{ ubuntu_password_path }}
   register: ubuntu_password_stat


### PR DESCRIPTION
(package is available on installation media, does not require a mirror)