### PR TITLE
Use Nova API v2.1 instead of v2

### DIFF
--- a/cookbooks/bcpc/attributes/catalog.rb
+++ b/cookbooks/bcpc/attributes/catalog.rb
@@ -30,9 +30,9 @@ default['bcpc']['catalog'] = {
       'public' => 8774
     },
     'uris' => {
-      'admin' => 'v2/%(tenant_id)s',
-      'internal' => 'v2/%(tenant_id)s',
-      'public' => 'v2/%(tenant_id)s'
+      'admin' => 'v2.1/%(tenant_id)s',
+      'internal' => 'v2.1/%(tenant_id)s',
+      'public' => 'v2.1/%(tenant_id)s'
     }
   },
   'ec2' => {

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -43,7 +43,7 @@ def get_api_version(service, uri_type='public')
     fail "#{service_str} is not a valid service, please select from #{node['bcpc']['catalog'].keys.join('/')}"
   end
 
-  api_version_list = node['bcpc']['catalog'][service_str]['uris'][uri_type_str].scan(/^[^\d]*(\d+)/)
+  api_version_list = node['bcpc']['catalog'][service_str]['uris'][uri_type_str].scan(/(\d+(\.\d+)?)/)
 
   if api_version_list.empty?
     # Glance URL should not include a version number, default to Glance API v2 in all cases
@@ -54,14 +54,7 @@ def get_api_version(service, uri_type='public')
     end
   end
 
-  # special workarounds for certain fussy non-Glance APIs
-  if service_str == 'identity' and api_version_list[0][0] == "2"
-    return "2.0"
-  elsif service_str == 'compute' and api_version_list[0][0] == "1"
-    return "1.1"
-  else
-    return api_version_list[0][0]
-  end
+  api_version_list[0][0]
 end
 
 def is_vip?


### PR DESCRIPTION
I initially set v2 for the Nova API due to an oversight. v2.1 is the current and preferred version. This PR also contains a change to the regex used to parse the version number out of the catalog URLs so that it can handle both integers and floats, which permitted the removal of some workaround code.

Cheffing over an existing build will automatically update the service catalog and RC files in root as necessary.