### PR TITLE
Tech preview for UEFI booting

### DIFF
--- a/bootstrap/ansible_scripts/scripts/spawn_local_vms.sh
+++ b/bootstrap/ansible_scripts/scripts/spawn_local_vms.sh
@@ -171,6 +171,12 @@ function get_node_ip {
     echo '10.0.100.12'
   elif [[ $1 == "ansible-bcpc-vm3" ]]; then
     echo '10.0.100.13'
+  elif [[ $1 == "ansible-bcpc-vm4" ]]; then
+    echo '10.0.100.14'
+  elif [[ $1 == "ansible-bcpc-vm5" ]]; then
+    echo '10.0.100.15'
+  elif [[ $1 == "ansible-bcpc-vm6" ]]; then
+    echo '10.0.100.16'
   else
     echo '169.254.1.1'
   fi
@@ -191,10 +197,13 @@ for VM in ansible-bcpc-bootstrap $VMS; do
   MAC_ADDRESS=$(VBoxManage showvminfo --machinereadable $VM | pcregrep -o1 -M '^hostonlyadapter\d="vboxnet0"$\n*^macaddress\d="(.+)"' | $SED 's/^(..)(..)(..)(..)(..)(..)$/\1:\2:\3:\4:\5:\6/')
   cat << EoF
   $VM:
+    cobbler_profile: bcpc_host
     domain: bcpc.example.com
     hardware_type: Virtual
     ip_address: $(get_node_ip $VM)
     ipmi_address:
+    ipmi_password: none
+    ipmi_username: none
     mac_address: $MAC_ADDRESS
     role: $(get_node_role $VM)
 EoF

--- a/bootstrap/ansible_scripts/software_deployment/tasks-prepare-deployed.yml
+++ b/bootstrap/ansible_scripts/software_deployment/tasks-prepare-deployed.yml
@@ -103,6 +103,9 @@
     DEBIAN_FRONTEND: noninteractive
     FILECACHE_MOUNT_POINT: "{{ bootstrap_files_dir }}/{{ chef_bcpc_version }}"
 
+- name: Fix permissions on {{ bootstrap_files_dir }}
+  file: path={{ bootstrap_files_dir }} owner=operations group=operators recurse=yes
+
 - name: Fix permissions on {{ bootstrap_deployed_dir }}
   file: path={{ bootstrap_deployed_dir }} owner=operations group=operators recurse=yes
 

--- a/bootstrap/shared/shared_build_bins.sh
+++ b/bootstrap/shared/shared_build_bins.sh
@@ -61,6 +61,12 @@ if [ ! -f ubuntu-14.04-mini.iso ]; then
 fi
 FILES="ubuntu-14.04-mini.iso $FILES"
 
+# Fetch grubnetx64.efi
+if [ ! -f grubnetx64.efi ]; then
+  cp -v $FILECACHE_MOUNT_POINT/grubnetx64.efi grubnetx64.efi
+fi
+FILES="grubnetx64.efi $FILES"
+
 # Test if diamond package version is <= 3.x, which implies a BrightCoveOS source
 if [ -f diamond.deb ]; then
     if [ `dpkg-deb -f diamond.deb Version | cut -b1` -le 3 ]; then

--- a/bootstrap/shared/shared_prereqs.sh
+++ b/bootstrap/shared/shared_prereqs.sh
@@ -96,6 +96,9 @@ fi
 # Obtain an Ubuntu netboot image to be used for PXE booting.
 download_file ubuntu-14.04-mini.iso http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/installer-amd64/current/images/netboot/mini.iso
 
+# Obtain the Xenial version of grubnetx64.efi (can be used with Trusty still)
+download_file grubnetx64.efi http://archive.ubuntu.com/ubuntu/dists/xenial/main/uefi/grub2-amd64/current/grubnetx64.efi
+
 # Obtain the VirtualBox guest additions ISO for use with Ansible.
 VBOX_VERSION=5.0.10
 VBOX_ADDITIONS=VBoxGuestAdditions_$VBOX_VERSION.iso

--- a/cookbooks/bcpc-binary-files/metadata.rb
+++ b/cookbooks/bcpc-binary-files/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "bcpc@bloomberg.net"
 license          "Apache License 2.0"
 description      'Binary files used by BCPC'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '6.0.0'
+version          '6.1.1'

--- a/cookbooks/bcpc/attributes/bootstrap.rb
+++ b/cookbooks/bcpc/attributes/bootstrap.rb
@@ -1,0 +1,30 @@
+
+###########################################
+#
+# defaults for the bcpc.bootstrap settings
+#
+###########################################
+#
+# A value of nil means to let the Ubuntu installer work it out - it
+# will try to find the nearest one. However the selected mirror is
+# often slow.
+default['bcpc']['bootstrap']['mirror'] = nil
+#
+# if you do specify a mirror, you can adjust the file path that comes
+# after the hostname in the URL here
+default['bcpc']['bootstrap']['mirror_path'] = "/ubuntu"
+#
+# worked example for the columbia mirror mentioned above which has a
+# non-standard path
+#default['bcpc']['bootstrap']['mirror']      = "mirror.cc.columbia.edu"
+#default['bcpc']['bootstrap']['mirror_path'] = "/pub/linux/ubuntu/archive"
+
+
+###########################################
+#
+#  Bootstrap tftpd settings
+#
+###########################################
+#
+# Address and port to listen
+default['bcpc']['tftpd']['address'] = ':69'

--- a/cookbooks/bcpc/attributes/bootstrap.rb
+++ b/cookbooks/bcpc/attributes/bootstrap.rb
@@ -1,4 +1,3 @@
-
 ###########################################
 #
 # defaults for the bcpc.bootstrap settings
@@ -18,6 +17,16 @@ default['bcpc']['bootstrap']['mirror_path'] = "/ubuntu"
 # non-standard path
 #default['bcpc']['bootstrap']['mirror']      = "mirror.cc.columbia.edu"
 #default['bcpc']['bootstrap']['mirror_path'] = "/pub/linux/ubuntu/archive"
+
+# Define the kernel to be installed by preseed. By default, track current HWE kernel
+default['bcpc']['bootstrap']['preseed_kernel'] = "linux-image-virtual-lts-xenial"
+
+# Device to install to for legacy BIOS installations
+default['bcpc']['bootstrap']['bios_boot_device'] = '/dev/sda'
+
+# Device to install to for UEFI installations
+default['bcpc']['bootstrap']['uefi_boot_device'] = '/dev/nvme0n1'
+
 
 
 ###########################################

--- a/cookbooks/bcpc/attributes/bootstrap.rb
+++ b/cookbooks/bcpc/attributes/bootstrap.rb
@@ -24,10 +24,11 @@ default['bcpc']['bootstrap']['preseed_kernel'] = "linux-image-virtual-lts-xenial
 # Device to install to for legacy BIOS installations
 default['bcpc']['bootstrap']['bios_boot_device'] = '/dev/sda'
 
+# Cobbler profile to use for UEFI
+default['bcpc']['bootstrap']['uefi_profile'] = 'bcpc_host_uefi'
+
 # Device to install to for UEFI installations
 default['bcpc']['bootstrap']['uefi_boot_device'] = '/dev/nvme0n1'
-
-
 
 ###########################################
 #

--- a/cookbooks/bcpc/attributes/cobbler.rb
+++ b/cookbooks/bcpc/attributes/cobbler.rb
@@ -9,6 +9,7 @@
 # 'cobbler.bcpc_ubuntu_host.preseed.erb', for example)
 default['bcpc']['cobbler']['kickstarts'] = %w(
   bcpc_ubuntu_host.preseed
+  bcpc_ubuntu_host_uefi.preseed
 )
 
 # hash of distributions in bcpc-binary-files to import into Cobbler
@@ -42,6 +43,10 @@ default['bcpc']['cobbler']['profiles'] = {
   'bcpc_host' => {
     'distro' => 'ubuntu-14.04-mini-x86_64',
     'kickstart' => 'bcpc_ubuntu_host.preseed',
+  },
+  'bcpc_host_uefi' => {
+    'distro' => 'ubuntu-14.04-mini-x86_64',
+    'kickstart' => 'bcpc_ubuntu_host_uefi.preseed'
   }
 }
 

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -12,8 +12,6 @@ default['bcpc']['openstack_release'] = "liberty"
 default['bcpc']['openstack_branch'] = "proposed"
 # Should be kvm (or qemu if testing in VMs that don't support VT-x)
 default['bcpc']['virt_type'] = "kvm"
-# Define the kernel to be installed. By default, track latest LTS kernel
-default['bcpc']['preseed']['kernel'] = "linux-image-generic-lts-trusty"
 # Define a specific kernel version to have GRUB default to (if non-nil)
 # - specify kernel like pattern "3.13.0-61-generic"
 # - a wrong pattern here will result in Chef convergence failure

--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -461,26 +461,6 @@ default['bcpc']['hardware']['powersave'] = false
 
 ###########################################
 #
-# defaults for the bcpc.bootstrap settings
-#
-###########################################
-#
-# A value of nil means to let the Ubuntu installer work it out - it
-# will try to find the nearest one. However the selected mirror is
-# often slow.
-default['bcpc']['bootstrap']['mirror'] = nil
-#
-# if you do specify a mirror, you can adjust the file path that comes
-# after the hostname in the URL here
-default['bcpc']['bootstrap']['mirror_path'] = "/ubuntu"
-#
-# worked example for the columbia mirror mentioned above which has a
-# non-standard path
-#default['bcpc']['bootstrap']['mirror']      = "mirror.cc.columbia.edu"
-#default['bcpc']['bootstrap']['mirror_path'] = "/pub/linux/ubuntu/archive"
-
-###########################################
-#
 # Rally settings
 #
 ###########################################
@@ -683,12 +663,3 @@ default['bcpc']['getty']['ttys'] = %w( ttyS0 ttyS1 )
 # VNC uses cluster domain name by default
 # for proxy base url. Set to 'true' to use vip
 default['bcpc']['vnc']['proxy_use_vip'] = false
-
-###########################################
-#
-#  Bootstrap tftpd settings
-#
-###########################################
-#
-# Address and port to listen
-default['bcpc']['tftpd']['address'] = ':69'

--- a/cookbooks/bcpc/metadata.rb
+++ b/cookbooks/bcpc/metadata.rb
@@ -13,4 +13,4 @@ depends "cron", ">= 1.2.2"
 depends "ntp", ">= 1.3.2"
 depends "hostsfile", ">= 2.4.5"
 depends "concat", ">= 0.3.0"
-depends 'bcpc-binary-files', '>= 6.0.0'
+depends 'bcpc-binary-files', '>= 6.1.1'

--- a/cookbooks/bcpc/recipes/cobbler.rb
+++ b/cookbooks/bcpc/recipes/cobbler.rb
@@ -58,6 +58,13 @@ template "/etc/cobbler/dhcp.template" do
     notifies :run, "bash[run-cobbler-sync]", :immediately
 end
 
+cookbook_file '/var/lib/tftpboot/grubnetx64.efi' do
+  source   'grubnetx64.efi'
+  cookbook 'bcpc-binary-files'
+  owner    'root'
+  mode     '00444'
+end
+
 node['bcpc']['cobbler']['kickstarts'].each do |kickstart|
   template "/var/lib/cobbler/kickstarts/#{kickstart}" do
     source "cobbler.#{kickstart}.erb"

--- a/cookbooks/bcpc/recipes/cobbler.rb
+++ b/cookbooks/bcpc/recipes/cobbler.rb
@@ -158,6 +158,7 @@ end
 
 service "cobbler" do
     action [:enable, :start]
+    restart_command "service cobbler restart; sleep 5"
 end
 
 bash "run-cobbler-sync" do

--- a/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host_uefi.preseed.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.bcpc_ubuntu_host_uefi.preseed.erb
@@ -20,22 +20,17 @@ d-i     netcfg/get_gateway      string
 d-i     netcfg/confirm_static   boolean true
 
 d-i     partman/early_command string \
-udevadm trigger; udevadm settle --timeout=30 \
-for d in $(ls /dev/sd[a-z]); do \
-dd if=/dev/zero of=$d bs=4M count=16 || echo "Write to $d failed" \
-done
-d-i     partman-auto/disk string <%= @node['bcpc']['bootstrap']['bios_boot_device'] %>
+        udevadm trigger; udevadm settle --timeout=30 \
+        for d in \$(ls /dev/sd[a-z]) \$(ls /dev/nvme*n*); do \
+            dd if=/dev/zero of=\$d bs=4M count=16 || echo "Write to \$d failed" \
+        done
+d-i     partman-auto/disk string <%= @node['bcpc']['bootstrap']['uefi_boot_device'] %>
 d-i     partman-auto/method string regular
 d-i     partman-auto/expert_recipe string root :: \
-                1 1 1 free method{ biosgrub } . \
-                5000 100000 10000000000 ext4 \
-                $primary{ } $bootable{ } method{ format } \
-                format{ } use_filesystem{ } filesystem{ ext4 } \
-                mountpoint{ / } \
-                . \
-                8192 8192 8192 linux-swap \
-                $primary{ } method{ swap } format{ } \
-                .
+        1 1 1 free \$gptonly{ } \$primary{ } \$lvmignore{ } \$bios_boot{ } method{ biosgrub } . \
+        512 2 512 fat32 \$gptonly{ } \$primary{ } \$lvmignore{ } method{ efi } format{ } . \
+        8192 3 8192 linux-swap \$gptonly{ } \$primary{ } method{ swap } format{ } . \
+        40000 4 100000000000000 ext4 \$gptonly{ } \$primary{ } method{ format } format{ } use_filesystem{ } filesystem{ ext4 } mountpoint{ / } .
 d-i     partman-auto/choose_recipe select root
 d-i     partman-partitioning/confirm_write_new_label boolean true
 d-i     partman/choose_partition select Finish partitioning and write changes to disk
@@ -104,4 +99,4 @@ d-i     preseed/late_command string true && \
         in-target chmod 0755 /root/get-ssh-keys ; in-target install -d -m0600 /root/.ssh ;\
         in-target env no_proxy=$http_server /root/get-ssh-keys root -o /root/.ssh/authorized_keys ;\
         echo -e "\n<%=@bootstrap_node['bcpc']['bootstrap'] && @bootstrap_node['bcpc']['bootstrap']['server']%>\t<%=@bootstrap_node['fqdn']%>\n" >> /target/etc/hosts ;\
-        wget "http://$http_server:$http_port/cblr/svc/op/nopxe/system/$system_name" -O /dev/null ;
+        wget "http://$http_server:$http_port/cblr/svc/op/nopxe/system/\$(hostname)" -O /dev/null ;

--- a/cookbooks/bcpc/templates/default/cobbler.create_grub_cfg.sh.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.create_grub_cfg.sh.erb
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# write out grub/grub.cfg for EFI GRUB to find
+
+GRUB_CFG="set timeout=2
+
+menuentry \"Install Ubuntu Trusty\" {
+    linux /images/<%= @profile_distro %>/linux ksdevice=bootif locale=en_US text interface=auto auto-install/enable=true priority=critical url=http://<%= @bootstrap_node %>/cblr/svc/op/ks/profile/<%= @profile %>
+    initrd /images/<%= @profile_distro %>/initrd.gz
+}"
+
+echo "$GRUB_CFG" > /var/lib/tftpboot/grub/grub.cfg

