### PR TITLE
Explicitly define the order of AZ joins/departs if in maintenance

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -399,14 +399,6 @@ def openstack_json_to_hash(input)
   }
 end
 
-def join_aggregate_action
-  node['bcpc']['in_maintenance'] ? :depart : :member
-end
-
-def maintenance_action
-  node['bcpc']['in_maintenance'] ? :member : :depart
-end
-
 def generate_service_catalog_uri(svcprops, access_level)
   "#{node['bcpc']['protocol'][svcprops['project']]}://openstack.#{node['bcpc']['cluster_domain']}:#{svcprops['ports'][access_level]}/#{svcprops['uris'][access_level]}"
 end

--- a/cookbooks/bcpc/recipes/host-aggregates.rb
+++ b/cookbooks/bcpc/recipes/host-aggregates.rb
@@ -32,17 +32,32 @@ bcpc_host_aggregate availability_zone do
 end
 
 # join/leave compute aggregates and AZ depending on maintenance flag
-node['bcpc']['aggregate_membership'].each do |name|
-  bcpc_host_aggregate name do
-    action join_aggregate_action
+if node['bcpc']['in_maintenance']
+  node['bcpc']['aggregate_membership'].each do |name|
+    bcpc_host_aggregate name do
+      action :depart
+    end
   end
-end
 
-bcpc_host_aggregate availability_zone do
-  action join_aggregate_action
-end
+  bcpc_host_aggregate availability_zone do
+    action :depart
+  end
 
-# join/leave maintenance aggregate if maintenance flag is se
-bcpc_host_aggregate 'maintenance' do
-  action maintenance_action
+  bcpc_host_aggregate 'maintenance' do
+    action :member
+  end
+else
+  bcpc_host_aggregate 'maintenance' do
+    action :depart
+  end
+
+  bcpc_host_aggregate availability_zone do
+    action :member
+  end
+
+  node['bcpc']['aggregate_membership'].each do |name|
+    bcpc_host_aggregate name do
+      action :member
+    end
+  end
 end


### PR DESCRIPTION
I tried to be too cute with how entering/exiting maintenance would work.
In practice, it didn't actually work because OpenStack would still blow
up if you tried to put a node into two AZs at the same time. This gets
rid of that and explicitly defines the order in which AZs should be
joined and departed when entering and exiting maintenance.