### PR TITLE
Slightly decrease enthusiasm for scourging PHP from every node

### DIFF
--- a/cookbooks/bcpc/recipes/apache2.rb
+++ b/cookbooks/bcpc/recipes/apache2.rb
@@ -32,9 +32,14 @@ end
     end
 end
 
-# Exclude php packages
+# Remove PHP packages from non-monitoring nodes
 package 'php5-common' do
   action :purge
+  not_if do
+    search_nodes('role', 'BCPC-Alerting').include?(node) ||
+    search_nodes('role', 'BCPC-Logging').include?(node) ||
+    search_nodes('role', 'BCPC-Metrics').include?(node)
+  end
 end
 
 %w{python}.each do |mod|


### PR DESCRIPTION
#1169 was extremely excited to remove PHP; so excited, in fact, that it also removed it from monitoring nodes (which would then reinstall it 2 steps down in the Zabbix server recipe). This calms things down slightly.