### PR TITLE
Move zabbix-agent after host-aggregates

### DIFF
--- a/roles/BCPC-Compute.json
+++ b/roles/BCPC-Compute.json
@@ -17,8 +17,8 @@
       "recipe[bcpc::fluentd]",
       "recipe[bcpc::tpm]",
       "recipe[bcpc::checks-work]",
-      "recipe[bcpc::zabbix-agent]",
-      "recipe[bcpc::host-aggregates]"
+      "recipe[bcpc::host-aggregates]",
+      "recipe[bcpc::zabbix-agent]"
     ],
     "description": "Run list for a general compute function. Building block, not designed as an applied role.",
     "chef_type": "role"


### PR DESCRIPTION
Zabbix agent installation appears to trigger an Apache restart,
which causes Keystone to restart and results in 503s from HAProxy.
Swapping the two recipes in the run list resolves this issue.