### PR TITLE
Support classless float subnet

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -21,6 +21,7 @@ require 'openssl'
 require 'base64'
 require 'thread'
 require 'ipaddr'
+require 'ipaddress'
 
 # this method deals in strings even though API versions are numbers because
 # some API versions are integers and others are floats and it would be bad
@@ -292,28 +293,23 @@ def ceph_keygen()
     Base64.encode64(key).strip
 end
 
-# requires cidr in form '1.2.3.0/24', where 1.2.3.0 is a dotted quad ip4 address
-# and 24 is a number of netmask bits (e.g. 8, 16, 24)
+def calc_octets_to_drop(cidr)
+  cidr = IPAddress(cidr)
+  prefix = cidr.prefix.to_i
+  prefix = 24 if prefix != 8 && prefix != 16
+  4 - prefix / 8 # octets to drop
+end
+
+# Generates an array of classful reverse DNS zone(s) by dividing provided CIDR
+# (min /24) in the form of '1.2.3.0/24'.
 def calc_reverse_dns_zone(cidr)
-
-    # Validate and parse cidr as an IP
-    cidr_ip = IPAddr.new(cidr) # Will throw exception if cidr is bad.
-
-    # Pull out the netmask and throw an error if we can't find it.
-    netmask = cidr.split('/')[1].to_i
-    raise ("Couldn't find netmask portion of CIDR in #{cidr}.") unless netmask > 0  # nil.to_i == 0, "".to_i == 0  Should always be one of [8,16,24]
-
-    # Knock off leading quads in the reversed IP as specified by the netmask.  (24 ==> Remove one quad, 16 ==> remove two quads, etc)
-    # So for example: 192.168.100.0, we'd expect the following input/output:
-    # Netmask:   8  => 192.in-addr.arpa         (3 quads removed)
-    #           16  => 168.192.in-addr.arpa     (2 quads removed)
-    #           24  => 100.168.192.in-addr.arpa (1 quad removed)
-
-    reverse_ip = cidr_ip.reverse   # adds .in-addr.arpa automatically
-    (4 - (netmask.to_i/8)).times { reverse_ip = reverse_ip.split('.')[1..-1].join('.') } # drop off element 0 each time through
-
-    return reverse_ip
-
+  cidr = IPAddress(cidr)
+  prefix = cidr.prefix.to_i
+  prefix = 24 if prefix != 8 && prefix != 16
+  subnets = cidr.subnet(prefix) # array of /24 subnets
+  octets = 4 - prefix / 8 # octets to drop
+  subnets.map {
+    |x| x.reverse.to_s.split('.')[octets, x.reverse.length].join('.') }
 end
 
 # We do not have net/ping, so just call out to system and check err value.

--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -306,7 +306,7 @@ def calc_reverse_dns_zone(cidr)
   cidr = IPAddress(cidr)
   prefix = cidr.prefix.to_i
   prefix = 24 if prefix != 8 && prefix != 16
-  subnets = cidr.subnet(prefix) # array of /24 subnets
+  subnets = cidr.subnet(prefix)
   octets = 4 - prefix / 8 # octets to drop
   subnets.map {
     |x| x.reverse.to_s.split('.')[octets, x.reverse.length].join('.') }

--- a/cookbooks/bcpc/recipes/powerdns-nova.rb
+++ b/cookbooks/bcpc/recipes/powerdns-nova.rb
@@ -30,7 +30,7 @@ if node['bcpc']['enabled']['dns']
     variables({
       :database_name      => node['bcpc']['dbname']['pdns'],
       :cluster_domain     => node['bcpc']['cluster_domain'],
-      :reverse_fixed_zone => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])),
+      :reverse_fixed_zone => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr']).first)
     })
     notifies :run, 'ruby_block[powerdns-load-fixed-records]', :immediately
   end

--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -114,10 +114,11 @@ if node['bcpc']['enabled']['dns'] then
     }
   end
 
-  reverse_fixed_zone = node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])
+  reverse_fixed_zone = node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr']).first
   reverse_float_zone = node['bcpc']['floating']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])
-  management_zone = calc_reverse_dns_zone(node['bcpc']['management']['cidr'])
+  management_zone = calc_reverse_dns_zone(node['bcpc']['management']['cidr']).first
 
+  # Reverse fixed zone is assumed to be classful.
   ruby_block "powerdns-table-domains-reverse-fixed-zone" do
     block do
       %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
@@ -132,20 +133,24 @@ if node['bcpc']['enabled']['dns'] then
     }
   end
 
