### PR TITLE
Move apt-get upgrade/dist-upgrade to end of Chef run

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -64,8 +64,8 @@ default['bcpc']['enabled']['dns'] = true
 default['bcpc']['enabled']['host_firewall'] = true
 # This will enable of encryption of the chef data bag
 default['bcpc']['enabled']['encrypt_data_bag'] = false
-# These will enable automatic dist-upgrade/upgrade at the start of a Chef run
-# (not recommended for stability)
+# These will enable automatic dist-upgrade/upgrade at the end of a Chef run
+# (recommended for scenarios where package versions are managed via frozen mirror)
 default['bcpc']['enabled']['apt_dist_upgrade'] = false
 default['bcpc']['enabled']['apt_upgrade'] = false
 # This will enable running apt-get update at the start of every Chef run

--- a/cookbooks/bcpc/recipes/packages-common.rb
+++ b/cookbooks/bcpc/recipes/packages-common.rb
@@ -35,19 +35,3 @@ package 'logtail'
 package "powernap" do
   action :remove
 end
-
-if node['bcpc']['enabled']['apt_dist_upgrade']
-  include_recipe "apt::default"
-  bash "perform-dist-upgrade" do
-    user "root"
-    code "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" dist-upgrade"
-  end
-end
-
-if node['bcpc']['enabled']['apt_upgrade']
-  include_recipe "apt::default"
-  bash "perform-upgrade" do
-    user "root"
-    code "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade"
-  end
-end

--- a/cookbooks/bcpc/recipes/packages-upgrade.rb
+++ b/cookbooks/bcpc/recipes/packages-upgrade.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: packages-upgrade
+#
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_recipe "apt::default"
+
+bash "perform-dist-upgrade" do
+  user "root"
+  code "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" dist-upgrade"
+  only_if { node['bcpc']['enabled']['apt_dist_upgrade'] }
+end
+
+bash "perform-upgrade" do
+  user "root"
+  code "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade"
+  only_if { node['bcpc']['enabled']['apt_upgrade'] }
+end

--- a/roles/BCPC-Bootstrap.json
+++ b/roles/BCPC-Bootstrap.json
@@ -12,7 +12,8 @@
       "recipe[bcpc::rally]",
       "recipe[bcpc::diamond]",
       "recipe[bcpc::fluentd]",
-      "recipe[bcpc::zabbix-agent]"
+      "recipe[bcpc::zabbix-agent]",
+      "recipe[bcpc::packages-upgrade]"
     ],
     "description": "A bootstrap node in a BCPC cluster",
     "chef_type": "role",

--- a/roles/BCPC-EphemeralWorknode.json
+++ b/roles/BCPC-EphemeralWorknode.json
@@ -3,7 +3,8 @@
   "default_attributes": {},
   "json_class": "Chef::Role",
   "run_list": [
-    "role[BCPC-Ephemeral]"
+    "role[BCPC-Ephemeral]",
+      "recipe[bcpc::packages-upgrade]"
   ],
   "description": "An ephemeral compute node in a BCPC cluster",
   "chef_type": "role",

--- a/roles/BCPC-Headnode.json
+++ b/roles/BCPC-Headnode.json
@@ -32,7 +32,8 @@
       "recipe[bcpc::checks-head]",
       "recipe[bcpc::flavors]",
       "recipe[bcpc::rgw-quota]",
-      "recipe[bcpc::os-quota]"
+      "recipe[bcpc::os-quota]",
+      "recipe[bcpc::packages-upgrade]"
     ],
     "description": "A highly-available head node in a BCPC cluster",
     "chef_type": "role",

--- a/roles/BCPC-Monitoring.json
+++ b/roles/BCPC-Monitoring.json
@@ -6,7 +6,8 @@
     "run_list": [
       "role[BCPC-Alerting]",
       "role[BCPC-Metrics]",
-      "role[BCPC-Logging]"
+      "role[BCPC-Logging]",
+      "recipe[bcpc::packages-upgrade]"
     ],
     "description": "Monitoring head node in a BCPC cluster",
     "chef_type": "role",

--- a/roles/BCPC-Worknode.json
+++ b/roles/BCPC-Worknode.json
@@ -4,7 +4,8 @@
     },
     "json_class": "Chef::Role",
     "run_list": [
-      "role[BCPC-Compute]"
+      "role[BCPC-Compute]",
+      "recipe[bcpc::packages-upgrade]"
     ],
     "description": "A functional compute node in a BCPC cluster",
     "chef_type": "role",


### PR DESCRIPTION
This change relocates the running of `apt-get upgrade` and `apt-get dist-upgrade`, if configured, to the end of the Chef run for a node. The reason for this is so that the recipes ahead of it in the Chef run can upgrade specific targeted packages in a managed fashion and handle configuration file changes appropriately, and then packages not managed by any recipe can be upgraded en masse to bring a node into a converged state with its package mirror. With the previous location, it would upgrade all packages at the beginning of the Chef run and cause various issues (restarting services with default configuration files, Chef checksum errors, etc.).