### PR TITLE
Restart Apache as reloads raise errors

### DIFF
--- a/cookbooks/bcpc/recipes/horizon.rb
+++ b/cookbooks/bcpc/recipes/horizon.rb
@@ -160,7 +160,7 @@ bcpc_patch 'horizon-openrc-api-versions' do
   patch_root_dir       '/usr/share/openstack-dashboard'
   shasums_before_apply 'horizon-openrc-api-versions-BEFORE.SHASUMS'
   shasums_after_apply  'horizon-openrc-api-versions-AFTER.SHASUMS'
-  notifies :reload, 'service[apache2]', :immediately
+  notifies :restart, 'service[apache2]', :immediately
 end
 
 # fix upstream bug 1593751 - broken LDAP groups in Horizon
@@ -169,7 +169,7 @@ bcpc_patch 'horizon-ldap-groups' do
   patch_root_dir       '/usr/share/openstack-dashboard'
   shasums_before_apply 'horizon-ldap-groups-BEFORE.SHASUMS'
   shasums_after_apply  'horizon-ldap-groups-AFTER.SHASUMS'
-  notifies :reload, 'service[apache2]', :delayed
+  notifies :restart, 'service[apache2]', :delayed
 end
 
 # update openrc.sh template to provide additional environment variables and user domain

--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -313,14 +313,14 @@ template "/etc/apache2/sites-available/wsgi-keystone.conf" do
     :processes => node['bcpc']['keystone']['wsgi']['processes'],
     :threads   => node['bcpc']['keystone']['wsgi']['threads']
   )
-  notifies :reload, "service[apache2]", :immediately
+  notifies :restart, "service[apache2]", :immediately
 end
 
 bash "a2ensite-enable-wsgi-keystone" do
   user     "root"
   code     "a2ensite wsgi-keystone"
   not_if   "test -r /etc/apache2/sites-enabled/wsgi-keystone.conf"
-  notifies :reload, "service[apache2]", :immediately
+  notifies :restart, "service[apache2]", :immediately
 end
 
 ruby_block "keystone-database-creation" do


### PR DESCRIPTION
Reloading of Apache sometimes result in Keystone outage of approximately 5 minutes on a local build, leading to host aggregate configuration failures (depends on Keystone). It appears that this is a known issue with Keystone/Apache per https://bugs.launchpad.net/fuel/+bug/1493353. If this PR does not sufficiently work around the issue, we may have to consider other measures mentioned in the bug report.