-  ruby_block "powerdns-table-domains-reverse-float-zone" do
-    block do
-      %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
-          mysql -uroot #{node['bcpc']['dbname']['pdns']} <<-EOH
-          INSERT INTO domains (name, type) values ('#{ reverse_float_zone }', 'NATIVE');
-      ]
-      self.notifies :restart, resources(:service => "pdns"), :delayed
-      self.resolve_notification_references
+  # Reverse float zones are always translated to /24 zone(s).
+  reverse_float_zone.each do |zone|
+    ruby_block "powerdns-table-domains-reverse-float-zone-#{zone}" do
+      block do
+        %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+            mysql -uroot #{node['bcpc']['dbname']['pdns']} <<-EOH
+            INSERT INTO domains (name, type) values ('#{zone}', 'NATIVE');
+        ]
+        self.notifies :restart, resources(:service => "pdns"), :delayed
+        self.resolve_notification_references
+      end
+      only_if {
+        %x[ MYSQL_PWD=#{get_config('mysql-root-password')} mysql -B --skip-column-names -uroot -e 'SELECT count(*) FROM pdns.domains WHERE name = \"#{zone}\"' ].to_i.zero?
+      }
     end
-    only_if {
-      %x[ MYSQL_PWD=#{get_config('mysql-root-password')} mysql -B --skip-column-names -uroot -e 'SELECT count(*) FROM pdns.domains WHERE name = \"#{ reverse_float_zone }\"' ].to_i.zero?
-    }
   end
 
+  # Reverse management zone is assumed to be classful.
   ruby_block "powerdns-table-domains-management-zone" do
     block do
       %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
@@ -178,6 +183,40 @@ if node['bcpc']['enabled']['dns'] then
       self.notifies :restart, resources(:service => "pdns"), :delayed
     end
     not_if { system "MYSQL_PWD=#{get_config('mysql-root-password')} mysql -uroot -e 'SELECT name FROM mysql.proc WHERE name = \"ip4_to_ptr_name\" AND db = \"#{node['bcpc']['dbname']['pdns']}\";' \"#{node['bcpc']['dbname']['pdns']}\" | grep -q \"ip4_to_ptr_name\" >/dev/null" }
+  end
+
+  # MySQL function to determine the /24 DNS zone a float PTR belongs to.
+  ruby_block 'powerdns-function-get_ptr_domain' do
+    block do
+      %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
+          mysql -uroot #{node['bcpc']['dbname']['pdns']} <<-EOH
+          delimiter //
+          CREATE FUNCTION get_ptr_domain(
+          ptr VARCHAR(64) CHARACTER SET latin1,
+          octets TINYINT(1))
+          RETURNS INT
+          COMMENT 'Returns the domain ID the PTR belongs to'
+          DETERMINISTIC
+          BEGIN
+            DECLARE domain_id INT(11);
+            SELECT id FROM pdns.domains
+            WHERE
+            name = (SELECT SUBSTRING_INDEX(
+                    SUBSTRING_INDEX(ptr, '.', 6), '.', -6+octets))
+                    INTO domain_id;
+            RETURN domain_id;
+          END//
+      ]
+      self.notifies :restart, resources(:service => 'pdns'), :delayed
+    end
+    not_if {
+      system "MYSQL_PWD=#{get_config('mysql-root-password')} \
+              mysql -uroot -e 'SELECT name FROM mysql.proc
+              WHERE name = \"get_ptr_domain\"
+              AND db = \"#{node['bcpc']['dbname']['pdns']}\";' \
+              \"#{node['bcpc']['dbname']['pdns']}\" \
+              | grep -q get_ptr_domain >/dev/null"
+    }
   end
 
   ruby_block "powerdns-function-dns-name" do
@@ -237,6 +276,11 @@ if node['bcpc']['enabled']['dns'] then
   # fixed IPs require the nova schema to be present in MySQL, so that has been moved to its own template and recipe
   float_records_file = "/tmp/powerdns_generate_float_records.sql"
 
+  # Determine the number of right-most octets to drop for addresses to help
+  # find the reverse DNS zone name one is part of.
+  mgmt_octets = calc_octets_to_drop(node['bcpc']['management']['cidr'])
+  float_octets = calc_octets_to_drop(node['bcpc']['floating']['cidr'])
+
   template float_records_file do
     source "powerdns_generate_float_records.sql.erb"
     owner "root"
@@ -251,9 +295,11 @@ if node['bcpc']['enabled']['dns'] then
       :floating_vip        => node['bcpc']['floating']['vip'],
       :management_vip      => node['bcpc']['management']['vip'],
       :monitoring_vip      => node['bcpc']['monitoring']['vip'],
-      :reverse_fixed_zone  => (node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr'])),
-      :reverse_float_zone  => (node['bcpc']['floating']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])),
-      :management_zone     => calc_reverse_dns_zone(node['bcpc']['management']['cidr'])
+      :reverse_fixed_zone  => reverse_fixed_zone,
+      :reverse_float_zone  => reverse_float_zone,
+      :management_zone     => management_zone,
+      :mgmt_octets         => mgmt_octets,
+      :float_octets        => float_octets
     })
     notifies :run, 'ruby_block[powerdns-load-float-records]', :immediately
   end

