### PR TITLE
Do not re-nice osds on headnodes. Set primary-affinity to 0 on headnodes

### DIFF
--- a/cookbooks/bcpc/attributes/ceph.rb
+++ b/cookbooks/bcpc/attributes/ceph.rb
@@ -49,3 +49,8 @@ default['bcpc']['ceph']['rebalance'] = false
 # Set the default niceness of Ceph OSD and monitor processes
 default['bcpc']['ceph']['osd_niceness'] = -10
 default['bcpc']['ceph']['mon_niceness'] = -10
+
+# set the following 2 parameters to true to reduce
+# osds primary affinity to 0 on headnodes
+default['bcpc']['ceph']['allow_primary_affinity'] = true
+default['bcpc']['ceph']['set_headnode_affinity'] = true

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -22,6 +22,7 @@
 [mon]
     keyring = /var/lib/ceph/mon/$cluster-$id/keyring
     debug paxos = 0/5
+    mon osd allow primary affinity = <%= @node['bcpc']['ceph']['allow_primary_affinity'] %>
 
 # Not using CephFS but mds remains until it's removed at some later point.
 #[mds]


### PR DESCRIPTION
Do not re-nice osds and set primary-affinity to 0 on headnodes to not starve mons.

please note: applying this over existing installation will not remove osd re-nice scripts.

Testing:
* osds on headnodes should have primary-affinity == 0 `ceph osd tree`
* osds on headnodes should not have a higher priority `pgrep ceph-osd | xargs -I % cut -f 18 -d ' ' /proc/%/stat`