### PR TITLE
Check /vnc_auto.html for novnc status

### DIFF
--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -156,7 +156,7 @@ listen novnc
   bind <%=node['bcpc']['management']['vip']%>:6080 ssl crt /etc/haproxy/haproxy.pem
   balance source
   option tcplog
-  option httpchk GET /
+  option httpchk GET /vnc_auto.html
   http-check expect status 200
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:6080 check inter 5s rise 1 fall 1" %>


### PR DESCRIPTION
Oversight: on Kilo nova-novncproxy returns 200, on Liberty 404.