### PR TITLE
Write out Fernet keys in the data bag that are not on disk

### DIFF
--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -108,6 +108,9 @@ ruby_block 'write-out-fernet-keys-from-data-bag' do
         if config_defined("keystone-fernet-key-#{idx}")
           need_to_write_keys << (key_on_disk != get_config("keystone-fernet-key-#{idx}"))
         end
+      else
+        # key does not exist on disk, ensure that it is written out
+        need_to_write_keys << true
       end
     end
     need_to_write_keys.any?


### PR DESCRIPTION
This guard was incorrect; if a particular key file did not exist on disk while the keys that were on disk matched the data bag, the resource would take no action. You could get into a situation where 2 keys existed on disk instead of the usual 3, and those 2 keys matched the data bag, but the 3rd key would never be written out, which could lead to spurious authentication failures due to that Keystone instance missing a Fernet key.