### PR TITLE
Create separate ceph health warn trigger for blocked ops

### DIFF
--- a/cookbooks/bcpc/files/default/ceph_health_filter.sh
+++ b/cookbooks/bcpc/files/default/ceph_health_filter.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+BLOCKED_OP_RE='osds\ have\ slow\ request|(ops|requests)\ are\ blocked'
+
+STDIN=$(cat)
+
+# Report Ceph health output verbatim if it is not HEALTH_WARN
+echo $STDIN | grep -q ^HEALTH_WARN >/dev/null 2>&1 \
+  || { echo "$STDIN" && exit 0; }
+
+if [ "`echo "$STDIN" | egrep -vc \"$BLOCKED_OP_RE\"`" -gt 0 ]; then
+  STDIN=`echo "$STDIN" | sed 's/^HEALTH_WARN/HEALTH_WARN_non_blocked/'`
+else
+  STDIN=`echo "$STDIN" | sed 's/^HEALTH_WARN/HEALTH_WARN_blocked/'`
+fi
+
+echo "$STDIN"

--- a/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
+++ b/cookbooks/bcpc/files/default/zabbix_bcpc_templates.xml
@@ -167,6 +167,49 @@
             </applications>
             <items>
                 <item>
+                    <name>VIP Holder</name>
+                    <type>0</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>net.vip_holder</key>
+                    <delay>90</delay>
+                    <history>3</history>
+                    <trends>3</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>3</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>Check if host is VIP holder</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Network interfaces</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
                     <name>Ceph Health</name>
                     <type>0</type>
                     <snmp_community/>
@@ -4401,12 +4444,22 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{BCPC-Headnode:ceph.health.str(HEALTH_WARN,#1)}=1</expression>
+            <expression>{BCPC-Headnode:net.vip_holder.last()}=1 and {BCPC-Headnode:ceph.health.str(HEALTH_WARN_non_blocked,#1)}=1</expression>
             <name>Ceph Health Warn</name>
             <url/>
             <status>0</status>
             <priority>2</priority>
             <description>Ceph Reporting health issues</description>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{BCPC-Headnode:net.vip_holder.last()}=1 and {BCPC-Headnode:ceph.health.str(HEALTH_WARN_blocked,#1)}=1</expression>
+            <name>Ceph Health Warn - Blocked Ops</name>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
+            <description>Ceph Reporting health issues - blocked ops</description>
             <type>0</type>
             <dependencies/>
         </trigger>

--- a/cookbooks/bcpc/recipes/zabbix-agent.rb
+++ b/cookbooks/bcpc/recipes/zabbix-agent.rb
@@ -157,4 +157,11 @@ if node['bcpc']['enabled']['monitoring'] then
         mode "00755"
         only_if do get_cached_head_node_names.include?(node['hostname']) end
     end
+
+    cookbook_file '/usr/local/bin/ceph_health_filter.sh' do
+      source 'ceph_health_filter.sh'
+      owner 'root'
+      group 'root'
+      mode 00755
+    end
 end

--- a/cookbooks/bcpc/templates/default/zabbix_openstack.conf.erb
+++ b/cookbooks/bcpc/templates/default/zabbix_openstack.conf.erb
@@ -4,7 +4,7 @@ UserParameter=openstack.cinder.reserved,HOME=/var/lib/zabbix mysql -u<%=get_conf
 UserParameter=openstack.nova.rootusage,HOME=/var/lib/zabbix mysql -u<%=get_config('mysql-nova-user')%> --password=<%=get_config('mysql-nova-password')%> nova  -e 'select coalesce(sum(root_gb),0) from instances where terminated_at is NULL;' | tail -n1
 UserParameter=openstack.nova.quota[*],HOME=/var/lib/zabbix mysql -u<%=get_config('mysql-nova-user')%> --password=<%=get_config('mysql-nova-password')%> nova  -e 'select coalesce(sum(hard_limit),0) from quotas where resource="$1";' | tail -n1
 UserParameter=openstack.nova.quota_usage[*],HOME=/var/lib/zabbix mysql -u<%=get_config('mysql-nova-user')%> --password=<%=get_config('mysql-nova-password')%> nova  -e 'select coalesce(sum(in_use),0) from quota_usages where resource="$1";' | tail -n1
-UserParameter=ceph.health,HOME=/var/lib/zabbix ceph health | head -1
+UserParameter=ceph.health,HOME=/var/lib/zabbix ceph health detail | /usr/local/bin/ceph_health_filter.sh | head -1
 UserParameter=ceph.pg_count[*],HOME=/var/lib/zabbix ceph pg dump | egrep "^[0-9a-f]+\.[0-9a-f]*\w" | awk '{}{print $$9}' | grep "$1" | wc -l
 UserParameter=ceph.pool.usage[*],HOME=/var/lib/zabbix rados df | egrep "^$1 " | awk '{}{print $$3}'
 UserParameter=ceph.pool.objects[*],HOME=/var/lib/zabbix rados df | egrep "^$1 " | awk '{}{print $$4}'
@@ -13,3 +13,4 @@ UserParameter=ceph.total.space[*],HOME=/var/lib/zabbix rados df | egrep "total s
 UserParameter=ceph.total.objects[*],HOME=/var/lib/zabbix rados df | egrep "total used" | awk '{}{print $$4}' | tr -d '\n'
 UserParameter=rabbitmq.fd_usage,HOME=/var/lib/zabbix sudo -u rabbitmq /usr/sbin/rabbitmqctl status 2>/dev/null | egrep -o 'total_used,[0-9]{1,}' | awk -F',' '{print $2}'
 UserParameter=rabbitmq.partition,HOME=/var/lib/zabbix sudo -u rabbitmq /usr/sbin/rabbitmqctl cluster_status 2>/dev/null | egrep -c '{partitions,\[\{'
+UserParameter=net.vip_holder,HOME=/var/lib/zabbix /usr/local/bin/if_vip echo vip_holder | wc -l


### PR DESCRIPTION
Blocked ops is generally a more common cause of Ceph health warnings, so create a separate trigger to clearly distinguish the fault.

After cheffing, remove the old Ceph health warn trigger via the web UI.

This can be tested by altering `ceph.health` parameter in `/etc/zabbix/zabbix_agentd.d/`, then restart `zabbix-agent`.
```
#UserParameter=ceph.health,HOME=/var/lib/zabbix ceph health | head -1
UserParameter=ceph.health,HOME=/var/lib/zabbix echo HEALTH_WARN 29 requests are blocked | head -1
```