### PR TITLE
Additional monitoring band and parameterized Diamond handlers

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -52,11 +52,14 @@ default['bcpc']['in_maintenance'] = false
 #  Flags to enable/disable BCPC cluster features
 #
 ###########################################
-# This will enable elasticsearch & kibana on head nodes and fluentd on all nodes
+# This will enable elasticsearch & kibana on monitoring nodes and fluentd on
+# all nodes
 default['bcpc']['enabled']['logging'] = true
-# This will enable graphite web and carbon on head nodes and diamond on all nodes
+# This will enable graphite web and carbon on monitoring nodes and diamond on
+# all nodes
 default['bcpc']['enabled']['metrics'] = true
-# This will enable zabbix server on head nodes and zabbix agent on all nodes
+# This will enable zabbix server on monitoring nodes and zabbix agent on all
+# nodes
 default['bcpc']['enabled']['monitoring'] = true
 # This will enable powerdns on head nodes
 default['bcpc']['enabled']['dns'] = true

--- a/cookbooks/bcpc/attributes/monitoring.rb
+++ b/cookbooks/bcpc/attributes/monitoring.rb
@@ -8,6 +8,10 @@
 default['bcpc']['monitoring']['provider'] = false
 # VIP for monitoring services and agents
 default['bcpc']['monitoring']['vip'] = "10.17.1.16"
+# CIDR of monitoring endpoints outside of cluster.
+default['bcpc']['monitoring']['cidrs'] = ['10.17.1.0/24']
+# Agent TCP ports that monitoring servers need to reach
+default['bcpc']['monitoring']['agent_tcp_ports'] = [10050]
 # List of monitoring clients external to cluster that we are monitoring
 default['bcpc']['monitoring']['external_clients'] = []
 # Monitoring database settings
