### PR TITLE
Chef Server upgrade fixes and cleanup

### DIFF
--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-client.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-client.yml
@@ -53,11 +53,11 @@
   - name: Remove previous version of knife-acl
     become: yes
     command: /opt/opscode/embedded/bin/gem uninstall knife-acl -v 0.0.12
-    when: old_knife_acl_installed.stdout.find('true')
+    when: old_knife_acl_installed.rc == 0
 
   - name: Install knife-acl 1.0.2
     become: yes
-    command: /opt/opscode/embedded/bin/gem install {{ bootstrap_files_dir }}/{{ chef_bcpc_version }}/knife-acl-1.0.2.gem
+    command: /opt/opscode/embedded/bin/gem install {{ bootstrap_files_dir }}/{{ chef_bcpc_version }}/knife-acl-1.0.2.gem --local
 
   - name: Make bootstrap node an admin in the Chef server
     become: no

--- a/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-server.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/tasks-configure-chef-server.yml
@@ -42,6 +42,25 @@
     tags:
       - chef
 
+  - name: Remove deprecated opscode-expander-reindexer service from runit supervision
+    file: name=/opt/opscode/service/opscode-expander-reindexer state=absent
+    register: chef_remove_reindexer_result
+    tags:
+      - chef
+
+  - name: Wait for runit to pick up above change
+    become: no
+    pause: seconds=10
+    when: chef_remove_reindexer_result.changed
+    tags:
+      - chef
+
+  - name: Remove deprecated opscode-expander-reindexer runit service dir
+    file: name=/opt/opscode/sv/opscode-expander-reindexer state=absent
+    when: chef_remove_reindexer_result.changed
+    tags:
+      - chef
+
   - name: Restart Chef Server components after upgrade
     sudo: yes
     command: chef-server-ctl restart

--- a/bootstrap/ansible_scripts/group_vars/vars.template
+++ b/bootstrap/ansible_scripts/group_vars/vars.template
@@ -142,8 +142,8 @@ dependency_cookbooks:
 # CHEF PACKAGE VERSIONS
 ################################################
 # Chef package names
-chef_server_deb: chef-server-core_12.0.8-1_amd64.deb
-chef_client_deb: chef_12.3.0-1_amd64.deb
+chef_server_deb: chef-server-core_12.6.0-1_amd64.deb
+chef_client_deb: chef_12.9.41-1_amd64.deb
 
 ################################################
 # REMOTE PATHS


### PR DESCRIPTION
Besides fixing #1078, this correctly uninstalls the old `knife-acl` gem and also forces gem to only install locally so we don't wait for it to timeout on Internet-disconnected clusters.
