### PR TITLE
Ignore errors on nova lock/unlock

### DIFF
--- a/bootstrap/ansible_scripts/hardware_management/restart-target-nodes.yml
+++ b/bootstrap/ansible_scripts/hardware_management/restart-target-nodes.yml
@@ -137,6 +137,7 @@
       with_items: "{{ running_instances }}"
       when: item != ""
       delegate_to: "{{ control_headnode }}"
+      ignore_errors: true
       tags:
         - stopstart
 
@@ -170,6 +171,7 @@
       with_items: "{{ running_instances }}"
       when: item != ""
       delegate_to: "{{ control_headnode }}"
+      ignore_errors: true
       tags:
         - stopstart
 


### PR DESCRIPTION
Ignore errors on lock/unlock caused by automations tools which sometimes delete instances before the command is run