--- a/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
@@ -39,8 +39,8 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='<%=s_hostname%>.<%=@cluster_domain%>', type='A', content='<%=s_management_ip%>', bcpc_record_type='STATIC';
 
 INSERT INTO <%= @database_name %>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM domains WHERE name='<%= @management_zone %>'), '<%= s_management_reverse %>', 'PTR', '<%= s_hostname %>.<%= @cluster_domain %>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%= @management_zone %>'), name='<%= s_management_reverse %>', type='PTR', content='<%= s_hostname %>.<%= @cluster_domain %>', bcpc_record_type='STATIC';
+    (get_ptr_domain('<%= s_management_reverse %>', <%= @mgmt_octets %>), '<%= s_management_reverse %>', 'PTR', '<%= s_hostname %>.<%= @cluster_domain %>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=get_ptr_domain('<%= s_management_reverse %>', <%= @mgmt_octets %>), name='<%= s_management_reverse %>', type='PTR', content='<%= s_hostname %>.<%= @cluster_domain %>', bcpc_record_type='STATIC';
 
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
     ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), '<%=s_hostname%>-shared.<%=@cluster_domain%>', 'A' , '<%=s_floating_ip%>', 'STATIC')

--- a/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
@@ -9,7 +9,7 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
 -- MySQL does not allow deleting from a table and selecting from that same table in a subquery, so ids of old SOA records are written to a temporary table, records are deleted,
 -- then the temporary table is cleaned up
 CREATE TEMPORARY TABLE soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%> (id int);
-<% [@cluster_domain, @reverse_float_zone, @reverse_fixed_zone, @management_zone].each do |zone| %>
+<% [@cluster_domain, @reverse_float_zone, @reverse_fixed_zone, @management_zone].flatten.each do |zone| %>
 
 -- delete malformed NS record where the content is the management VIP instead of cluster domain
 DELETE FROM <%= @database_name %>.records WHERE type='NS' and content='<%= @management_vip %>';
@@ -47,8 +47,8 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='<%=s_hostname%>-shared.<%=@cluster_domain%>', type='A', content='<%=s_floating_ip%>', bcpc_record_type='STATIC';
 
 INSERT INTO <%= @database_name %>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM domains WHERE name='<%= @reverse_float_zone %>'), '<%= s_floating_reverse %>', 'PTR', '<%= s_hostname %>-shared.<%= @cluster_domain %>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%= @reverse_float_zone %>'), name='<%= s_floating_reverse %>', type='PTR', content='<%= s_hostname %>-shared.<%= @cluster_domain %>', bcpc_record_type='STATIC';
+    (get_ptr_domain('<%=s_floating_reverse%>', <%= @float_octets %>), '<%= s_floating_reverse %>', 'PTR', '<%= s_hostname %>-shared.<%= @cluster_domain %>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=get_ptr_domain('<%=s_floating_reverse%>', <%= @float_octets %>), name='<%= s_floating_reverse %>', type='PTR', content='<%= s_hostname %>-shared.<%= @cluster_domain %>', bcpc_record_type='STATIC';
 <% end %>
 
 -- insert A records for certain management/monitoring functions
@@ -80,8 +80,8 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
     ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), '<%=s_hostname%>', 'A', '<%=ip.to_s%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='<%=s_hostname%>', type='A', content='<%=ip.to_s%>', bcpc_record_type='STATIC';
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    ((SELECT id FROM domains WHERE name='<%=@reverse_float_zone%>'), '<%=reverse_name%>', 'PTR', '<%=s_hostname%>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@reverse_float_zone%>'), name='<%=reverse_name%>', type='PTR', content='<%=s_hostname%>', bcpc_record_type='STATIC';
+    (get_ptr_domain('<%=reverse_name%>', <%= @float_octets %>), '<%=reverse_name%>', 'PTR', '<%=s_hostname%>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=get_ptr_domain('<%=reverse_name%>', <%= @float_octets %>), name='<%=reverse_name%>', type='PTR', content='<%=s_hostname%>', bcpc_record_type='STATIC';
 <% end %>
 
 -- fixed IPs are inserted by another template (look at powerdns-nova recipe)


### PR DESCRIPTION
Current DNS zone configuration assumes float subnets are classful (/8, /16) and this could result in incorrect DNS resolution on VMs. This attempts to remediate the assumption by dividing classless float subnet into classful zones. For testing, float subnet can be reconfigured via the environment:

```
    "bcpc": {
      "floating": {
        ...
        "cidr" : "192.168.100.0/22",
        "available_subnet" : "192.168.100.128/23"
      },
```

After recheffing, expect to see following additional zones in `pdns.domains`.

```
101.168.192.in-addr.arpa
102.168.192.in-addr.arpa
103.168.192.in-addr.arpa
```

With a query like `SELECT d.name, r.name from records r, domains d WHERE d.id = r.domain_id AND r.type = 'PTR' AND r.content like 'public-%'"`, you should see the float PTRs associated with their respective reverse zones.
