### PR TITLE
Add custom weigher that favors nodes with <1:1 CPU commit

### DIFF
--- a/cookbooks/bcpc/files/default/bbweigher.py
+++ b/cookbooks/bcpc/files/default/bbweigher.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2017 Bloomberg L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Bloomberg custom weigher that gives high priority to hosts with less than
+1:1 CPU commit.
+"""
+
+import math
+
+from nova.scheduler import weights
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+class BBWeigher(weights.BaseHostWeigher):
+    minval = 0
+
+    def _weigh_object(self, host_state, weight_properties):
+        memory_weight = math.sqrt(max(0.0, host_state.free_ram_mb/1024.0))
+        host_vcpu_limit = host_state.limits.get('vcpu', 0.0)
+        host_vcpu_threshold = host_vcpu_limit - host_state.vcpus_used
+        cpu_weight = max(0.0, host_vcpu_threshold)
+
+        # if host is not overcommitted, strongly favor it
+        if host_state.vcpus_total > host_state.vcpus_used:
+            cpu_weight = (host_state.vcpus_total - host_state.vcpus_used)**2
+
+        # amplified to be on the same scale as the RAM weigher
+        bb_weight = (memory_weight + cpu_weight)**2
+
+        LOG.debug("BBWEIGHER: HOST %s: %f" % (host_state.nodename, bb_weight))
+
+        return bb_weight

--- a/cookbooks/bcpc/recipes/nova-head.rb
+++ b/cookbooks/bcpc/recipes/nova-head.rb
@@ -81,5 +81,13 @@ end
     end
 end
 
+cookbook_file '/usr/lib/python2.7/dist-packages/nova/scheduler/weights/bbweigher.py' do
+  source 'bbweigher.py'
+  mode   '00644'
+  owner  'root'
+  group  'root'
+  notifies :restart, "service[nova-scheduler]", :delayed
+end
+
 include_recipe "bcpc::nova-work"
 include_recipe "bcpc::nova-setup"


### PR DESCRIPTION
The default weigher configuration uses RAMWeigher to decide which hosts
are the most favorable for placement. This results in severe imbalances
in clusters with machines with varying memory sizes - the scheduler will
ignore empty nodes with less total memory and pile up instances on
heavily-committed nodes that have large amounts of memory.

This weigher runs alongside other weighers and returns extremely high
weights for hosts that are undercommitted on CPU, improving the chances
of spreading load. Once 1:1 commit is reached on all hosts, higher
memory hosts will become more favorable for placement again.

This algorithm will likely be tuned more in the future and is a starting
point.