### PR TITLE
Add playbooks to do independent stops and starts of hypervisors

### DIFF
--- a/bootstrap/ansible_scripts/hardware_management/start-target-nodes.yml
+++ b/bootstrap/ansible_scripts/hardware_management/start-target-nodes.yml
@@ -1,0 +1,206 @@
+# USAGE:
+#
+# - target: specify the nodes to be rebooted via a hosts pattern
+#   (start with ~, e.g. "~blah" for a regex pattern)
+#
+# - control_headnode: specify the head node to use to execute the
+#   Ceph/nova management commands (strictly speaking it does not have
+#   to be a head node, but it must have admin access to Ceph
+#   and have /root/adminrc present with admin credentials)
+#
+# - ipmi_power_on (default true): attempt to power on the node via IPMI
+#   if not already powered on (set to false if the node cannot be controlled
+#   via IPMI)
+#
+# - serial (default 1): specify the number of nodes to work on at once
+#   WARNING: for serial higher than 1 it is strongly recommended to also
+#   specify -c paramiko to avoid Ansible tripping over itself and closing
+#   the SSH shared connection for the delegation, which will require all
+#   sorts of obnoxious cleanup
+#   WARNING: note that when waiting for nova-network with serial > 1,
+#   the sleep time will be the value calculated for the first node
+#   alphabetically in the batch of nodes being worked on (so it may be
+#   insufficiently long for the rest of the nodes in the batch to get
+#   all their networks set up again)
+#
+# - chef_after_startup (default true): rechef nodes after startup (the
+#   default, in order to ensure MD devices are configured and kernel tools
+#   packages are installed after kernel upgrades)
+---
+- include: ../common_playbooks/validate_environment.yml
+
+- hosts: bootstraps
+  gather_facts: no
+  vars_prompt:
+    - name: "start_confirm"
+      prompt: "Please type YES to confirm you want to start nodes"
+      default: "no"
+      private: no
+  tasks:
+    - fail: msg="Acknowledgement not received, exiting"
+      when: start_confirm != "YES"
+      tags:
+        - always
+
+    - set_fact: control_headnode={{ groups['headnodes'][0] }}
+      when: control_headnode is not defined
+      tags:
+        - always
+
+- hosts: "{{ target }}"
+  become: yes
+  gather_facts: no
+  serial: "{{ serial|default(1) }}"
+  tasks:
+    - set_fact: control_headnode={{ groups['headnodes'][0] }}
+      when: control_headnode is not defined
+      tags:
+        - always
+
+    - name: Run Chef after startup?
+      set_fact: chef_after_startup_internal="{{ chef_after_startup | default(True) }}"
+      tags:
+        - chef
+
+    - name: Get hosts in general compute aggregate
+      shell: ". /root/adminrc && nova aggregate-details general_compute"
+      register: general_compute_agg
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - start
+
+    - name: Get hosts in ephemeral compute aggregate
+      shell: ". /root/adminrc && nova aggregate-details ephemeral_compute"
+      register: ephemeral_compute_agg
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - start
+
+    # attempt to power on the hypervisor via IPMI
+    - name: Get power state of hypervisor
+      command: ipmitool -H {{ ipmi_address }} -I lanplus -U {{ ipmi_username }} -P {{ ipmi_password }} chassis power status
+      delegate_to: "{{ groups['bootstraps'][0] }}"
+      when:
+        - hardware_type != "Virtual"
+        - ipmi_power_on|default(True)
+      register: power_state
+      tags:
+        - ipmi
+
+    - name: Power hypervisor on
+      command: ipmitool -H {{ ipmi_address }} -I lanplus -U {{ ipmi_username }} -P {{ ipmi_password }} chassis power on
+      delegate_to: "{{ groups['bootstraps'][0] }}"
+      when:
+        - hardware_type != "Virtual"
+        - power_state.stdout.find("is off")
+        - ipmi_power_on|default(True)
+      tags:
+        - ipmi
+
+    - name: Wait for hypervisor to come back online
+      become: no
+      local_action: wait_for host={{ ansible_ssh_host }} port=22 state=started timeout=1800
+      tags:
+        - ipmi
+        - start
+
+    - name: Locate instance list on disk
+      stat: path=/usr/local/etc/hv_maint/instance_list.json
+      register: instance_list_stat
+      tags:
+        - start
+
+    - name: Load instance list from disk
+      command: cat /usr/local/etc/hv_maint/instance_list.json
+      register: instance_list_raw
+      when: instance_list_stat.stat.exists
+      tags:
+        - start
+
+    - name: Parse instance list into fact
+      set_fact: running_instances={{ instance_list_raw.stdout|from_json }}
+      when:
+        - instance_list_raw is defined
+        - instance_list_stat.stat.exists
+      tags:
+        - start
+
+    - name: Set blank instance list if none is found on disk
+      set_fact: running_instances=[]
+      when: not instance_list_stat.stat.exists
+      tags:
+        - start
+
+    - name: Wait to allow Nova Networking to recreate tenant networks
+      pause: seconds="{{ ((running_instances | length) * 20)+1 }}"
+      tags:
+        - start
+
+    - name: Rechef node
+      command: chef-client
+      when: chef_after_startup_internal
+      tags:
+        - chef
+
+    - name: Unlock stopped instances on the server
+      shell: ". /root/adminrc && nova unlock {{ item }} && sleep 2"
+      with_items: "{{ running_instances }}"
+      when: item != ""
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - start
+
+    - name: nova start instances on hypervisor
+      shell: ". /root/adminrc && nova start {{ item }} && sleep 15"
+      with_items: "{{ running_instances }}"
+      delegate_to: "{{ control_headnode }}"
+      when: "{{ restart_instances | default(True) }} and item != ''"
+      ignore_errors: true
+      tags:
+        - start
+
+    - name: Add node back to general compute aggregate
+      shell: ". /root/adminrc && nova aggregate-add-host general_compute {{ inventory_hostname }}"
+      when: (general_compute_agg.stdout | search("{{ inventory_hostname }}")) and (not chef_after_reboot_internal)
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - start
+
+    - name: Add node back to ephemeral compute aggregate
+      shell: ". /root/adminrc && nova aggregate-add-host ephemeral_compute {{ inventory_hostname }}"
+      when: (ephemeral_compute_agg.stdout | search("{{ inventory_hostname }}")) and (not chef_after_reboot_internal)
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - start
+
+    - name: Restart OpenStack services
+      command: /usr/local/bin/hup_openstack
+      tags:
+        - start
+
+    - name: Wait 30 seconds for OpenStack services to settle
+      command: sleep 30
+      tags:
+        - start
+
+    - name: Archive saved instance list
+      shell: "mv /usr/local/etc/hv_maint/instance_list.json /usr/local/etc/hv_maint/instance_list.json.$(date +%s)"
+      when: instance_list_stat.stat.exists
+      tags:
+        - start
+
+- hosts: bootstraps
+  become: yes
+  gather_facts: no
+  serial: 1
+  tasks:
+    - set_fact: control_headnode={{ groups['headnodes'][0] }}
+      when: control_headnode is not defined
+      tags:
+        - always
+
+    - name: Unset noout
+      command: ceph osd unset noout
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - always

