### PR TITLE
Detect headnode VIP jump

### DIFF
--- a/cookbooks/bcpc/files/default/zabbix_bcpc_template.xml
+++ b/cookbooks/bcpc/files/default/zabbix_bcpc_template.xml
@@ -4545,5 +4545,15 @@
             <type>0</type>
             <dependencies/>
         </trigger>
+        <trigger>
+            <expression>{BCPC-Headnode:net.vip_holder.diff()}&gt;0</expression>
+            <name>VIP jump detected</name>
+            <url/>
+            <status>0</status>
+            <priority>3</priority>
+            <description>VIP jump on head node detected</description>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
     </triggers>
 </zabbix_export>


### PR DESCRIPTION
We want to be notified of such events for further investigation and possible interventions, such as cleanly restarting PowerDNS when it is wedged during the transition.