### PR TITLE
Use partial search and only return attributes we need

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -113,14 +113,23 @@ def get_config(key)
 end
 
 def search_nodes(key, value)
+    filter = {
+      :filter_result => {
+        'ipaddress' => ['ipaddress'],
+        'hostname' => ['hostname'],
+        'fqdn' => ['fqdn'],
+        'bcpc' => ['bcpc'],
+        'roles' => ['roles']
+      }
+    }
     if key == "recipe"
-        results = search(:node, "recipes:bcpc\\:\\:#{value} AND chef_environment:#{node.chef_environment}")
+        results = search(:node, "recipes:bcpc\\:\\:#{value} AND chef_environment:#{node.chef_environment}", filter)
         results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
         if not results.include?(node) and node.run_list.expand(node.chef_environment).recipes.include?("bcpc::#{value}")
             results.push(node)
         end
     elsif key == "role"
-        results = search(:node, "#{key}:#{value} AND chef_environment:#{node.chef_environment}")
+        results = search(:node, "#{key}:#{value} AND chef_environment:#{node.chef_environment}", filter)
         results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
         if not results.include?(node) and node.run_list.expand(node.chef_environment).roles.include?(value)
             results.push(node)
@@ -133,7 +142,16 @@ def search_nodes(key, value)
 end
 
 def get_all_nodes
-    results = search(:node, "recipes:bcpc AND chef_environment:#{node.chef_environment}")
+    filter = {
+      :filter_result => {
+        'ipaddress' => ['ipaddress'],
+        'hostname' => ['hostname'],
+        'fqdn' => ['fqdn'],
+        'bcpc' => ['bcpc'],
+        'roles' => ['roles']
+      }
+    }
+    results = search(:node, "recipes:bcpc AND chef_environment:#{node.chef_environment}", filter)
     if results.any? { |x| x['hostname'] == node['hostname'] }
         results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
     else
@@ -143,7 +161,16 @@ def get_all_nodes
 end
 
 def get_ceph_osd_nodes
-  results = search(:node, "recipes:bcpc\\:\\:ceph-osd AND chef_environment:#{node.chef_environment}")
+    filter = {
+      :filter_result => {
+        'ipaddress' => ['ipaddress'],
+        'hostname' => ['hostname'],
+        'fqdn' => ['fqdn'],
+        'bcpc' => ['bcpc'],
+        'roles' => ['roles']
+      }
+    }
+    results = search(:node, "recipes:bcpc\\:\\:ceph-osd AND chef_environment:#{node.chef_environment}", filter)
     if results.any? { |x| x['hostname'] == node['hostname'] }
         results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
     else
@@ -153,7 +180,16 @@ def get_ceph_osd_nodes
 end
 
 def get_head_nodes
-    results = search(:node, "role:BCPC-Headnode AND chef_environment:#{node.chef_environment}")
+    filter = {
+      :filter_result => {
+        'ipaddress' => ['ipaddress'],
+        'hostname' => ['hostname'],
+        'fqdn' => ['fqdn'],
+        'bcpc' => ['bcpc'],
+        'roles' => ['roles']
+      }
+    }
+    results = search(:node, "role:BCPC-Headnode AND chef_environment:#{node.chef_environment}", filter)
     results.map! { |x| x['hostname'] == node['hostname'] ? node : x }
     if not results.include?(node) and node.run_list.roles.include?('BCPC-Headnode')
         results.push(node)
@@ -162,7 +198,16 @@ def get_head_nodes
 end
 
 def get_bootstrap_node
-    results = search(:node, "role:BCPC-Bootstrap AND chef_environment:#{node.chef_environment}")
+    filter = {
+      :filter_result => {
+        'ipaddress' => ['ipaddress'],
+        'hostname' => ['hostname'],
+        'fqdn' => ['fqdn'],
+        'bcpc' => ['bcpc'],
+        'roles' => ['roles']
+      }
+    }
+    results = search(:node, "role:BCPC-Bootstrap AND chef_environment:#{node.chef_environment}", filter)
     raise 'There is not exactly one bootstrap node found.' if results.size != 1
     results.first
 end

--- a/cookbooks/bcpc/recipes/haproxy-head.rb
+++ b/cookbooks/bcpc/recipes/haproxy-head.rb
@@ -28,7 +28,7 @@ concat_fragment "haproxy-main-config" do
     lazy {
       {
         :servers => get_head_nodes,
-        :all_servers => get_ceph_osd_nodes
+        :radosgw_servers => get_ceph_osd_nodes
       }
     }
   )

--- a/cookbooks/bcpc/recipes/networking-link-test.rb
+++ b/cookbooks/bcpc/recipes/networking-link-test.rb
@@ -29,12 +29,12 @@ if node['bcpc']['enabled']['network_tests'] then
             get_all_nodes.each do |host|
                 if (
                     not othernodes.include? host and (
-                        host.roles.include? "BCPC-Worknode" or
-                        host.roles.include? "BCPC-Headnode"
+                        host['roles'].include? "BCPC-Worknode" or
+                        host['roles'].include? "BCPC-Headnode"
                     ) and
                     host['hostname'] != node['hostname']
                 ) then
-                    Chef::Log.info("Found a peer : #{host.hostname}")
+                    Chef::Log.info("Found a peer: #{host['hostname']}")
                     othernodes.push host
                     float_addr.push host['bcpc']['floating']['ip']
                     storage_addr.push host['bcpc']['storage']['ip']

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -224,6 +224,6 @@ backend radosgw-http-backend
   option httpchk GET /
   http-check expect status 200
   source <%=node['bcpc']['floating']['vip']%>
-<% @all_servers.each do |server| -%>
+<% @radosgw_servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['floating']['ip']}:#{node['bcpc']['ports']['radosgw']} check inter 5s rise 1 fall 1 observe layer7" %>
 <% end -%>


### PR DESCRIPTION
This modifies how our node searches work to only return certain attributes that are used in our recipes, instead of returning everything in Ohai (most of which we don't need). From a convergence perspective, this should be a no-op in all cases. On a cluster the size of a local build, I would not expect to see any statistically significant time savings, but as cluster size ramps up, the time savings become quite significant. When tested on a 100+ node cluster with 5 head nodes, head node convergence time dropped from around 450 seconds to 178 seconds, and work node convergence time dropped from around 66 seconds to 33 seconds.