### PR TITLE
Control I/O scheduler

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -522,6 +522,15 @@ default['bcpc']['system']['parameters']['net.nf_conntrack_max'] = 262144
 
 ###########################################
 #
+# BCPC system hardware settings
+#
+###########################################
+#
+# Select desired I/O scheduler to be applied at startup (deadline, noop, cfq)
+default['bcpc']['hardware']['io_scheduler'] = 'deadline'
+
+###########################################
+#
 # CPU governor settings
 #
 ###########################################

--- a/cookbooks/bcpc/templates/default/system.etc_default_grub.erb
+++ b/cookbooks/bcpc/templates/default/system.etc_default_grub.erb
@@ -19,7 +19,8 @@ GRUB_HIDDEN_TIMEOUT_QUIET=true
 GRUB_TIMEOUT=0
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet console=tty0 console=tty1"
-GRUB_CMDLINE_LINUX=""
+# use <%= @node['bcpc']['hardware']['io_scheduler'] %> I/O scheduler
+GRUB_CMDLINE_LINUX="elevator=<%= @node['bcpc']['hardware']['io_scheduler'] %>"
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs
 # This works with Linux (no patch required) and with any kernel that obtains
@@ -42,6 +43,3 @@ GRUB_CMDLINE_LINUX=""
 
 # Uncomment to get a beep at grub start
 #GRUB_INIT_TUNE="480 440 1"
-
-# add deadline elevator
-GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT elevator=deadline"


### PR DESCRIPTION
This PR allows setting the I/O scheduler. (Incidentally, the previous thing where we hardcoded deadline in the grub config never actually worked, it just so happened that deadline was the default anyway.)