### PR TITLE
Fixes #1097: boot in text mode for LOM serial consoles

### DIFF
--- a/cookbooks/bcpc/templates/default/system.etc_default_grub.erb
+++ b/cookbooks/bcpc/templates/default/system.etc_default_grub.erb
@@ -18,7 +18,7 @@ GRUB_HIDDEN_TIMEOUT=0
 GRUB_HIDDEN_TIMEOUT_QUIET=true
 GRUB_TIMEOUT=0
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet console=tty0 console=tty1"
+GRUB_CMDLINE_LINUX_DEFAULT="vga=normal nomodeset 3 console=tty0 console=tty1"
 # use <%= @node['bcpc']['hardware']['io_scheduler'] %> I/O scheduler
 GRUB_CMDLINE_LINUX="elevator=<%= @node['bcpc']['hardware']['io_scheduler'] %>"
 


### PR DESCRIPTION
Unfortunately this can't really be tested on VirtualBox because the display mode looks the same in the GUI both before and after. It is easy to test on the hardware that requires this setting.