### PR TITLE
Toggle for bootstrap data location

### DIFF
--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-create-directory-structure.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-create-directory-structure.yml
@@ -5,15 +5,23 @@
 
   - name: Set up /mnt directory
     filesystem: fstype=ext4 dev=/dev/sdb opts="-F"
+    when: not bootstrap_data_root_disk
 
   - name: Mount the /mnt directory
     mount: name=/mnt src=/dev/sdb fstype=ext4 state=mounted
+    when: not bootstrap_data_root_disk
+
+  - name: Set up /bcpc directory on root disk if enabled
+    file: path=/bcpc state=directory
+    when: bootstrap_data_root_disk
 
   - name: Set up /bcpc directory
     filesystem: fstype=ext4 dev=/dev/sdc opts="-F"
+    when: not bootstrap_data_root_disk
 
   - name: Mount the /bcpc directory
     mount: name=/bcpc src=/dev/sdc fstype=ext4 state=mounted
+    when: not bootstrap_data_root_disk
 
   - name: Create various staging areas
     file: path={{ item }} state=directory owner=operations group=operators mode=0775 recurse=yes

--- a/bootstrap/ansible_scripts/group_vars/vars.template
+++ b/bootstrap/ansible_scripts/group_vars/vars.template
@@ -155,6 +155,10 @@ bootstrap_apt_mirror_dir: "{{ bootstrap_staging_dir }}/apt-mirror"
 bootstrap_deployed_dir: "{{ bootstrap_staging_dir }}/deployed"
 bootstrap_mirror_root_dir: "{{ bootstrap_staging_dir }}/mirror-root"
 
+# Use root disk for bootstrap data. It will use separate disks (/dev/sd[bc] by
+# default.
+bootstrap_data_root_disk: false
+
 ################################################
 # APT MIRROR SYMLINK PATHS
 # (these should not need to be changed unless upstream repos change)


### PR DESCRIPTION
Ansible bootstrap will still use `/dev/sdb` and `/dev/sdc` for bootstrap data by default. This toggle allows use of `/` to store bootstrap data. `bootstrap_data_root_disk` needs to be pre-defined in Ansible `group_vars` regardless of choice.