### PR TITLE
Fix knife format parameter

### DIFF
--- a/cookbooks/bcpc/templates/default/bcpc_backup.sh.erb
+++ b/cookbooks/bcpc/templates/default/bcpc_backup.sh.erb
@@ -139,7 +139,7 @@ CHEF_ENVS=( $CHEF_ENVS_RAW )
 for CHEF_ENV in ${CHEF_ENVS[@]}; do
   DATABAG_BACKUP_PATH=$BACKUP_PATH/$CHEF_ENV-databag.json
   if [ ! -f $DATABAG_BACKUP_PATH ]; then
-    $KNIFE data bag show configs -f json $CHEF_ENV > $DATABAG_BACKUP_PATH 2>/dev/null
+    $KNIFE data bag show configs -F json $CHEF_ENV > $DATABAG_BACKUP_PATH 2>/dev/null
     log "Backed up data bag for $CHEF_ENV to $DATABAG_BACKUP_PATH."
   else
     error "File $DATABAG_BACKUP_PATH already exists, refusing to overwrite."
@@ -147,7 +147,7 @@ for CHEF_ENV in ${CHEF_ENVS[@]}; do
 
   ENVIRONMENT_BACKUP_PATH=$BACKUP_PATH/$CHEF_ENV-environment.json
   if [ ! -f $ENVIRONMENT_BACKUP_PATH ]; then
-    $KNIFE environment show -f json $CHEF_ENV > $ENVIRONMENT_BACKUP_PATH 2>/dev/null
+    $KNIFE environment show -F json $CHEF_ENV > $ENVIRONMENT_BACKUP_PATH 2>/dev/null
     log "Backed up environment for $CHEF_ENV to $ENVIRONMENT_BACKUP_PATH."
   else
     error "File $ENVIRONMENT_BACKUP_PATH already exists, refusing to overwrite."


### PR DESCRIPTION
Current backups of data bag and environment are failing due to incorrect `knife` command usage.

```
# knife data bag show configs -f Test-Laptop-Vagrant
/opt/chef/embedded/lib/ruby/gems/2.1.0/gems/mixlib-cli-1.5.0/lib/mixlib/cli.rb:191:in `parse_options': ambiguous option: -f (OptionParser::AmbiguousOption)
        from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.9.41/lib/chef/knife.rb:320:in `parse_options'
        from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.9.41/lib/chef/knife.rb:300:in `initialize'
        from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.9.41/lib/chef/knife.rb:217:in `new'
        from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.9.41/lib/chef/knife.rb:217:in `run'
        from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.9.41/lib/chef/application/knife.rb:148:in `run'
        from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/chef-12.9.41/bin/knife:25:in `<top (required)>'
        from /usr/bin/knife:51:in `load'
        from /usr/bin/knife:51:in `<main>'
```

The format parameter for `knife` appears to have changed from `-f` to `-F` at some point - https://docs.chef.io/knife_data_bag.html.

Upon cheffing in the change, re-run backups and verify data bag and environment files are non-empty.