### PR TITLE
Put the booleans in need_to_add_keys so #any? returns true

### DIFF
--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -206,7 +206,7 @@ ruby_block 'add-fernet-keys-to-data-bag' do
         if config_defined("keystone-fernet-key-#{idx}")
           need_to_add_keys << (key_on_disk != get_config("keystone-fernet-key-#{idx}"))
         else
-          true
+          need_to_add_keys << true
         end
       end
     end


### PR DESCRIPTION
This fixes a daft bug where the `add-fernet-keys-to-data-bag` resource would always return false, because the `true` being set on this line just disappeared into the abyss instead of being added to `need_to_add_keys`. Consequently, `need_to_add_keys.any?` would always return `false`, so the resource would never fire and the keys would never be inserted into the data bag. This would cause multi-headnode setups to just not work.

Without this applied, the affected resource will never trigger and the data bag should not have any of the Fernet keys in it (e.g. `keystone-fernet-key-0`). If you have a multi-headnode setup, the Fernet keys on each head node will be different and this will cause service calls to erratically fail depending on HAProxy routing. After this is applied, re-chef the head node that you want to be the authoritative source for Fernet keys; it will upload them to the data bag and then they will be accessible to all other head nodes.