### PR TITLE
Add option to deploy Berks packaged cookbooks via Ansible

### DIFF
--- a/bootstrap/ansible_scripts/group_vars/vars.template
+++ b/bootstrap/ansible_scripts/group_vars/vars.template
@@ -112,6 +112,12 @@ chef_bcpc_deploy_from_dir: /deploy/chef-bcpc/from/here/
 #  version:  1.0.0
 internal_cookbooks: []
 
+# berks_packages is for deploying additional cookbooks that are packaged
+# by Berkshelf, e.g.:
+#berks_packages:
+#- cookbook: blah
+#  version: 1470755000
+
 # these cookbooks are obtained by looking for a .tar.gz in
 # bootstrap-files/cookbooks with the appropriate name and version
 dependency_cookbooks:

--- a/bootstrap/ansible_scripts/software_deployment/tasks-prepare-deployed.yml
+++ b/bootstrap/ansible_scripts/software_deployment/tasks-prepare-deployed.yml
@@ -61,6 +61,14 @@
   command: mv {{ staging_location.path }}/{{ item.cookbook }}-{{ item.version }} {{ bootstrap_deployed_dir }}/cookbooks/{{ item.cookbook }}
   with_items: "{{ internal_cookbooks }}"
 
+- name: Decompress Berks-packaged cookbooks to temporary location
+  unarchive: copy=no src={{ bootstrap_git_staging_dir }}/{{ item.cookbook }}-{{ item.version }}.tar.gz dest={{ staging_location.path }}
+  with_items: "{{ berks_packages|default([]) }}"
+
+- name: Move additional Berks-packaged cookbooks into deployment directory cookbooks
+  shell: mv {{ staging_location.path }}/cookbooks/* {{ bootstrap_deployed_dir }}/cookbooks/
+  when: berks_packages is defined
+
 - name: Discard temporary staging location
   file: path={{ staging_location.path }} state=absent
 


### PR DESCRIPTION
Deploy cookbooks that are packaged via Berkshelf, i.e. `berks package`.