### PR TITLE
Enable applying nova-network patches to Nova 12.0.4

### DIFF
--- a/cookbooks/bcpc/files/default/nova-network-liberty-linux_net-12.0.4-AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-network-liberty-linux_net-12.0.4-AFTER.SHASUMS
@@ -1,0 +1,1 @@
+5b0707324a2cf8ba090c4648e236b0ace69cd447  nova/network/linux_net.py

--- a/cookbooks/bcpc/files/default/nova-network-liberty-linux_net-12.0.4-BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-network-liberty-linux_net-12.0.4-BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+48a6b35ac9bb5bc50eb4bf43384d628718b84eb6  nova/network/linux_net.py

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -287,5 +287,14 @@ bcpc_patch "nova-network-liberty-linux_net" do
   shasums_before_apply 'nova-network-liberty-linux_net-BEFORE.SHASUMS'
   shasums_after_apply  'nova-network-liberty-linux_net-AFTER.SHASUMS'
   notifies :restart, 'service[nova-network]', :immediately
-  only_if "dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') ge 2:0"
+  only_if "dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') ge 2:0 && dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') lt 2:12.0.4"
+end
+
+bcpc_patch "nova-network-liberty-linux_net-12.0.4" do
+  patch_file           'nova-network-liberty-linux_net.patch'
+  patch_root_dir       '/usr/lib/python2.7/dist-packages'
+  shasums_before_apply 'nova-network-liberty-linux_net-12.0.4-BEFORE.SHASUMS'
+  shasums_after_apply  'nova-network-liberty-linux_net-12.0.4-AFTER.SHASUMS'
+  notifies :restart, 'service[nova-network]', :immediately
+  only_if "dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') ge 2:12.0.4 && dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') lt 2:13.0.0"
 end


### PR DESCRIPTION
Nova 12.0.4 broke one of our patches. This fixes it.
```
    ================================================================================
    Error executing action `apply` on resource 'bcpc_patch[nova-network-liberty-linux_net]'
    ================================================================================
    
    RuntimeError
    ------------
          errors raised by shasum both before and after:
          BEFORE: shasum: WARNING: 1 computed checksum did NOT match
    
          AFTER: shasum: WARNING: 1 computed checksum did NOT match
    
    
    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/bcpc/providers/patch.rb:76:in `block in class_from_file'
    
    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/bcpc/recipes/nova-work.rb
    
    284: bcpc_patch "nova-network-liberty-linux_net" do
    285:   patch_file           'nova-network-liberty-linux_net.patch'
    286:   patch_root_dir       '/usr/lib/python2.7/dist-packages'
    287:   shasums_before_apply 'nova-network-liberty-linux_net-BEFORE.SHASUMS'
    288:   shasums_after_apply  'nova-network-liberty-linux_net-AFTER.SHASUMS'
    289:   notifies :restart, 'service[nova-network]', :immediately
    290:   only_if "dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') ge 2:0"
    291: end
    
    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/bcpc/recipes/nova-work.rb:284:in `from_file'
    
    bcpc_patch("nova-network-liberty-linux_net") do
      action [:apply]
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      declared_type :bcpc_patch
      cookbook_name "bcpc"
      recipe_name "nova-work"
      patch_file "nova-network-liberty-linux_net.patch"
      patch_root_dir "/usr/lib/python2.7/dist-packages"
      shasums_before_apply "nova-network-liberty-linux_net-BEFORE.SHASUMS"
      shasums_after_apply "nova-network-liberty-linux_net-AFTER.SHASUMS"
      only_if "dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') ge 2:0"
    end
    
    Platform:
    ---------
    x86_64-linux
```