### PR TITLE
Add custom flavor sorting in horizon

### DIFF
--- a/cookbooks/bcpc/templates/default/horizon.local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/horizon.local_settings.py.erb
@@ -308,6 +308,8 @@ TIME_ZONE = "UTC"
 #     'reverse': False,
 # }
 
+<%= render 'horizon/bcpc_flavor_sort.py.erb' %>
+
 # The Horizon Policy Enforcement engine uses these values to load per service
 # policy rule files. The content of these files should match the files the
 # OpenStack services are using to determine role based access control in the

--- a/cookbooks/bcpc/templates/default/horizon/bcpc_flavor_sort.py.erb
+++ b/cookbooks/bcpc/templates/default/horizon/bcpc_flavor_sort.py.erb
@@ -1,0 +1,27 @@
+_FLAVOR_CLASS_ORDER = ['generic1', 'nondurable1', 'm1', 'e1']
+_flavor_class_map = dict([(name, rank)
+                         for rank, name in enumerate(_FLAVOR_CLASS_ORDER)])
+# Sort by flavor prefix in pre-defined order, then flavor ram. If prefix not
+# matched, punt to back of list and stably sort all unmatched # prefixes by
+# flavor ram.
+def bcpc_flavor_sort(obj):
+    prefix = str(getattr(obj, 'name', '')).split('.')[0]
+    flavor_ram = int(getattr(obj, 'ram', 0))
+    flavor_cpu = int(getattr(obj, 'vcpus', 1))
+    pfx_score = int(_flavor_class_map.get(prefix, len(_flavor_class_map)))
+    rv_score = flavor_ram
+    if hasattr(globals(), 'logging'):
+        logging.debug({'obj': obj.name, 'prefix': prefix,
+                       'pfx_score': pfx_score, 'rv_score': rv_score})
+    return (pfx_score, rv_score)
+
+# When launching an instance, the menu of available flavors is
+# sorted by RAM usage, ascending. If you would like a different sort order,
+# you can provide another flavor attribute as sorting key. Alternatively, you
+# can provide a custom callback method to use for sorting. You can also provide
+# a flag for reverse sort. For more info, see
+# http://docs.python.org/2/library/functions.html#sorted
+CREATE_INSTANCE_FLAVOR_SORT = {
+     'key': bcpc_flavor_sort,
+     'reverse': False,
+}


### PR DESCRIPTION
This is a follow-up to #1039, #1076, to ease some confusion with flavor sorting in horzon. To test, from the root of the repo:
```
git clone -b feature/test-local-flavor-sort https://github.com/kamidzi/horizon
cp ../cookbooks/bcpc/templates/default/horizon/bcpc_flavor_sort.py.erb openstack_dashboard/test/local/settings.py
./run_tests.sh -q -P
```

Alternatively, one could login to horizon, attempt to create an instance, expand the flavor drop-down and observe the sorted order.