### PR TITLE
Parameterize Graphite replication factor

### DIFF
--- a/cookbooks/bcpc/attributes/monitoring.rb
+++ b/cookbooks/bcpc/attributes/monitoring.rb
@@ -59,6 +59,8 @@ default['bcpc']['graphite']['use_whitelist'] = {
   'whitelist' => [],
   'blacklist' => []
 }
+# Number of copies of metrics to store. The default (1) implies no redundancy.
+default['bcpc']['graphite']['replication_factor'] = 1
 
 ###########################################
 #

--- a/cookbooks/bcpc/recipes/graphite.rb
+++ b/cookbooks/bcpc/recipes/graphite.rb
@@ -78,7 +78,7 @@ if node['bcpc']['enabled']['metrics']
     mode 00644
     variables(
       :servers => search_nodes('recipe', 'graphite'),
-      :min_quorum => search_nodes('recipe', 'graphite').length / 2 + 1
+      :replication_factor => node['bcpc']['graphite']['replication_factor']
     )
     notifies :restart, 'service[carbon-cache]', :delayed
     notifies :restart, 'service[carbon-relay]', :delayed

--- a/cookbooks/bcpc/templates/default/carbon.conf.erb
+++ b/cookbooks/bcpc/templates/default/carbon.conf.erb
@@ -184,7 +184,7 @@ RELAY_METHOD = consistent-hashing
 # If you use consistent-hashing you may want to add redundancy
 # of your data by replicating every datapoint to more than
 # one machine.
-REPLICATION_FACTOR = <%= @min_quorum %>
+REPLICATION_FACTOR = <%= @replication_factor %>
 
 # This is a list of carbon daemons we will send any relayed or
 # generated metrics to. The default provided would send to a single


### PR DESCRIPTION
This parameterizes relay's `REPLICATION_FACTOR` in `/opt/graphite/conf/carbon.conf`. If the value is set to the number of monitoring machines, ingested metrics will be replicated to all machines.