--- a/bootstrap/ansible_scripts/hardware_management/stop-target-nodes.yml
+++ b/bootstrap/ansible_scripts/hardware_management/stop-target-nodes.yml
@@ -1,0 +1,142 @@
+# USAGE:
+#
+# - target: specify the nodes to be stopped via a hosts pattern
+#   (start with ~, e.g. "~blah" for a regex pattern)
+#
+# - control_headnode: specify the head node to use to execute the
+#   Ceph/nova management commands (strictly speaking it does not have
+#   to be a head node, but it must have admin access to Ceph
+#   and have /root/adminrc present with admin credentials)
+#
+# - serial (default 1): specify the number of nodes to work on at once
+#   WARNING: for serial higher than 1 it is strongly recommended to also
+#   specify -c paramiko to avoid Ansible tripping over itself and closing
+#   the SSH shared connection for the delegation, which will require all
+#   sorts of obnoxious cleanup
+---
+- include: ../common_playbooks/validate_environment.yml
+
+- hosts: bootstraps
+  gather_facts: no
+  vars_prompt:
+    - name: "shutdown_confirm"
+      prompt: "Please type YES to confirm you want to shut down nodes"
+      default: "no"
+      private: no
+  tasks:
+    - fail: msg="Acknowledgement not received, exiting"
+      when: shutdown_confirm != "YES"
+      tags:
+        - always
+
+    - set_fact: control_headnode={{ groups['headnodes'][0] }}
+      when: control_headnode is not defined
+      tags:
+        - always
+
+    - name: Set noout
+      command: ceph osd set noout
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - always
+
+- hosts: "{{ target }}"
+  become: yes
+  gather_facts: no
+  serial: "{{ serial|default(1) }}"
+  tasks:
+    - set_fact: control_headnode={{ groups['headnodes'][0] }}
+      when: control_headnode is not defined
+      tags:
+        - always
+
+    - name: Get running instances on hypervisor
+      command: virsh list --state-running --uuid
+      register: running_instances_raw
+      tags:
+        - stop
+
+    - name: Render instance list into fact
+      set_fact: running_instances="{{ running_instances_raw.stdout.split('\n') }}"
+      tags:
+        - stop
+
+    - name: Create non-temporary location on disk to record the instance list
+      file: path=/usr/local/etc/hv_maint state=directory
+      tags:
+        - stop
+
+    - name: Write the instance list to disk
+      copy: dest=/usr/local/etc/hv_maint/instance_list.json content="{{ running_instances|to_json|safe }}"
+      when: (running_instances|length > 0) and (running_instances[0] != "")
+      tags:
+        - stop
+
+    - name: Get hosts in general compute aggregate
+      shell: ". /root/adminrc && nova aggregate-details general_compute"
+      register: general_compute_agg
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - stop
+
+    - name: Get hosts in ephemeral compute aggregate
+      shell: ". /root/adminrc && nova aggregate-details ephemeral_compute"
+      register: ephemeral_compute_agg
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - stop
+
+    - name: Remove node from general compute aggregate
+      shell: ". /root/adminrc && nova aggregate-remove-host general_compute {{ inventory_hostname }}"
+      when: general_compute_agg.stdout | search("{{ inventory_hostname }}")
+      register: general_compute_agg_remove
+      failed_when: general_compute_agg_remove.rc != 0 and "404" not in general_compute_agg_remove.stderr
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - stop
+
+    - name: Remove node from ephemeral compute aggregate
+      shell: ". /root/adminrc && nova aggregate-remove-host ephemeral_compute {{ inventory_hostname }}"
+      when: ephemeral_compute_agg.stdout | search("{{ inventory_hostname }}")
+      register: ephemeral_compute_agg_remove
+      failed_when: ephemeral_compute_agg_remove.rc != 0 and "404" not in ephemeral_compute_agg_remove.stderr
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - stop
+
+    - name: nova stop running instances on hypervisor
+      shell: ". /root/adminrc && nova stop {{ item }} && sleep 2"
+      with_items: "{{ running_instances }}"
+      when: item != ""
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - stop
+
+    - name: Verify instances are stopped
+      shell: ". /root/adminrc && nova show {{ item }} | grep vm_state | grep -q -v active"
+      register: instance_stopped
+      until: instance_stopped.rc == 0
+      ignore_errors: true
+      retries: 20
+      delay: 3
+      with_items: "{{ running_instances }}"
+      when: item != ""
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - stop
+
+    - name: Lock stopped instances on the server
+      shell: ". /root/adminrc && nova lock {{ item }} && sleep 2"
+      with_items: "{{ running_instances }}"
+      when: item != ""
+      delegate_to: "{{ control_headnode }}"
+      tags:
+        - stop
+
+    - name: Shut down hypervisor
+      command: /sbin/poweroff
+      async: false
+      poll: false
+      ignore_errors: true
+      tags:
+        - poweroff


### PR DESCRIPTION
This adds stop and start playbooks (basically refactors of the restart
playbook) that can be run to bring down a hypervisor and then to start
it back up and restart the instances that were running on it. The use
case here is to allow HVs to be powered off for firmware updates while
still knowing what instances should be relaunched on them when they are
powered back up.