### PR TITLE
Move imports back to top-level in dns_fill.py

### DIFF
--- a/cookbooks/bcpc/files/default/dns_fill.py
+++ b/cookbooks/bcpc/files/default/dns_fill.py
@@ -7,17 +7,16 @@ Asks openstack about all the running instances that currently have floats
 then creates a CNAME record to point to the public-X.X.X.X username
 
 """
+import keystoneclient
+from keystoneclient.v2_0 import client as kclient
+from keystoneclient import exceptions as kc_exceptions
+import MySQLdb as mdb
+import re
+import syslog
 
 
 class dns_popper(object):
     def __init__(self, config):
-        import keystoneclient
-        from keystoneclient.v2_0 import client as kclient
-        from keystoneclient import exceptions as kc_exceptions
-        import MySQLdb as mdb
-        import re
-        import syslog
-
         self.config = config
         self.keystone = kclient.Client(
             username=config["OS_USERNAME"],


### PR DESCRIPTION
The imports were originally moved out of the top level in order to facilitate running the unit tests on this script on systems that didn't have all the modules installed. However, this resulted in
```
Traceback (most recent call last):
  File "/usr/local/bin/dns_fill.py", line 228, in <module>
    args.func(args)
  File "/usr/local/bin/dns_fill.py", line 195, in c_run
    dnsp.update_db(db_rows, nova_rows)
  File "/usr/local/bin/dns_fill.py", line 127, in update_db
    except mdb.Error, e:
NameError: global name 'mdb' is not defined
```
...whenever the script ran for real, which is obviously not ideal.