### PR TITLE
Flag to enable/disable authority for reverse zones

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -709,3 +709,16 @@ default['bcpc']['vnc']['proxy_use_vip'] = false
 #
 # Address and port to listen
 default['bcpc']['tftpd']['address'] = ':69'
+
+###########################################
+#
+#  PowerDNS settings
+#
+###########################################
+#
+# Authority for DNS zones
+default['bcpc']['pdns']['authority']['reverse'] = {
+  'management' => true,
+  'fixed'      => true,
+  'float'      => true
+}

--- a/cookbooks/bcpc/recipes/powerdns-nova.rb
+++ b/cookbooks/bcpc/recipes/powerdns-nova.rb
@@ -18,24 +18,24 @@
 #
 
 if node['bcpc']['enabled']['dns']
-  include_recipe "bcpc::nova-head"
+  include_recipe 'bcpc::nova-head'
 
   # this template replaces several old ruby_block resources and pre-seeds fixed entries into a template file to be loaded into MySQL
-  fixed_records_file = "/tmp/powerdns_generate_fixed_records.sql"
+  fixed_records_file = '/tmp/powerdns_generate_fixed_records.sql'
   template fixed_records_file do
-    source "powerdns_generate_fixed_records.sql.erb"
-    owner "root"
-    group "root"
+    source 'powerdns_generate_fixed_records.sql.erb'
+    owner 'root'
+    group 'root'
     mode 00644
     variables({
       :database_name      => node['bcpc']['dbname']['pdns'],
       :cluster_domain     => node['bcpc']['cluster_domain'],
-      :reverse_fixed_zone => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])),
+      :reverse_fixed_zone => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr']))
     })
     notifies :run, 'ruby_block[powerdns-load-fixed-records]', :immediately
   end
 
-  ruby_block "powerdns-load-fixed-records" do
+  ruby_block 'powerdns-load-fixed-records' do
     block do
       system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot #{node['bcpc']['dbname']['pdns']} < #{fixed_records_file}"
     end
@@ -43,24 +43,24 @@ if node['bcpc']['enabled']['dns']
   end
 
   # dns_fill.py handles creating CNAMEs based on instance and tenancy
-  template "/usr/local/etc/dns_fill.yml" do
-    source "pdns.dns_fill.yml.erb"
-    owner "pdns"
-    group "root"
+  template '/usr/local/etc/dns_fill.yml' do
+    source 'pdns.dns_fill.yml.erb'
+    owner 'pdns'
+    group 'root'
     mode 00640
   end
 
-  cookbook_file "/usr/local/bin/dns_fill.py" do
-    source "dns_fill.py"
-    mode "00755"
-    owner "pdns"
-    group "root"
+  cookbook_file '/usr/local/bin/dns_fill.py' do
+    source 'dns_fill.py'
+    mode '00755'
+    owner 'pdns'
+    group 'root'
   end
 
-  cron "run dns_fill" do
-    minute "*/5"
-    hour "*"
-    weekday "*"
-    command "/usr/local/bin/if_vip /usr/local/bin/dns_fill.py -c /usr/local/etc/dns_fill.yml run"
+  cron 'run dns_fill' do
+    minute '*/5'
+    hour '*'
+    weekday '*'
+    command '/usr/local/bin/if_vip /usr/local/bin/dns_fill.py -c /usr/local/etc/dns_fill.yml run'
   end
 end

--- a/cookbooks/bcpc/templates/default/powerdns_generate_fixed_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_fixed_records.sql.erb
@@ -2,6 +2,8 @@
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) SELECT
     (SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), 'A', address, 'STATIC' FROM nova.fixed_ips
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name=concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), type='A', content=address, bcpc_record_type='STATIC';
+<% if node['bcpc']['pdns']['authority']['reverse']['fixed'] %>
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) SELECT
     (SELECT id FROM domains WHERE name='<%=@reverse_fixed_zone%>'), ip4_to_ptr_name(address), 'PTR', concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), 'STATIC' FROM nova.fixed_ips
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@reverse_fixed_zone%>'), name=ip4_to_ptr_name(address), type='PTR', content=concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), bcpc_record_type='STATIC';
+<% end %>

--- a/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
@@ -8,8 +8,12 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
 -- so we must delete the old ones after these are inserted
 -- MySQL does not allow deleting from a table and selecting from that same table in a subquery, so ids of old SOA records are written to a temporary table, records are deleted,
 -- then the temporary table is cleaned up
