### PR TITLE
Always specify Glance API v2 since glanceclient commands are in v2 format

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -46,9 +46,9 @@ def get_api_version(service, uri_type='public')
   api_version_list = node['bcpc']['catalog'][service_str]['uris'][uri_type_str].scan(/^[^\d]*(\d+)/)
 
   if api_version_list.empty?
-    # Glance URL should not include a version number, default to Glance API v1 for Kilo and v2 otherwise
+    # Glance URL should not include a version number, default to Glance API v2 in all cases
     if service_str == 'image'
-      return (is_kilo? ? '1' : '2')
+      return '2'
     else
       fail "Could not derive API version for #{service_str} from #{uri_type_str} URI, please inspect service catalog"
     end


### PR DESCRIPTION
This fixes an oversight where our Glance client commands are in v2 format only (e.g. `--visibility=public` instead of `--is-public`) but on Kilo it would explicitly specify Glance API v1. This would result in a convergence failure when using Kilo in 6.x:
```
    glance: error: unrecognized arguments: --visibility=public
    ---- End output of "bash"  "/tmp/chef-script20160701-5126-lvsik8" ----
    Ran "bash"  "/tmp/chef-script20160701-5126-lvsik8" returned 2
```

This corrects that by always preferring v2, which Kilo is fine with. (Glance client defaults to v1 in Kilo, hence the reason for my confusion, but everything works fine with v2.)

*NOTE*: if building from scratch using Kilo on 6.0.0 by setting **bcpc.openstack_release** to `kilo`, if you want Horizon to work, also specify **bcpc.keystone.providers.token** as `pki`, otherwise it will default to Fernet tokens and Horizon will return the error *Unauthorized. Please try logging in again.* when attempting to log in. CLI clients are unaffected.