### PR TITLE
Fixes upstream #1593571: Horizon project workflow fails with LDAP bac…

### DIFF
--- a/cookbooks/bcpc/files/default/horizon-ldap-groups-AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/horizon-ldap-groups-AFTER.SHASUMS
@@ -1,0 +1,1 @@
+750f25ca16bf6ae05c05af2c1b84bab11fd369e1  openstack_dashboard/dashboards/identity/projects/workflows.py

--- a/cookbooks/bcpc/files/default/horizon-ldap-groups-BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/horizon-ldap-groups-BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+922d874e900ba8a62c428a52abdec076567968cb  openstack_dashboard/dashboards/identity/projects/workflows.py

--- a/cookbooks/bcpc/files/default/horizon-ldap-groups.patch
+++ b/cookbooks/bcpc/files/default/horizon-ldap-groups.patch
@@ -1,0 +1,16 @@
+diff --git a/openstack_dashboard/dashboards/identity/projects/workflows.py b/openstack_dashboard/dashboards/identity/projects/workflows.py
+index e8e9283..045d634 100644
+--- a/openstack_dashboard/dashboards/identity/projects/workflows.py
++++ b/openstack_dashboard/dashboards/identity/projects/workflows.py
+@@ -322,7 +322,10 @@ class UpdateProjectGroupsAction(workflows.MembershipAction):
+                                                  domain=domain_id)
+         except Exception:
+             exceptions.handle(request, err_msg)
+-        groups_list = [(group.id, group.name) for group in all_groups]
++        # some backends (e.g. LDAP) do not provide group names
++        groups_list = [
++            (group.id, getattr(group, 'name', group.id))
++            for group in all_groups]
+
+         # Get list of roles
+         role_list = []

--- a/cookbooks/bcpc/recipes/horizon.rb
+++ b/cookbooks/bcpc/recipes/horizon.rb
@@ -227,6 +227,15 @@ bcpc_patch 'horizon-openrc-api-versions' do
   notifies :reload, 'service[apache2]', :immediately
 end
 
+# fix upstream bug 1593751 - broken LDAP groups in Horizon
+bcpc_patch 'horizon-ldap-groups' do
+  patch_file           'horizon-ldap-groups.patch'
+  patch_root_dir       '/usr/share/openstack-dashboard'
+  shasums_before_apply 'horizon-ldap-groups-BEFORE.SHASUMS'
+  shasums_after_apply  'horizon-ldap-groups-AFTER.SHASUMS'
+  notifies :reload, 'service[apache2]', :delayed
+end
+
 # update openrc.sh template to provide additional environment variables and user domain
 openrc_path = ::File.join(
   '/usr', 'share', 'openstack-dashboard', 'openstack_dashboard',


### PR DESCRIPTION
…kend

This fixes a problem with Horizon where LDAP groups do not have a name
attribute, causing all Horizon project dashboards to fail when the LDAP
group backend is in use.

(This cannot be tested on a local build unless you are willing to go to
the effort of setting up your own LDAP server.)