### PR TITLE
Move "option nolinger" to only affect MySQL

### DIFF
--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -21,7 +21,6 @@ defaults
   option abortonclose
   option tcplog
   option dontlognull
-  option nolinger
   option redispatch
   retries 3
   timeout http-request 10s
@@ -40,6 +39,7 @@ listen mysql-galera
   option tcplog
   option tcpka
   option httpchk
+  option nolinger
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:3306 check port 3307 inter 5s rise 1 fall 1 observe layer4 backup" %>
 <% end -%>


### PR DESCRIPTION
"option nolinger" was originally added as part of a set of changes
for stabilizing MySQL access through HAProxy. However, the presence of
this option appears to be responsible for triggering TCP RSTs when
accessing the OpenStack APIs. "option nolinger" has been moved from the
defaults into the mysql-galera listener configuration, so that it will
continue to apply to MySQL while not impacting the OpenStack APIs.