### PR TITLE
Fix upstream bug #1608934: broken ephemeral disk creation in Liberty

### DIFF
--- a/cookbooks/bcpc/files/default/nova-virt-libvirt-imagebackend-AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-virt-libvirt-imagebackend-AFTER.SHASUMS
@@ -1,0 +1,1 @@
+5efb0b980d1a31aa0c62f08b56f2de91822e3fd6  nova/virt/libvirt/imagebackend.py

--- a/cookbooks/bcpc/files/default/nova-virt-libvirt-imagebackend-BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/nova-virt-libvirt-imagebackend-BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+c57d01866d6004ad3a4f47688d7f6a9945793702  nova/virt/libvirt/imagebackend.py

--- a/cookbooks/bcpc/files/default/nova-virt-libvirt-imagebackend.patch
+++ b/cookbooks/bcpc/files/default/nova-virt-libvirt-imagebackend.patch
@@ -1,0 +1,15 @@
+diff --git a/nova/virt/libvirt/imagebackend.py b/nova/virt/libvirt/imagebackend.py
+index d5a44e3..c24721a 100644
+--- a/nova/virt/libvirt/imagebackend.py
++++ b/nova/virt/libvirt/imagebackend.py
+@@ -218,7 +218,9 @@ class Image(object):
+                               *args, **kwargs)
+
+         if size:
+-            if size > self.get_disk_size(base):
++            # create_image() only creates the base image if needed, so
++            # we cannot rely on it to exist here
++            if os.path.exists(base) and size > self.get_disk_size(base):
+                 self.resize_image(size)
+
+             if (self.preallocate and self._can_fallocate() and

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -298,3 +298,14 @@ bcpc_patch "nova-network-liberty-linux_net-12.0.4" do
   notifies :restart, 'service[nova-network]', :immediately
   only_if "dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') ge 2:12.0.4 && dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') lt 2:13.0.0"
 end
+
+# fix bug 1608934 - Canonical backported a patch in 12.0.4 that broke
+# ephemeral LVM behavior, so detect and fix
+bcpc_patch "nova-virt-libvirt-imagebackend-12.0.4" do
+  patch_file           'nova-virt-libvirt-imagebackend.patch'
+  patch_root_dir       '/usr/lib/python2.7/dist-packages'
+  shasums_before_apply 'nova-virt-libvirt-imagebackend-BEFORE.SHASUMS'
+  shasums_after_apply  'nova-virt-libvirt-imagebackend-AFTER.SHASUMS'
+  notifies :restart, 'service[nova-compute]', :immediately
+  only_if "dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') ge 2:12.0.4-0ubuntu1~cloud1 && dpkg --compare-versions $(dpkg -s python-nova | egrep '^Version:' | awk '{ print $NF }') lt 2:13.0.0"
+end


### PR DESCRIPTION
Canonical backported a patch to fix a problem with disk resizing that
unintentionally broke ephemeral disk creation when images_type
is raw or lvm. This corrects that behavior.