### PR TITLE
Ensure rabbitmq is started up

### DIFF
--- a/cookbooks/bcpc/recipes/rabbitmq.rb
+++ b/cookbooks/bcpc/recipes/rabbitmq.rb
@@ -102,7 +102,7 @@ end
 
 service "rabbitmq-server" do
     stop_command "service rabbitmq-server stop && epmd -kill"
-    action [:enable]
+    action [:enable, :start]
     supports :status => true
 end
 


### PR DESCRIPTION
Current build fails during rabbitmq recipe run, due to non-started rabbitmq. Ensure it is started.

```
* service[rabbitmq-server] action enable (up to date)
  * ruby_block[set-rabbitmq-guest-password] action runError: unable to connect to node 'rabbit@bcpc-vm1': nodedown

DIAGNOSTICS
===========

attempted to contact: ['rabbit@bcpc-vm1']

rabbit@bcpc-vm1:
  * connected to epmd (port 4369) on bcpc-vm1
  * epmd reports: node 'rabbit' not running at all
                  no other nodes on bcpc-vm1
  * suggestion: start the node

current node details:
- node name: 'rabbitmq-cli-07@bcpc-vm1'
- home dir: /var/lib/rabbitmq
- cookie hash: LHG+RiYA8oO1rld7zyfWjg==


    - execute the ruby block set-rabbitmq-guest-password
  * bash[set-rabbitmq-ha-policy] action run

    ================================================================================
    Error executing action `run` on resource 'bash[set-rabbitmq-ha-policy]'
    ================================================================================

    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '69'
    ---- Begin output of "bash"  "/tmp/chef-script20160805-118859-bwpexb" ----
    STDOUT:
    STDERR: Error: unable to connect to node 'rabbit@bcpc-vm1': nodedown
```