### PR TITLE
Only filter on existing instances, not actively powered-on ones

### DIFF
--- a/cookbooks/bcpc/files/default/dns_fill.py
+++ b/cookbooks/bcpc/files/default/dns_fill.py
@@ -62,7 +62,7 @@ class dns_popper(object):
             "FROM nova.instances i "
             "JOIN nova.fixed_ips f ON i.uuid = f.instance_uuid "
             "JOIN nova.floating_ips n ON f.id = n.fixed_ip_id "
-            "WHERE i.vm_state = 'active' AND i.project_id IS NOT NULL")
+            "WHERE i.deleted = 0 AND i.project_id IS NOT NULL")
         servers = c.fetchall()
 
         rc = []


### PR DESCRIPTION
This query had a bad habit of deleting CNAMEs for instances that are powered off. Change the query to only delete CNAMEs when instances are actually terminated.