### PR TITLE
Parameterize Glance debug logging

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -402,6 +402,7 @@ default['bcpc']['cinder']['quota'] = {
 ###########################################
 # Verbose logging (level INFO)
 default['bcpc']['glance']['verbose'] = false
+default['bcpc']['glance']['debug'] = false
 default['bcpc']['glance']['workers'] = 5
 
 ###########################################

--- a/cookbooks/bcpc/templates/default/glance-api.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-api.conf.erb
@@ -6,7 +6,7 @@
 
 [DEFAULT]
 verbose = <%= node['bcpc']['glance']['verbose'] %>
-#debug = False
+debug = <%= node['bcpc']['glance']['debug'] %>
 default_store = rbd
 known_stores = glance.store.rbd.Store
 #image_size_cap = 1099511627776

--- a/cookbooks/bcpc/templates/default/glance-cache.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-cache.conf.erb
@@ -9,7 +9,7 @@
 verbose = <%= node['bcpc']['glance']['verbose'] %>
 
 # Show debugging output in logs (sets DEBUG log level output)
-#debug = False
+debug = <%= node['bcpc']['glance']['debug'] %>
 
 # Log to this file. Make sure you do not set the same log file for both the API
 # and registry servers!

--- a/cookbooks/bcpc/templates/default/glance-registry.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance-registry.conf.erb
@@ -9,7 +9,7 @@
 verbose = <%= node['bcpc']['glance']['verbose'] %>
 
 # Show debugging output in logs (sets DEBUG log level output)
-#debug = False
+debug = <%= node['bcpc']['glance']['debug'] %>
 
 # Address to bind the registry server
 bind_host = <%=node['bcpc']['management']['ip']%>


### PR DESCRIPTION
For whatever reason, we forgot to parameterize Glance debug logging. This fixes that.