### PR TITLE
Extend cobbler and chef bootstrap functionality to monitoring nodes

### DIFF
--- a/bootstrap/ansible_scripts/bootstrap_deployment/enroll-all-nodes-in-cobbler.yml
+++ b/bootstrap/ansible_scripts/bootstrap_deployment/enroll-all-nodes-in-cobbler.yml
@@ -22,14 +22,8 @@
       fail: msg="Please provide a cluster.yaml or cluster.yml in /bcpc/deployed on the bootstrap node"
       when: not cluster_yaml_stat.stat.exists and not cluster_yml_stat.stat.exists
 
-    - name: register head nodes from cluster YAML
-      command: ./bootstrap/ansible_scripts/scripts/enroll_cobbler.py add_role -t head chdir={{ bootstrap_deployed_dir }}
-
-    - name: register OSD work nodes from cluster YAML
-      command: ./bootstrap/ansible_scripts/scripts/enroll_cobbler.py add_role -t work chdir={{ bootstrap_deployed_dir }}
-
-    - name: register ephemeral work nodes from cluster YAML
-      command: ./bootstrap/ansible_scripts/scripts/enroll_cobbler.py add_role -t work-ephemeral chdir={{ bootstrap_deployed_dir }}
+    - name: register all nodes from cluster YAML
+      command: ./bootstrap/ansible_scripts/scripts/enroll_cobbler.py add_all chdir={{ bootstrap_deployed_dir }}
 
     - name: sync Cobbler
       command: cobbler sync

--- a/bootstrap/ansible_scripts/software_deployment/tasks-assign-roles-to-target.yml
+++ b/bootstrap/ansible_scripts/software_deployment/tasks-assign-roles-to-target.yml
@@ -8,35 +8,45 @@
       command: hostname -f
       register: hostfqdn
 
-    - name: Register variable for head node
-      set_fact:
-        chef_role: BCPC-Headnode
+    - name: Set baseline node roles
+      command: knife node run_list set {{ hostfqdn.stdout }} 'role[BCPC-Hardware-{{ hardware_type }}]'
+      delegate_to: "{{ groups['bootstraps'][0] }}"
+
+    - name: Add role for head node
+      command: knife node run_list add {{ hostfqdn.stdout }} 'role[BCPC-Headnode]'
       when: "'headnodes' in group_names"
+      delegate_to: "{{ groups['bootstraps'][0] }}"
 
-    - name: Register variable for work node
-      set_fact:
-        chef_role: BCPC-Worknode
+    - name: Add role for work node
+      command: knife node run_list add {{ hostfqdn.stdout }} 'role[BCPC-Worknode]'
       when: "'worknodes' in group_names"
+      delegate_to: "{{ groups['bootstraps'][0] }}"
 
-    - name: Register variable for ephemeral work node
-      set_fact:
-        chef_role: BCPC-EphemeralWorknode
+    - name: Add role for ephemeral work node
+      command: knife node run_list add {{ hostfqdn.stdout }} 'role[BCPC-EphemeralWorknode]'
       when: "'ephemeral-worknodes' in group_names"
+      delegate_to: "{{ groups['bootstraps'][0] }}"
+
+    - name: Add role for alerting node
+      command: knife node run_list add {{ hostfqdn.stdout }} 'role[BCPC-Alerting]'
+      when: "'alerting' in group_names"
+      delegate_to: "{{ groups['bootstraps'][0] }}"
+
+    - name: Add role for metrics node
+      command: knife node run_list add {{ hostfqdn.stdout }} 'role[BCPC-Metrics]'
+      when: "'metrics' in group_names"
+      delegate_to: "{{ groups['bootstraps'][0] }}"
+
+    - name: Add role for logging node
+      command: knife node run_list add {{ hostfqdn.stdout }} 'role[BCPC-Logging]'
+      when: "'logging' in group_names"
+      delegate_to: "{{ groups['bootstraps'][0] }}"
 
     - name: Set node environment
       command: knife node environment set {{ hostfqdn.stdout }} {{ cluster_name }}
       delegate_to: "{{ groups['bootstraps'][0] }}"
 
-    - name: Set node roles
-      command: knife node run_list set {{ hostfqdn.stdout }} 'role[BCPC-Hardware-{{ hardware_type }}]','role[{{ chef_role }}]'
+    - name: Give head/monitoring node admin access to Chef server (set node as admin)
+      command: /opt/opscode/embedded/bin/knife group add client {{ hostfqdn.stdout }} admins
       delegate_to: "{{ groups['bootstraps'][0] }}"
-
-    - name: Give head node admin access to Chef server (write out actor map)
-      command: /opt/opscode/embedded/bin/knife actor map
-      delegate_to: "{{ groups['bootstraps'][0] }}"
-      when: "'headnodes' in group_names"
-
-    - name: Give head node admin access to Chef server (set node as admin)
-      command: /opt/opscode/embedded/bin/knife group add actor admins {{ hostfqdn.stdout }}
-      delegate_to: "{{ groups['bootstraps'][0] }}"
-      when: "'headnodes' in group_names"
+      when: "'headnodes' in group_names or 'monitoring' in group_names"


### PR DESCRIPTION
Monitoring nodes may not have an all-encompassing role (i.e. BCPC-Monitoring), hence using run list addition in knife. This is for 5.x release.