### PR TITLE
Install/upgrade xtrabackup before MySQL

### DIFF
--- a/cookbooks/bcpc/recipes/packages-mysql.rb
+++ b/cookbooks/bcpc/recipes/packages-mysql.rb
@@ -26,6 +26,11 @@ apt_repository "percona" do
     key "percona-release.key"
 end
 
-package "percona-xtradb-cluster-56" do
+# ensure percona-xtrabackup is updated before MySQL as Percona
+# sometimes introduces hard requirements on new minimum
+# xtrabackup versions without reflecting that in package deps
+%w(percona-xtrabackup percona-xtradb-cluster-56).each do |pkg|
+  package pkg do
     action :upgrade
+  end
 end


### PR DESCRIPTION
This change fixes a situation that can be encountered during MySQL
upgrade when Percona requires a new minimum version of xtrabackup (for
Galera synchronization). This specifically fixes situations that put
errors like the following in the MySQL error log on MySQL start:
```
WSREP_SST: [ERROR] FATAL: The innobackupex version is 2.3.3. Needs
xtrabackup-2.3.5 or higher to perform SST (20161028 14:44:28.220)
```