### PR TITLE
Add ability to specify readahead value for all disks

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -476,6 +476,8 @@ default['bcpc']['system']['additional_reserved_ports'] = []
 default['bcpc']['system']['parameters']['kernel.pid_max'] = 4194303
 # Connection tracking table max size
 default['bcpc']['system']['parameters']['net.nf_conntrack_max'] = 262144
+# readhead value for all disks in the system, in kb
+default['bcpc']['system']['readahead_kb'] = 512
 
 ###########################################
 #

--- a/cookbooks/bcpc/recipes/system.rb
+++ b/cookbooks/bcpc/recipes/system.rb
@@ -76,6 +76,13 @@ execute "reload-sysctl" do
     command "sysctl -p /etc/sysctl.d/70-bcpc.conf"
 end
 
+template "/etc/udev/rules.d/99-readahead.rules" do
+    source "readahead-udev.rules.erb"
+    owner "root"
+    group "root"
+    mode 00644
+end
+
 ruby_block "set-nf_conntrack-hashsize" do
     block do
         %x[ echo $((#{node['bcpc']['system']['parameters']['net.nf_conntrack_max']}/8)) > /sys/module/nf_conntrack/parameters/hashsize ]

--- a/cookbooks/bcpc/templates/default/readahead-udev.rules.erb
+++ b/cookbooks/bcpc/templates/default/readahead-udev.rules.erb
@@ -1,0 +1,1 @@
+SUBSYSTEM=="block", ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{bdi/read_ahead_kb}="<%=node['bcpc']['system']['readahead_kb']%>"


### PR DESCRIPTION
`cat /sys/class/block/sd*/bdi/read_ahead_kb` should show 512 (or whatever you specify in attributes)