--- a/cookbooks/bcpc/templates/default/cobbler.create_grub_cfg.sh.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.create_grub_cfg.sh.erb
@@ -4,8 +4,8 @@
 
 GRUB_CFG="set timeout=2
 
-menuentry \"Install Ubuntu Trusty\" {
-    linux /images/<%= @profile_distro %>/linux ksdevice=bootif locale=en_US text interface=auto auto-install/enable=true priority=critical url=http://<%= @bootstrap_node %>/cblr/svc/op/ks/profile/<%= @profile %>
+menuentry \"Install <%= @profile_distro %>\" {
+    linux /images/<%= @profile_distro %>/linux ksdevice=bootif locale=en_US text interface=auto auto-install/enable=true priority=critical url=http://<%= @bootstrap_node['bcpc']['bootstrap']['server'] %>/cblr/svc/op/ks/profile/<%= @profile %>
     initrd /images/<%= @profile_distro %>/initrd.gz
 }"
 

--- a/cookbooks/bcpc/templates/default/cobbler.dhcp.template.erb
+++ b/cookbooks/bcpc/templates/default/cobbler.dhcp.template.erb
@@ -21,17 +21,26 @@ allow bootp;
 
 ignore client-updates;
 set vendorclass = option vendor-class-identifier;
+option pxe-system-type code 93 = unsigned integer 16;
+set pxetype = option pxe-system-type;
 
 subnet <%= @subnet %> netmask <%=node['bcpc']['management']['netmask']%> {
-     option routers             <%=node['bcpc']['management']['gateway']%>;
-     option domain-name-servers <%=@node['bcpc']['dns_servers'].join(', ') %>;
-     option subnet-mask         <%=node['bcpc']['management']['netmask']%>;
-     range dynamic-bootp        <%= @range %>;
-     filename                   "/pxelinux.0";
-     default-lease-time         21600;
-     max-lease-time             43200;
-     next-server                $next_server;
-     deny                       unknown-clients;
+    option routers             <%=node['bcpc']['management']['gateway']%>;
+    option domain-name-servers <%=@node['bcpc']['dns_servers'].join(', ') %>;
+    option subnet-mask         <%=node['bcpc']['management']['netmask']%>;
+    range dynamic-bootp        <%= @range %>;
+    default-lease-time         21600;
+    max-lease-time             43200;
+    next-server                $next_server;
+    deny                       unknown-clients;
+    class "pxeclients" {
+        match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+        if option pxe-system-type = 00:07 {
+            filename "/grubnetx64.efi";
+        } else {
+            filename "/pxelinux.0";
+        }
+    }
 }
 
 #for dhcp_tag in $dhcp_tags.keys():
@@ -57,7 +66,6 @@ group {
         #if $iface.gateway:
         option routers $iface.gateway;
         #end if
-        filename "$iface.filename";
         ## Cobbler defaults to $next_server, but some users
         ## may like to use $iface.system.server for proxied setups
         next-server $next_server;


### PR DESCRIPTION
This revisits UEFI bootstrapping by adding the Cobbler components needed to successfully boot UEFI systems. With this in place, an appropriately configured system can be bootstrapped via UEFI by changing its profile from **bcpc_host** to **bcpc_host_uefi**. This PR does *not* include anything for enabling UEFI PXE boot on VirtualBox; we will be borrowing something from our sister project at http://github.com/bloomberg/chef-bach to do that in the future.

This should be considered a tech preview, but it should not impact any existing legacy BIOS booting (unless you were using a legacy BIOS bootloader not named `/pxelinux.0`; this has been hardcoded into the DHCP server configuration).