### PR TITLE
Add core and disk filters

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -357,6 +357,7 @@ default['bcpc']['nova']['scheduler_default_filters'] = %w(
   AvailabilityZoneFilter
   CoreFilter
   RamFilter
+  DiskFilter
   ComputeFilter
   ComputeCapabilitiesFilter
   NUMATopologyFilter

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -351,7 +351,19 @@ default['bcpc']['nova']['debug'] = false
 # Nova default log levels
 default['bcpc']['nova']['default_log_levels'] = nil
 # Nova scheduler default filters
-default['bcpc']['nova']['scheduler_default_filters'] = ['AggregateInstanceExtraSpecsFilter', 'RetryFilter', 'AvailabilityZoneFilter', 'RamFilter', 'ComputeFilter', 'ComputeCapabilitiesFilter', 'NUMATopologyFilter', 'ImagePropertiesFilter', 'ServerGroupAntiAffinityFilter', 'ServerGroupAffinityFilter']
+default['bcpc']['nova']['scheduler_default_filters'] = %w(
+  AggregateInstanceExtraSpecsFilter
+  RetryFilter
+  AvailabilityZoneFilter
+  CoreFilter
+  RamFilter
+  ComputeFilter
+  ComputeCapabilitiesFilter
+  NUMATopologyFilter
+  ImagePropertiesFilter
+  ServerGroupAntiAffinityFilter
+  ServerGroupAffinityFilter
+)
 
 # configure optional Nova notification system
 default['bcpc']['nova']['notifications']['enabled'] = false


### PR DESCRIPTION
CoreFilter and DiskFilter were unintentionally left out of the default filter list. We should honor these filters so that failures to provision instances due to CPU overcommit or disk exhaustion are caught by the scheduler instead of during instance creation.