### PR TITLE
Fixes #1096: override td-agent restart command

### DIFF
--- a/cookbooks/bcpc/recipes/fluentd.rb
+++ b/cookbooks/bcpc/recipes/fluentd.rb
@@ -94,6 +94,7 @@ if node['bcpc']['enabled']['logging'] then
 
     service "td-agent" do
         action [:enable, :start]
+        restart_command "service td-agent stop; while service td-agent status; do sleep 1; done; service td-agent start; while ! service td-agent status; do sleep 1; done"
     end
 
 end


### PR DESCRIPTION
This seems to fix #1096 (which looked like a race condition because occasionally I had it happen to me on non-monitoring nodes as well).