+<% zones = [@cluster_domain] %>
+<% zones << @reverse_float_zone if node['bcpc']['pdns']['authority']['reverse']['float'] %>
+<% zones << @reverse_fixed_zone if node['bcpc']['pdns']['authority']['reverse']['fixed'] %>
+<% zones << @management_zone if node['bcpc']['pdns']['authority']['reverse']['management'] %>
 CREATE TEMPORARY TABLE soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%> (id int);
-<% [@cluster_domain, @reverse_float_zone, @reverse_fixed_zone, @management_zone].each do |zone| %>
+<% zones.each do |zone| %>
 
 -- delete malformed NS record where the content is the management VIP instead of cluster domain
 DELETE FROM <%= @database_name %>.records WHERE type='NS' and content='<%= @management_vip %>';
@@ -26,7 +30,7 @@ INSERT INTO soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%> S
 <% end %>
 DELETE FROM <%=@database_name%>.records WHERE id IN (SELECT id FROM soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%>);
 
--- insert A and PTR records for all BCPC physical hosts
+-- conditionally insert A and PTR records for all BCPC physical hosts
 <% @all_servers.each do |server| %>
 <% s_hostname = server['hostname'] %>
 <% s_management_ip = server['bcpc']['management']['ip'] %>
@@ -38,17 +42,20 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
     ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), '<%=s_hostname%>.<%=@cluster_domain%>', 'A', '<%=s_management_ip%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='<%=s_hostname%>.<%=@cluster_domain%>', type='A', content='<%=s_management_ip%>', bcpc_record_type='STATIC';
 
-INSERT INTO <%= @database_name %>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM domains WHERE name='<%= @management_zone %>'), '<%= s_management_reverse %>', 'PTR', '<%= s_hostname %>.<%= @cluster_domain %>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%= @management_zone %>'), name='<%= s_management_reverse %>', type='PTR', content='<%= s_hostname %>.<%= @cluster_domain %>', bcpc_record_type='STATIC';
-
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
     ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), '<%=s_hostname%>-shared.<%=@cluster_domain%>', 'A' , '<%=s_floating_ip%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='<%=s_hostname%>-shared.<%=@cluster_domain%>', type='A', content='<%=s_floating_ip%>', bcpc_record_type='STATIC';
 
 INSERT INTO <%= @database_name %>.records (domain_id, name, type, content, bcpc_record_type) VALUES
+    ((SELECT id FROM domains WHERE name='<%= @management_zone %>'), '<%= s_management_reverse %>', 'PTR', '<%= s_hostname %>.<%= @cluster_domain %>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%= @management_zone %>'), name='<%= s_management_reverse %>', type='PTR', content='<%= s_hostname %>.<%= @cluster_domain %>', bcpc_record_type='STATIC';
+
+<% if node['bcpc']['pdns']['authority']['reverse']['float'] %>
+INSERT INTO <%= @database_name %>.records (domain_id, name, type, content, bcpc_record_type) VALUES
     ((SELECT id FROM domains WHERE name='<%= @reverse_float_zone %>'), '<%= s_floating_reverse %>', 'PTR', '<%= s_hostname %>-shared.<%= @cluster_domain %>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%= @reverse_float_zone %>'), name='<%= s_floating_reverse %>', type='PTR', content='<%= s_hostname %>-shared.<%= @cluster_domain %>', bcpc_record_type='STATIC';
+<% end %>
+
 <% end %>
 
 -- insert A records for certain management/monitoring functions
@@ -79,9 +86,11 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
     ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), '<%=s_hostname%>', 'A', '<%=ip.to_s%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='<%=s_hostname%>', type='A', content='<%=ip.to_s%>', bcpc_record_type='STATIC';
+<% if node['bcpc']['pdns']['authority']['reverse']['float'] %>
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
     ((SELECT id FROM domains WHERE name='<%=@reverse_float_zone%>'), '<%=reverse_name%>', 'PTR', '<%=s_hostname%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@reverse_float_zone%>'), name='<%=reverse_name%>', type='PTR', content='<%=s_hostname%>', bcpc_record_type='STATIC';
+<% end %>
 <% end %>
 
 -- fixed IPs are inserted by another template (look at powerdns-nova recipe)


### PR DESCRIPTION
Reverse zones are fairly static and therefore, are good candidates to be hosted on an external DNS service to reduce chef-bcpc's infrastructure scope. Disabling them involves a environment file update per below:

```
    "bcpc": {
      "pdns": {
        "authority": {
          "reverse": {
            "management": false,
            "fixed": false,
            "float": false
          }
        }
      },
      ...
```
... and deleting the affected zones from `pdns.domains` and NS/SOA (optionally, PTR) from `pdns.records`.