### PR TITLE
Fixes various minor issues in restart playboooks

### DIFF
--- a/bootstrap/ansible_scripts/hardware_management/restart-target-nodes.yml
+++ b/bootstrap/ansible_scripts/hardware_management/restart-target-nodes.yml
@@ -40,10 +40,20 @@
 
     - set_fact: control_headnode={{ groups['headnodes'][0] }}
       when: control_headnode is not defined
+      tags:
+        - always
+
+    - set_fact: manage_noout=True
+      when: manage_noout is not defined
+      tags:
+        - always
 
     - name: Set noout
       command: ceph osd set noout
       delegate_to: "{{ control_headnode }}"
+      when: manage_noout
+      tags:
+        - always
 
 - hosts: "{{ target }}"
   become: yes
@@ -52,6 +62,8 @@
   tasks:
     - set_fact: control_headnode={{ groups['headnodes'][0] }}
       when: control_headnode is not defined
+      tags:
+        - always
 
     - name: Get running instances on hypervisor
       command: virsh list --state-running --uuid
@@ -133,17 +145,25 @@
       async: false
       poll: false
       ignore_errors: true
+      tags:
+        - reboot
 
     - name: Wait for hypervisor to come back online
       become: no
       local_action: wait_for host={{ ansible_ssh_host }} port=22 state=started timeout=1800
+      tags:
+        - reboot
 
     - name: Wait to allow Nova Networking to recreate tenant networks
       pause: seconds="{{ ((running_instances | length) * 20)+1 }}"
+      tags:
+        - reboot
 
     - name: Rechef node
       command: chef-client
       when: chef_after_reboot_internal
+      tags:
+        - reboot
 
     - name: Unlock stopped instances on the server
       shell: ". /root/adminrc && nova unlock {{ item }} && sleep 2"
@@ -176,16 +196,15 @@
       tags:
         - stopstart
 
-- hosts: "{{ target }}"
-  become: yes
-  gather_facts: no
-  serial: "{{ serial|default(1) }}"
-  tasks:
     - name: Restart OpenStack services
       command: /usr/local/bin/hup_openstack
+      tags:
+        - always
 
     - name: Wait 30 seconds for OpenStack services to settle
       command: sleep 30
+      tags:
+        - always
 
 - hosts: bootstraps
   become: yes
@@ -194,8 +213,17 @@
   tasks:
     - set_fact: control_headnode={{ groups['headnodes'][0] }}
       when: control_headnode is not defined
+      tags:
+        - always
+
+    - set_fact: manage_noout=True
+      when: manage_noout is not defined
+      tags:
+        - always
 
     - name: Unset noout
       command: ceph osd unset noout
       delegate_to: "{{ control_headnode }}"
-
+      when: manage_noout
+      tags:
+        - always

--- a/bootstrap/ansible_scripts/hardware_management/start-target-nodes.yml
+++ b/bootstrap/ansible_scripts/hardware_management/start-target-nodes.yml
@@ -199,8 +199,14 @@
       tags:
         - always
 
+    - set_fact: manage_noout=True
+      when: manage_noout is not defined
+      tags:
+        - always
+
     - name: Unset noout
       command: ceph osd unset noout
       delegate_to: "{{ control_headnode }}"
+      when: manage_noout
       tags:
         - always

--- a/bootstrap/ansible_scripts/hardware_management/stop-target-nodes.yml
+++ b/bootstrap/ansible_scripts/hardware_management/stop-target-nodes.yml
@@ -34,9 +34,15 @@
       tags:
         - always
 
+    - set_fact: manage_noout=True
+      when: manage_noout is not defined
+      tags:
+        - always
+
     - name: Set noout
       command: ceph osd set noout
       delegate_to: "{{ control_headnode }}"
+      when: manage_noout
       tags:
         - always
 


### PR DESCRIPTION
- Allows disabling the playbook management of Ceph noout
- Moves OpenStack service restart to happen after each node is ready,
  rather than all at once at the end
- Adds tags in places where there were none