### PR TITLE
General DB cleanup script

### DIFF
--- a/cookbooks/bcpc/files/default/db_cleanup.sh
+++ b/cookbooks/bcpc/files/default/db_cleanup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+function error {
+  echo "ERROR: $1" >&2
+  log "$1"
+  echo "Terminating abnormally." >&2
+  log "Terminating abnormally."
+  exit 1
+}
+
+function warn {
+  echo "WARNING: $1" >&2
+  log "$1"
+}
+
+function check_for_bin {
+  if ! which $1 >/dev/null; then
+    error "$1 not found on path."
+  fi
+}
+
+function log {
+  if ! [ -z $LOG_VERBOSE ]; then
+    echo "LOG: $1"
+  fi
+  logger -t BCPC_DB_Cleanup "$1"
+}
+
+MYSQL=mysql
+check_for_bin $MYSQL
+
+# .my.cnf is expected to exist in the following format:
+# [client]
+# host=xxx
+# user=xxx
+# password=xxx
+if [ ! -f $HOME/.my.cnf ]; then
+  error "$HOME/.my.cnf not found."
+fi
+
+log "Disabling slow query logging for main databases."
+$MYSQL --defaults-file=$HOME/.my.cnf --batch -e 'SET GLOBAL slow_query_log = OFF'
+
+TABLES_TO_CLEAN_UP=( nova.virtual_interfaces nova.instance_system_metadata nova.instance_info_caches nova.security_group_instance_association )
+
+for TABLE in ${TABLES_TO_CLEAN_UP[@]}; do
+  log "Cleaning up table ${TABLE}."
+  $MYSQL --defaults-file=$HOME/.my.cnf --batch -e "CREATE TABLE IF NOT EXISTS ${TABLE}_archive LIKE ${TABLE};
+    START TRANSACTION;
+    INSERT ${TABLE}_archive SELECT * FROM ${TABLE} WHERE deleted > 0 AND instance_uuid NOT IN (SELECT uuid FROM nova.instances WHERE deleted = 0);
+    DELETE FROM ${TABLE} WHERE id IN (SELECT id FROM ${TABLE}_archive);
+    COMMIT;"
+done
+
+log "Re-enabling slow query logging for main databases."
+$MYSQL --defaults-file=$HOME/.my.cnf --batch -e 'SET GLOBAL slow_query_log = ON'
+
+# ding!
+log "Database cleanup complete."

--- a/cookbooks/bcpc/files/default/vifs_cleanup.sh
+++ b/cookbooks/bcpc/files/default/vifs_cleanup.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# cleans up stale virtual interfaces from nova-network tables
-# (otherwise nova-network restarts can take a very long time)
-mysql -e "USE nova; CREATE TABLE IF NOT EXISTS virtual_interfaces_archive LIKE virtual_interfaces; START TRANSACTION; INSERT virtual_interfaces_archive SELECT * FROM virtual_interfaces WHERE deleted > 0 AND instance_uuid NOT IN (SELECT uuid FROM instances WHERE deleted = 0); DELETE FROM virtual_interfaces WHERE id IN (SELECT id FROM virtual_interfaces_archive); COMMIT;"

--- a/cookbooks/bcpc/recipes/mysql-head.rb
+++ b/cookbooks/bcpc/recipes/mysql-head.rb
@@ -118,20 +118,26 @@ template '/root/.my.cnf' do
   )
 end
 
-vifs_cleanup_script = '/usr/local/bin/vifs_cleanup.sh'
-cookbook_file vifs_cleanup_script do
-  source 'vifs_cleanup.sh'
+
+# vifs-cleanup cron job removed (replaced by db_cleanup below)
+cron 'vifs-cleanup-daily' do
+  action :delete
+end
+
+db_cleanup_script = '/usr/local/bin/db_cleanup.sh'
+cookbook_file db_cleanup_script do
+  source 'db_cleanup.sh'
   mode   '00755'
   owner  'root'
   group  'root'
 end
 
-cron 'vifs-cleanup-daily' do
+cron 'db-cleanup-daily' do
   home    '/root'
   user    'root'
   minute  '0'
   hour    '3'
-  command "/usr/local/bin/if_vip #{vifs_cleanup_script}"
+  command "/usr/local/bin/if_vip #{db_cleanup_script}"
 end
 
 template '/usr/local/bin/mysql_slow_query_check.sh' do

--- a/cookbooks/bcpc/templates/default/wsrep.cnf.erb
+++ b/cookbooks/bcpc/templates/default/wsrep.cnf.erb
@@ -124,10 +124,10 @@ wsrep_slave_threads=<%= @wsrep_slave_threads %>
 wsrep_certify_nonPK=1
 
 # Maximum number of rows in write set
-wsrep_max_ws_rows=131072
+# wsrep_max_ws_rows=0
 
 # Maximum size of write set
-wsrep_max_ws_size=1073741824
+# wsrep_max_ws_size=2147483648
 
 # to enable debug level logging, set this to 1
 wsrep_debug=0


### PR DESCRIPTION
This supersedes vifs_cleanup.sh to provide a more general way of cleaning up tables that fill up with soft deletes over time.

The changes to wsrep_max_ws_* are to ensure that the cleanups can always run, because the tables in question can grow to millions of rows over time.

Special callout for nova.instance_system_metadata: there is a bug in early versions of Kilo that caused rows in this table to not be marked as deleted when the instance was deleted. To backfill the deleted flag onto rows for deleted instances, run
```
UPDATE nova.instance_system_metadata SET deleted = id WHERE deleted = 0 AND instance_uuid IN (SELECT uuid FROM nova.instances WHERE deleted > 0);
```

Not running the above command will not prevent the cleanup from running, but will mean that the cleanup script will not find many valid rows to move and will leave a lot of stuff behind.