### PR TITLE
Ensure ipmi_devintf kernel module is inserted

### DIFF
--- a/cookbooks/bcpc/recipes/system.rb
+++ b/cookbooks/bcpc/recipes/system.rb
@@ -35,6 +35,16 @@ if node['bcpc']['kernel_version']
   end
 end
 
+package "linux-image-extra-#{node['kernel']['release']}"
+
+# after installing linux-image-extra:
+# ensure ipmi_devintf module is inserted to create /dev/ipmi0 for monitoring
+# (on platforms without IPMI, the module will load but not create the dev node)
+bash 'modprobe-ipmi_devintf' do
+  code 'modprobe ipmi_devintf'
+  not_if 'lsmod | grep ipmi_devintf'
+end
+
 template "/etc/default/grub" do
   source "system.etc_default_grub.erb"
   owner  "root"


### PR DESCRIPTION
This module is required for creating `/dev/ipmi0` on platforms with IPMI support. This avoids a situation where Graphite metrics are not initially collected. On platforms without IPMI support, the module will still insert but `/dev/ipmi0` will not be created (e.g., when using VirtualBox, so in order to verify that this has the desired effect it really needs to be tested on IPMI-supporting hardware).