### PR TITLE
Install python-ldappool to work around Canonical Liberty packaging bug

### DIFF
--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -39,6 +39,10 @@ ruby_block "initialize-keystone-config" do
     end
 end
 
+package 'python-ldappool' do
+  action :upgrade
+end
+
 package 'keystone' do
   action :upgrade
   notifies :run, 'bash[clean-old-pyc-files]', :immediately


### PR DESCRIPTION
(required by Keystone but not declared as a dependency)