### PR TITLE
Switch slow query logging off during database backups

### DIFF
--- a/cookbooks/bcpc/recipes/mysql-backup.rb
+++ b/cookbooks/bcpc/recipes/mysql-backup.rb
@@ -28,3 +28,16 @@ ruby_block "initial-mysql-backup-config" do
       %x[MYSQL_PWD=#{get_config('mysql-root-password')} mysql -N --batch -uroot -e 'SELECT count(user) from mysql.user where user=\"#{get_config('mysql-backup-user')}\";'].to_i < 1
     }
 end
+
+# needed to disable/enable slow query logging
+ruby_block "give-mysql-backup-user-super-privileges" do
+    block do
+        %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+            mysql -u root -e "GRANT SUPER ON *.* TO '#{get_config('mysql-backup-user')}'@'%' IDENTIFIED BY '#{get_config('mysql-backup-password')}';"
+            mysql -u root -e "FLUSH PRIVILEGES;"
+        ]
+    end
+    only_if {
+      %x[MYSQL_PWD=#{get_config('mysql-root-password')} mysql -N --batch -uroot -e 'SELECT count(user) from mysql.user where user=\"#{get_config('mysql-backup-user')}\" AND super_priv = "Y";'].to_i < 1
+    }
+end

--- a/cookbooks/bcpc/templates/default/bcpc_backup.sh.erb
+++ b/cookbooks/bcpc/templates/default/bcpc_backup.sh.erb
@@ -95,6 +95,8 @@ if [ $? -ne 0 ]; then
   log "WARNING: unable to obtain information for main cluster databases."
 fi
 
+log "Disabling slow query logging for main databases."
+$MYSQL --defaults-file=$HOME/.my.main.cnf --batch -e 'SET GLOBAL slow_query_log = OFF'
 MAIN_DATABASES=( $MAIN_DATABASES_RAW )
 for DATABASE in ${MAIN_DATABASES[@]}; do
   DB_BACKUP_PATH=$MAIN_DB_BACKUP_PATH/$DATABASE.sql.gz
@@ -102,9 +104,14 @@ for DATABASE in ${MAIN_DATABASES[@]}; do
     $MYSQLDUMP --defaults-file=$HOME/.my.main.cnf --single-transaction --events $DATABASE | gzip > $DB_BACKUP_PATH
     log "Backed up database $DATABASE to $DB_BACKUP_PATH."
   else
+    # make sure we don't leave slow query logging off if the backup script bails out early
+    log "Error caught, re-enabling slow query logging for main databases."
+    $MYSQL --defaults-file=$HOME/.my.main.cnf --batch -e 'SET GLOBAL slow_query_log = ON'
     error "File $DB_BACKUP_PATH already exists, refusing to overwrite."
   fi
 done
+log "Re-enabling slow query logging for main databases."
+$MYSQL --defaults-file=$HOME/.my.main.cnf --batch -e 'SET GLOBAL slow_query_log = ON'
 
 <% if @monitoring_servers.length > 0 %>
 # if we have monitoring servers to back up, do the same thing for them as well
@@ -113,6 +120,8 @@ if [ $? -ne 0 ]; then
   log "WARNING: unable to obtain information for monitoring cluster databases."
 fi
 
+log "Disabling slow query logging for monitoring databases."
+$MYSQL --defaults-file=$HOME/.my.monitoring.cnf --batch -e 'SET GLOBAL slow_query_log = OFF'
 MONITORING_DATABASES=( $MONITORING_DATABASES_RAW )
 for DATABASE in ${MONITORING_DATABASES[@]}; do
   DB_BACKUP_PATH=$MONITORING_DB_BACKUP_PATH/$DATABASE.sql.gz
@@ -120,9 +129,14 @@ for DATABASE in ${MONITORING_DATABASES[@]}; do
     $MYSQLDUMP --defaults-file=$HOME/.my.monitoring.cnf --single-transaction --events $DATABASE | gzip > $DB_BACKUP_PATH
     log "Backed up database $DATABASE to $DB_BACKUP_PATH."
   else
+    # make sure we don't leave slow query logging off if the backup script bails out early
+    log "Error caught, re-enabling slow query logging for monitoring databases."
+    $MYSQL --defaults-file=$HOME/.my.monitoring.cnf --batch -e 'SET GLOBAL slow_query_log = ON'
     error "File $DB_BACKUP_PATH already exists, refusing to overwrite."
   fi
 done
+log "Re-enabling slow query logging for monitoring databases."
+$MYSQL --defaults-file=$HOME/.my.monitoring.cnf --batch -e 'SET GLOBAL slow_query_log = ON'
 <% end %>
 
 # back up Chef data bag


### PR DESCRIPTION
When applying this to an existing cluster, rechef at least one head node/monitoring node as well as the bootstrap node so that the privileges for the backup user will be updated (otherwise it will not be able to disable/enable slow query logging).