### PR TITLE
Parametrize mysql parameters responsible for performance

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -436,6 +436,11 @@ default['bcpc']['mysql-head']['max_connections'] = 0
 # pools of at least 1GB in size each
 default['bcpc']['mysql-head']['innodb_buffer_pool_instances'] = 1
 default['bcpc']['mysql-head']['innodb_buffer_pool_size'] = '128M'
+default['bcpc']['mysql-head']['thread_cache_size'] = nil
+default['bcpc']['mysql-head']['innodb_io_capacity'] = 200
+default['bcpc']['mysql-head']['innodb_log_buffer_size'] = '8M'
+default['bcpc']['mysql-head']['innodb_flush_method'] = 'O_DIRECT'
+default['bcpc']['mysql-head']['wsrep_slave_threads'] = 4
 
 ###########################################
 #

--- a/cookbooks/bcpc/attributes/monitoring.rb
+++ b/cookbooks/bcpc/attributes/monitoring.rb
@@ -13,6 +13,11 @@ default['bcpc']['monitoring']['external_clients'] = []
 # Monitoring database settings
 default['bcpc']['monitoring']['mysql']['innodb_buffer_pool_size'] = '128M'
 default['bcpc']['monitoring']['mysql']['innodb_buffer_pool_instances'] = 1
+default['bcpc']['monitoring']['mysql']['thread_cache_size'] = nil
+default['bcpc']['monitoring']['mysql']['innodb_io_capacity'] = 200
+default['bcpc']['monitoring']['mysql']['innodb_log_buffer_size'] = '8M'
+default['bcpc']['monitoring']['mysql']['innodb_flush_method'] = 'O_DIRECT'
+default['bcpc']['monitoring']['mysql']['wsrep_slave_threads'] = 4
 # Pagerduty integration
 default['bcpc']['monitoring']['pagerduty']['enabled'] = false
 # Pagerduty service key

--- a/cookbooks/bcpc/recipes/mysql-head.rb
+++ b/cookbooks/bcpc/recipes/mysql-head.rb
@@ -72,7 +72,12 @@ template "/etc/mysql/conf.d/wsrep.cnf" do
         :galera_user_key => "mysql-galera-user",
         :galera_pass_key => "mysql-galera-password",
         :innodb_buffer_pool_size => node['bcpc']['mysql-head']['innodb_buffer_pool_size'],
-        :innodb_buffer_pool_instances => node['bcpc']['mysql-head']['innodb_buffer_pool_instances']
+        :innodb_buffer_pool_instances => node['bcpc']['mysql-head']['innodb_buffer_pool_instances'],
+        :thread_cache_size => node['bcpc']['mysql-head']['thread_cache_size'],
+        :innodb_io_capacity => node['bcpc']['mysql-head']['innodb_io_capacity'],
+        :innodb_log_buffer_size => node['bcpc']['mysql-head']['innodb_log_buffer_size'],
+        :innodb_flush_method => node['bcpc']['mysql-head']['innodb_flush_method'],
+        :wsrep_slave_threads => node['bcpc']['mysql-head']['wsrep_slave_threads']
     )
     notifies :restart, "service[mysql]", :immediately
 end

--- a/cookbooks/bcpc/recipes/mysql-monitoring.rb
+++ b/cookbooks/bcpc/recipes/mysql-monitoring.rb
@@ -68,7 +68,12 @@ template "/etc/mysql/conf.d/wsrep.cnf" do
         :galera_user_key => "mysql-monitoring-galera-user",
         :galera_pass_key => "mysql-monitoring-galera-password",
         :innodb_buffer_pool_size => node['bcpc']['monitoring']['mysql']['innodb_buffer_pool_size'],
-        :innodb_buffer_pool_instances => node['bcpc']['monitoring']['mysql']['innodb_buffer_pool_instances']
+        :innodb_buffer_pool_instances => node['bcpc']['monitoring']['mysql']['innodb_buffer_pool_instances'],
+        :thread_cache_size => node['bcpc']['monitoring']['mysql']['thread_cache_size'],
+        :innodb_io_capacity => node['bcpc']['monitoring']['mysql']['innodb_io_capacity'],
+        :innodb_log_buffer_size => node['bcpc']['monitoring']['mysql']['innodb_log_buffer_size'],
+        :innodb_flush_method => node['bcpc']['monitoring']['mysql']['innodb_flush_method'],
+        :wsrep_slave_threads => node['bcpc']['monitoring']['mysql']['wsrep_slave_threads']
     )
     notifies :restart, "service[mysql]", :immediately
 end

--- a/cookbooks/bcpc/templates/default/wsrep.cnf.erb
+++ b/cookbooks/bcpc/templates/default/wsrep.cnf.erb
@@ -38,7 +38,7 @@ innodb_buffer_pool_size=<%= @innodb_buffer_pool_size %>
 # Number of buffer pool instances. Only takes effect if pool size is 1GB+.
 innodb_buffer_pool_instances=<%= @innodb_buffer_pool_instances %>
 
-<% if not @node['bcpc']['mysql-head']['thread_cache_size'].nil? %>
+<% if not @thread_cache_size.nil? %>
 thread_cache_size=<%= @thread_cache_size %>
 <% end %>
 innodb_io_capacity=<%= @innodb_io_capacity %>

--- a/cookbooks/bcpc/templates/default/wsrep.cnf.erb
+++ b/cookbooks/bcpc/templates/default/wsrep.cnf.erb
@@ -38,6 +38,11 @@ innodb_buffer_pool_size=<%= @innodb_buffer_pool_size %>
 # Number of buffer pool instances. Only takes effect if pool size is 1GB+.
 innodb_buffer_pool_instances=<%= @innodb_buffer_pool_instances %>
 
+<% if not @node['bcpc']['mysql-head']['thread_cache_size'].nil? %>
+thread_cache_size=<%= @thread_cache_size %>
+<% end %>
+innodb_io_capacity=<%= @innodb_io_capacity %>
+
 # Less thrash on restarts by dumping and loading buffer pools
 innodb_buffer_pool_dump_at_shutdown=ON
 innodb_buffer_pool_load_at_startup=ON
@@ -52,10 +57,11 @@ innodb_file_per_table=1
 innodb_log_file_size=64M
 
 # Set memory buffer size for the log
-innodb_log_buffer_size=8M
+innodb_log_buffer_size=<%= @innodb_log_buffer_size %>
 
 # Use direct I/O to avoid double buffering writes
-innodb_flush_method=O_DIRECT
+# note: 'O_DIRECT_NO_FSYNC' should not be used with XFS file system
+innodb_flush_method=<%= @innodb_flush_method %>
 
 # Query Cache is not supported with wsrep
 query_cache_size=0
@@ -100,7 +106,7 @@ wsrep_node_address="<%=node['bcpc']['management']['ip']%>:<%=@wsrep_port%>"
 wsrep_node_incoming_address="<%=node['bcpc']['management']['ip']%>:<%=@wsrep_port%>"
 
 # How many threads will process writesets from other nodes
-wsrep_slave_threads=4
+wsrep_slave_threads=<%= @wsrep_slave_threads %>
 
 # DBUG options for wsrep provider
 #wsrep_dbug_option


### PR DESCRIPTION
'thread_cache_size' parameter is checked for existence because if it is not defined, it is calculated dynamically by mysql. 