### PR TITLE
Terminate swap partition entry with a period

### DIFF
--- a/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host.preseed.erb
@@ -35,6 +35,7 @@ d-i     partman-auto/expert_recipe string root :: \
                 . \
                 8192 8192 8192 linux-swap \
                 $primary{ } method{ swap } format{ } \
+                .
 d-i     partman-auto/choose_recipe select root
 d-i     partman-partitioning/confirm_write_new_label boolean true
 d-i     partman/choose_partition select Finish partitioning and write changes to disk


### PR DESCRIPTION
When I rewrote the preseed partition table to add a biosgrub partition at the beginning, I failed to terminate the last entry with a period. This means it is not processed by the partitioner, and so the preseed complains that no partitions have been selected for swap. Adding the period fixes this problem.