### PR TITLE
Fixes #1033: fails the Chef run if the host_aggregates provider fails to execute

### DIFF
--- a/cookbooks/bcpc/providers/host_aggregate.rb
+++ b/cookbooks/bcpc/providers/host_aggregate.rb
@@ -34,18 +34,10 @@ end
 
 action :create do
   stdout, stderr, status = Open3.capture3(*(openstack_cli +
-  	                                    ["aggregate", "show",
+                                        ["aggregate", "show",
                                              @new_resource.name, "-f", "json" ]))
 
-  if not status.success?
-    converge_by("Creating host aggregate #{new_resource.name}") do
-      args = ["aggregate", "create", @new_resource.name , "-f", "json"]
-      args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil?
-      stdout, status = Open3.capture2( *(openstack_cli + args +
-     		                         @new_resource.metadata.collect {|k , v| ["--property", k.to_s + "=" + v.to_s ] }.flatten ))
-      Chef::Log.error "Failed to create host aggregate" unless status.success?
-    end
-  else
+  if status.success?
     ha_fields = JSON.parse(stdout)
     current_properties = ha_fields.select {|x| x['Field'] == "properties"}[0]["Value"]
 
@@ -54,12 +46,20 @@ action :create do
     @new_resource.metadata.each { |k,v| new_properties[k.to_s] = v.to_s }
     if new_properties != current_properties
       converge_by ("Update properties") do
-	args = ["aggregate", "set", @new_resource.name]
-	args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil?
-	stdout, status = Open3.capture2( *(openstack_cli +
-    	 		 	           args + new_properties.collect {|k , v| ["--property", k + "=" + v ] }.flatten ))
-	Chef::Log.error "Failed to update host aggregate" unless status.success?
+        args = ["aggregate", "set", @new_resource.name]
+        args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil?
+        stdout, stderr, status = Open3.capture3( *(openstack_cli +
+                             args + new_properties.collect {|k , v| ["--property", k + "=" + v ] }.flatten ))
+        raise "Failed to update host aggregate #{@new_resource.name}: #{stderr}" unless status.success?
       end
+    end
+  else
+    converge_by("Creating host aggregate #{new_resource.name}") do
+      args = ["aggregate", "create", @new_resource.name , "-f", "json"]
+      args += ["--zone", "#{@new_resource.zone}"] unless @new_resource.zone.nil?
+      stdout, stderr, status = Open3.capture3( *(openstack_cli + args +
+                                 @new_resource.metadata.collect {|k , v| ["--property", k.to_s + "=" + v.to_s ] }.flatten ))
+      raise "Failed to create host aggregate #{@new_resource.name}: #{stderr}" unless status.success?
     end
   end
 end
@@ -67,15 +67,16 @@ end
 action :member do
   # Adds the current host to the host aggregate
   stdout, stderr, status = Open3.capture3(*(openstack_cli +
-  	                                    ["aggregate", "show", @new_resource.name, "-f", "json" ]))
+                                        ["aggregate", "show", @new_resource.name, "-f", "json" ]))
   raise "Unable to find host aggregate #{@new_resource.name}" unless status.success?
 
   ha_fields = JSON.parse(stdout)
   current_hosts = ha_fields.select {|x| x['Field'] == "hosts"}[0]["Value"]
-  if not current_hosts.include?(node['hostname'])
+  unless current_hosts.include?(node['hostname'])
     converge_by ("Adding host") do
       stdout, stderr, status = Open3.capture3(*(openstack_cli +
-  			                        ["aggregate", "add", "host", @new_resource.name, node['hostname'] ]))
+                                ["aggregate", "add", "host", @new_resource.name, node['hostname'] ]))
+      raise "Failed to add host #{node['hostname']} to aggregate #{@new_resource.name}: #{stderr}" unless status.success?
     end
   end
 end
@@ -83,7 +84,7 @@ end
 action :depart do
   # Removes the current host from the host aggregate
   stdout, stderr, status = Open3.capture3(*(openstack_cli +
-  	                                    ["aggregate", "show", @new_resource.name, "-f", "json" ]))
+                                        ["aggregate", "show", @new_resource.name, "-f", "json" ]))
   raise "Unable to find host aggregate #{@new_resource.name}" unless status.success?
 
   ha_fields = JSON.parse(stdout)
@@ -91,7 +92,8 @@ action :depart do
   if current_hosts.include?(node['hostname'])
     converge_by ("Removing host") do
       stdout, stderr, status = Open3.capture3(*(openstack_cli +
-  			                        ["aggregate", "remove", "host", @new_resource.name, node['hostname'] ]))
+                                ["aggregate", "remove", "host", @new_resource.name, node['hostname'] ]))
+      raise "Failed to remove host #{node['hostname']} from aggregate #{@new_resource.name}: #{stderr}" unless status.success?
     end
   end
 end


### PR DESCRIPTION
This makes the **host_aggregates** provider fail correctly if something goes wrong. You can generally inspire it to blow up by doing something like:

* deleting the maintenance aggregate and recreating it with an attached AZ, then put a node in maintenance, re-chef, take it out of maintenance, re-chef (kaboom)
* possibly putting a node in an AZ it doesn't manage and removing it from a node it does manage will trigger failure
* not sure how to get it to fail when creating an aggregate, though you might be able to simulate that by killing Nova and just running the host-aggregates recipe by itself