@@ -62,6 +66,15 @@ default['bcpc']['graphite']['use_whitelist'] = {
 #
 ###########################################
 #
+# Handlers
+default['bcpc']['diamond']['handlers'] = {
+  'diamond.handler.graphitepickle.GraphitePickleHandler' => {
+    'host' => node['bcpc']['monitoring']['vip'],
+    'port' => 2014,
+    'batch' => 512,
+    'timeout' => 15
+  }
+}
 # CPU Collector parameters
 default['bcpc']['diamond']['collectors']['CPU']['normalize'] = 'True'
 default['bcpc']['diamond']['collectors']['CPU']['percore'] = 'False'

--- a/cookbooks/bcpc/recipes/diamond.rb
+++ b/cookbooks/bcpc/recipes/diamond.rb
@@ -78,7 +78,10 @@ if node['bcpc']['enabled']['metrics'] then
         owner "diamond"
         group "root"
         mode 00600
-        variables(:servers => get_head_nodes)
+        variables(
+          :servers  => get_head_nodes,
+          :handlers => node['bcpc']['diamond']['handlers']
+        )
         notifies :restart, "service[diamond]", :delayed
     end
 

--- a/cookbooks/bcpc/recipes/ufw.rb
+++ b/cookbooks/bcpc/recipes/ufw.rb
@@ -39,6 +39,18 @@ template "/etc/ufw/before.rules" do
     notifies :restart, "service[ufw]", :delayed
 end
 
+node['bcpc']['monitoring']['cidrs'].each do |cidr|
+  node['bcpc']['monitoring']['agent_tcp_ports'].each do |port|
+    bash "setup-allow-rules-ufw-#{cidr}-#{port}" do
+      user 'root'
+        code <<-EOH
+          ufw allow from #{cidr} to #{node['bcpc']['bootstrap']['server']} \
+          port #{port} proto tcp
+        EOH
+    end
+  end
+end
+
 bash "setup-allow-rules-ufw" do
     user "root"
     code <<-EOH
@@ -49,7 +61,6 @@ bash "setup-allow-rules-ufw" do
         ufw allow 4040/tcp
         ufw allow in on #{node['bcpc']['bootstrap']['pxe_interface']} from any port 68 to any port 67 proto udp
         ufw allow in on #{node['bcpc']['bootstrap']['pxe_interface']} from any to #{node['bcpc']['bootstrap']['server']} port tftp
-        ufw allow 10050/tcp
         ufw --force enable
     EOH
 end

--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -62,8 +62,11 @@ iptables-restore <<EOH
 ## ssh 22
 ## nova-novncproxy 6080
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["ip"]%> -p tcp --match multiport --dports 22,6080 -j ACCEPT
-## Fallback rule in case node is monitored by out-of-cluster Zabbix
--A INPUT -i <%= @node["bcpc"]["management"]["interface"] %> -s <%= @node["bcpc"]["monitoring"]["vip"] %> -d <%= @node["bcpc"]["management"]["ip"] %> -p tcp --dport 10050 -j ACCEPT
+## Fallback rules in case node is monitored by out-of-cluster monitoring
+# services
+<% node['bcpc']['monitoring']['cidrs'].each do |cidr| -%>
+-A INPUT -i <%= @node['bcpc']['management']['interface'] %> -s <%= cidr %> -d <%= @node['bcpc']['management']['ip'] %> -p tcp -m multiport --dports <%= @node['bcpc']['monitoring']['agent_tcp_ports'].join(',') %> -j ACCEPT
+<% end -%>
 
 # Allow external access to some VIP services
 ## apache 80, 443

--- a/cookbooks/bcpc/templates/default/diamond.conf.erb
+++ b/cookbooks/bcpc/templates/default/diamond.conf.erb
@@ -13,7 +13,7 @@
 [server]
 
 # Handlers for published metrics.
-handlers = diamond.handler.graphitepickle.GraphitePickleHandler
+handlers = <%= node['bcpc']['diamond']['handlers'].keys.sort.join(',') %>
 
 # User diamond will run as
 # Leave empty to use the current user
@@ -48,82 +48,16 @@ keys = rotated_file
 ### Defaults options for all Handlers
 [[default]]
 
-[[ArchiveHandler]]
-
-# File to write archive log files
-log_file = /var/log/diamond/archive.log
-
-# Number of days to keep archive log files
-days = 7
-
-[[GraphiteHandler]]
-### Options for GraphiteHandler
-
-# Graphite server host
-host = <%=node['bcpc']['monitoring']['vip']%>
-
-# Port to send metrics to
-port = 2013
-
-# Socket timeout (seconds)
-timeout = 15
-
-# Batch size for metrics
-batch = 512
-
-[[GraphitePickleHandler]]
-### Options for GraphitePickleHandler
-
-# Graphite server host
-host = <%=node['bcpc']['monitoring']['vip']%>
-
-# Port to send metrics to
-port = 2014
-
-# Socket timeout (seconds)
-timeout = 15
-
-# Batch size for pickled metrics
-batch = 512
-
-[[MySQLHandler]]
-### Options for MySQLHandler
-
-# MySQL Connection Info
-hostname    = 127.0.0.1
-port        = 3306
-username    = root
-password    =
-database    = diamond
-table       = metrics
-# INT UNSIGNED NOT NULL
-col_time    = timestamp
-# VARCHAR(255) NOT NULL
-col_metric  = metric
-# VARCHAR(255) NOT NULL
-col_value   = value
-
-[[StatsdHandler]]
-host = 127.0.0.1
-port = 8125
-
-[[TSDBHandler]]
-host = 127.0.0.1
-port = 4242
-timeout = 15
-
-[[LibratoHandler]]
-user = user@example.com
-apikey = abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01
-
-
-[[HttpPostHandler]]
-
-### Urp to post the metrics
-url = http://localhost:8888/
-### Metrics batch size
-batch = 100
-
+<% @handlers.sort.each do |handler, params| -%>
+[[<%= handler.split('.').last %>]]
+<% params.sort.each do |param, value| -%>
+<% if param == 'host' and value.empty? %>
+host = <%= node['bcpc']['management']['ip'] %>
+<% else %>
+<%= param %> = <%= value %>
+<% end %>
+<% end %>
+<% end %>
 
 ################################################################################
 ### Options for collectors


### PR DESCRIPTION
Parameterize some more configuration to support pull-based monitoring solution and additional Diamond handlers. The following can be inserted into the environment for testing. When cheffed, expect `ufw` and `iptables` to include the additional CIDRs/port and dual-written Diamond metrics (if you have a Graphite listener on port `:9109`).

```
      "diamond": {
        "handlers": {
          "diamond.handler.graphite.GraphiteHandler": {
            "host": "10.0.100.11",
            "port": "9109",
            "batch": "512",
            "timeout": "15"
          }
        }
      },
      "monitoring": {
        "vip": "10.0.100.6",
        "cidrs": [
          "1.1.1.0/24",
          "2.2.2.0/27"
        ],
        "agent_tcp_ports": ["10050", "9109"]
      },
```