### PR TITLE
Hardcode certain service ports into the firewall configuration

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -127,10 +127,11 @@ default['bcpc']['management']['interface'] = nil
 # if 'interface' is a VLAN interface, specifying a parent allows MTUs
 # to be set properly
 default['bcpc']['management']['interface-parent'] = nil
-# list of TCP ports that should be open on the management interface
+# list of extra TCP ports that should be open on the management interface
 # (generally stuff served via HAProxy)
+# some ports are hardcoded - see bcpc-firewall.erb template
 default['bcpc']['management']['firewall_tcp_ports'] = [
-  80,443,8088,7480,5000,35357,9292,8776,8773,8774,8004,8000,6080
+  8088,7480,35357,8004,8000
 ]
 
 default['bcpc']['metadata']['ip'] = "169.254.169.254"

--- a/cookbooks/bcpc/templates/default/bcpc-firewall.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-firewall.erb
@@ -70,14 +70,16 @@ iptables-restore <<EOH
 
 # Allow external access to some VIP services
 ## apache 80, 443
-## keystone 5000 35357
+## keystone 5000
 ## vnc console 6080
 ## glance 9292
 ## cinder 8776
 ## nova-api-ec2 8773
 ## nova-api 8774
-## heat-api 8004
-## heat-api-cfn 8000
+-A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --match multiport --dports 80,443,5000,6080,8773,8774,8776,9292 -j ACCEPT
+
+# Additional ports enabled here
+## keystone 35357
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p tcp --match multiport --dports <%= @node['bcpc']['management']['firewall_tcp_ports'].join(',') %> -j ACCEPT
 ## powerdns 53
 -A INPUT -i <%=@node["bcpc"]["management"]["interface"]%> -d <%=@node["bcpc"]["management"]["vip"]%> -p udp --dport 53 -j ACCEPT


### PR DESCRIPTION
iptables supports a maximum of 15 ports in a multiport specification.
In order to reduce the length of the list, certain ports are now
hardcoded into another multiport statement for services that we know we
will always be running (Apache on HTTP/HTTPS, public Keystone, Nova,
Cinder, Glance).

Keystone admin port 35357 is not included in this list in case we want
to easily remove it later on without requiring code changes.