### PR TITLE
Glance URL should not specify a version number

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -339,9 +339,9 @@ default['bcpc']['catalog'] = {
       'public' => 9292
     },
     'uris' => {
-      'admin' => 'v2',
-      'internal' => 'v2',
-      'public' => 'v2'
+      'admin' => '',
+      'internal' => '',
+      'public' => ''
     }
   }
 }


### PR DESCRIPTION
The Glance URL should not contain a version number. The legacy Glance client works in spite of this because it appears to remove all path components and then append `v1` or `v2`. The new OpenStack CLI client is broken by this, though, which you can verify by doing `openstack -vv image list` and watching as it tries to access a URL like `/v2/v1/images/blah`.

This PR only fixes the situation in Kilo for new builds. The changes to the Keystone recipes that modify service endpoints are only included in the Liberty PR #1000, which has a separate fix for this issue. Existing Kilo builds will need to have their service catalogs modified manually, or delete the Glance endpoint and then rechef in order to create the Glance endpoint anew.

Testing
---

Without this PR, the Glance client (`glance`), Horizon, and the Nova client image functions will work, but `openstack` will fail in all image-related matters. With this PR and an updated service catalog, all old functionality will continue to work and `openstack` will now work correctly.