### PR TITLE
Add lock/unlock to hypervisor restart

### DIFF
--- a/bootstrap/ansible_scripts/hardware_management/restart-target-nodes.yml
+++ b/bootstrap/ansible_scripts/hardware_management/restart-target-nodes.yml
@@ -120,6 +120,14 @@
       tags:
         - stopstart
 
+    - name: Lock stopped instances on the server
+      shell: ". /root/adminrc && nova lock {{ item }} && sleep 2"
+      with_items: "{{ running_instances }}"
+      when: item != ""
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - stopstart
+
     - name: Reboot hypervisor
       command: /sbin/reboot
       async: false
@@ -136,6 +144,14 @@
     - name: Rechef node
       command: chef-client
       when: chef_after_reboot_internal
+
+    - name: Unlock stopped instances on the server
+      shell: ". /root/adminrc && nova unlock {{ item }} && sleep 2"
+      with_items: "{{ running_instances }}"
+      when: item != ""
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - stopstart
 
     - name: nova start instances on hypervisor
       shell: ". /root/adminrc && nova start {{ item }} && sleep 15"


### PR DESCRIPTION
Add lock / unlock to hypervisor restart process to prevent automated tools from sending commands to instances that are offline