### PR TITLE
Break TPM and hardware RNG into separate recipes

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -75,8 +75,10 @@ default['bcpc']['enabled']['always_update_package_lists'] = true
 default['bcpc']['enabled']['keepalived_checks'] = true
 # This will enable the networking test scripts
 default['bcpc']['enabled']['network_tests'] = true
-# This will enable using TPM-based hwrngd
+# This will enable TPM features
 default['bcpc']['enabled']['tpm'] = false
+# This will enable using a hardware RNG
+default['bcpc']['enabled']['hwrng'] = false
 # This will block VMs from talking to the management network
 default['bcpc']['enabled']['secure_fixed_networks'] = true
 # Toggle to enable/disable swap memory
@@ -447,6 +449,8 @@ default['bcpc']['system']['parameters']['kernel.pid_max'] = 4194303
 default['bcpc']['system']['parameters']['net.nf_conntrack_max'] = 262144
 # readhead value for all disks in the system, in kb
 default['bcpc']['system']['readahead_kb'] = 512
+# set to HWRNG source or leave as nil for rng-tools autodetect
+default['bcpc']['system']['hwrng_source'] = nil
 
 ###########################################
 #

--- a/cookbooks/bcpc/recipes/hwrng.rb
+++ b/cookbooks/bcpc/recipes/hwrng.rb
@@ -1,0 +1,55 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: hwrng
+#
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+return unless node['bcpc']['enabled']['hwrng']
+
+bash "ensure-tpm_rng-module-is-loaded" do
+  code <<-EOH
+    modprobe tpm_rng
+  EOH
+  not_if "lsmod | grep -q tpm_rng"
+end
+
+bash "ensure-tpm_rng-module-loads-on-boot" do
+  code <<-EOH
+    echo 'tpm_rng' >> /etc/modules
+  EOH
+  not_if "grep -q tpm_rng /etc/modules"
+end
+
+# note that changes to this template do not take effect until reboot
+# if rngd is already running
+template "/etc/default/rng-tools" do
+  source 'rng-tools.erb'
+  user   'root'
+  group  'root'
+  mode   '00644'
+  variables(
+    rng_source: node['bcpc']['system']['hwrng_source']
+  )
+end
+
+package "rng-tools" do
+  action :upgrade
+end
+
+service "rng-tools" do
+  action [:enable, :start]
+  subscribes :restart, "template[/etc/default/rng-tools]", :delayed
+end

--- a/cookbooks/bcpc/recipes/tpm.rb
+++ b/cookbooks/bcpc/recipes/tpm.rb
@@ -16,54 +16,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-if node['bcpc']['enabled']['tpm'] then
-  include_recipe "bcpc::default"
-  
-  package "linux-image-extra-#{node['kernel']['release']}"
-  
-  bash "ensure-tpm_rng-module-is-loaded" do
-    code <<-EOH
-      modprobe tpm_rng
-    EOH
-    not_if "lsmod | grep -q tpm_rng"
-  end
-  
-  bash "ensure-tpm_rng-module-loads-on-boot" do
-    code <<-EOH
-      echo 'tpm_rng' >> /etc/modules
-    EOH
-    not_if "grep -q tpm_rng /etc/modules"
-  end
 
-  # this is the sort of thing that you wish didn't have to exist, but it does,
-  # because trousers has a broken postinst script
-  bash "work-around-broken-trousers-postinst" do
-    code <<-EOH
-      cd /tmp && apt-get download trousers
-      if [[ $? != 0 ]]; then exit 1; fi
-      TROUSERS_PKG=$(find . -maxdepth 1 -name trousers\*deb)
-      dpkg --unpack $TROUSERS_PKG
-      sed -i 's/pidof udevd/pidof systemd-udevd/g' /var/lib/dpkg/info/trousers.postinst
-      dpkg --configure trousers
-    EOH
-    only_if "dpkg -l trousers 2>&1 | grep -q 'no packages found'"
-  end
-  package "rng-tools"
-  package "tpm-tools"
+return unless node['bcpc']['enabled']['tpm']
 
-  service "rng-tools" do
-    action :stop
-  end
+include_recipe "bcpc::default"
 
-  template "/etc/default/rng-tools" do
-    source "rng-tools.erb"
-    user "root"
-    group "root"
-    mode 0644
-  end
+package "linux-image-extra-#{node['kernel']['release']}"
 
-  service "rng-tools" do
-    action :start
-  end
-
+# this is the sort of thing that you wish didn't have to exist, but it does,
+# because trousers has a broken postinst script
+bash "work-around-broken-trousers-postinst" do
+  code <<-EOH
+    cd /tmp && apt-get download trousers
+    if [[ $? != 0 ]]; then exit 1; fi
+    TROUSERS_PKG=$(find . -maxdepth 1 -name trousers\*deb)
+    dpkg --unpack $TROUSERS_PKG
+    sed -i 's/pidof udevd/pidof systemd-udevd/g' /var/lib/dpkg/info/trousers.postinst
+    dpkg --configure trousers
+  EOH
+  only_if "dpkg -l trousers 2>&1 | grep -q 'no packages found'"
 end
+
+package "tpm-tools"

--- a/cookbooks/bcpc/templates/default/rng-tools.erb
+++ b/cookbooks/bcpc/templates/default/rng-tools.erb
@@ -6,8 +6,11 @@
 # Set to the input source for random data, leave undefined
 # for the initscript to attempt auto-detection.  Set to /dev/null
 # for the viapadlock and tpm drivers.
-#HRNGDEVICE=/dev/hwrng
-HRNGDEVICE=/dev/null
+<% if @rng_source.nil? %>
+#HRNGDEVICE=/dev/null
+<% else %>
+HRNGDEVICE=<%= @rng_source %>
+<% end %>
 
 # Additional options to send to rngd. See the rngd(8) manpage for
 # more information.  Do not specify -r/--rng-device here, use

--- a/roles/Basic.json
+++ b/roles/Basic.json
@@ -11,6 +11,7 @@
       "recipe[bcpc::developer]",
       "recipe[bcpc::cpupower]",
       "recipe[bcpc::getty]",
+      "recipe[bcpc::hwrng]",
       "recipe[ntp]",
       "recipe[chef-client::delete_validation]",
       "recipe[chef-client::config]"


### PR DESCRIPTION
This changeset breaks the TPM and hardware RNG into separate recipes so that we can at least get hardware RNG going for improved entropy on platforms that provide TPM 2.0 but are still on Trusty (`tpm2-tools` is not provided until Xenial and we are not there yet).

**Note for testing**: neither the TPM nor hardware RNG stuff can be tested on a virtualized setup. Actually verifying the behavior will require hardware with a physical TPM.