### PR TITLE
Change compute:get_all_tenants to avoid quota summation across tenancies

### DIFF
--- a/cookbooks/bcpc/attributes/nova.policy.rb
+++ b/cookbooks/bcpc/attributes/nova.policy.rb
@@ -17,7 +17,7 @@ default['bcpc']['nova']['policy'] = {
 
   "compute:get" => "rule:admin_or_owner",
   "compute:get_all" => "rule:admin_or_owner",
-  "compute:get_all_tenants" => "rule:admin_or_owner",
+  "compute:get_all_tenants" => "is_admin:True",
 
   "compute:update" => "rule:admin_or_owner",
 


### PR DESCRIPTION
This fixes an unfortunate behavior quirk in Horizon where Horizon would
sum quotas for a user across all their tenancies but still apply the
per-tenancy quota limits when attempting to launch instances. For
example, if user X had launched 4 vCPUs worth of instances across 3
tenancies, and then tried to launch another instance in a tenancy with
a 4 vCPU quota that only had 1 vCPU consumed, the launch would still
fail.

NOTE: this only affects Horizon. Nova CLI commands are not affected.