### PR TITLE
Extend ability to manage CPU and NUMA configurations

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -323,6 +323,10 @@ default['bcpc']['ldap']['config'] = {}
 default['bcpc']['nova']['ram_allocation_ratio'] = 1.0
 default['bcpc']['nova']['reserved_host_memory_mb'] = 1024
 default['bcpc']['nova']['cpu_allocation_ratio'] = 2.0
+# CPU passthrough/masking configurations
+default['bcpc']['nova']['cpu_config']['cpu_mode'] = nil
+default['bcpc']['nova']['cpu_config']['cpu_model'] = nil
+default['bcpc']['nova']['cpu_config']['vcpu_pin_set'] = nil
 # select from between this many equally optimal hosts when launching an instance
 default['bcpc']['nova']['scheduler_host_subset_size'] = 3
 # maximum number of builds to allow the scheduler to run simultaneously
@@ -344,7 +348,7 @@ default['bcpc']['nova']['debug'] = false
 # Nova default log levels
 default['bcpc']['nova']['default_log_levels'] = nil
 # Nova scheduler default filters
-default['bcpc']['nova']['scheduler_default_filters'] = ['AggregateInstanceExtraSpecsFilter', 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter']
+default['bcpc']['nova']['scheduler_default_filters'] = ['AggregateInstanceExtraSpecsFilter', 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'NUMATopologyFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter']
 
 # configure optional Nova notification system
 default['bcpc']['nova']['notifications']['enabled'] = false

--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -19,6 +19,12 @@
 include_recipe "bcpc::ceph-work"
 include_recipe "bcpc::nova-common"
 
+# see https://specs.openstack.org/openstack/nova-specs/specs/juno/implemented/virt-driver-numa-placement.html
+# for information about NUMA in OpenStack
+package 'numactl' do
+  action :upgrade
+end
+
 package "nova-compute-#{node['bcpc']['virt_type']}" do
   action :upgrade
   notifies :restart, 'service[nova-compute]', :immediately

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -92,6 +92,9 @@ use_cow_images=True
 #snapshot_image_format=qcow2
 sync_power_state_interval=<%= node['bcpc']['nova']['sync_power_state_interval'] %>
 resume_guests_state_on_host_boot=<%= node['bcpc']['nova']['resume_guests_state_on_host_boot'] %>
+<% if node['bcpc']['nova']['cpu_config']['vcpu_pin_set'] %>
+vcpu_pin_set = <%= node['bcpc']['nova']['cpu_config']['vcpu_pin_set'] %>
+<% end %>
 
 # Nova Volume settings
 volume_api_class=nova.volume.cinder.API
@@ -222,6 +225,12 @@ live_migration_flag="VIR_MIGRATE_UNDEFINE_SOURCE,VIR_MIGRATE_PEER2PEER,VIR_MIGRA
 virt_type=<%=node['bcpc']['virt_type']%>
 use_virtio_for_bridges=True
 hw_disk_discard = unmap
+<% if node['bcpc']['nova']['cpu_config']['cpu_mode'] %>
+cpu_mode = <%= node['bcpc']['nova']['cpu_config']['cpu_mode'] %>
+<% end %>
+<% if node['bcpc']['nova']['cpu_config']['cpu_model'] %>
+cpu_model = <%= node['bcpc']['nova']['cpu_config']['cpu_model'] %>
+<% end %>
 
 <% unless node["bcpc"]["vendordata_config"].nil? %>
 [metadata]


### PR DESCRIPTION
This PR does the following:
* parameterizes cpu_mode, cpu_model, and vcpu_pin_set in nova.conf (but does not modify them from their current defaults)
* installs the numactl package
* adds NUMATopologyFilter to the default list of scheduler filters (note that without the relevant extra_specs information this filter will not do anything, so this is a no-op with all current configurations)
