### PR TITLE
Fix proxy specification to require full url.

### DIFF
--- a/bootstrap/config/bootstrap_config.sh.defaults
+++ b/bootstrap/config/bootstrap_config.sh.defaults
@@ -52,8 +52,8 @@ export BOOTSTRAP_CHEF_ENV=Test-Laptop-Vagrant
 export BOOTSTRAP_CHEF_DO_CONVERGE=1
 
 # Set servers to be used as an HTTP/HTTPS proxy. Provide without scheme (no http/https).
-export BOOTSTRAP_HTTP_PROXY=
-export BOOTSTRAP_HTTPS_PROXY=
+export BOOTSTRAP_HTTP_PROXY_URL=
+export BOOTSTRAP_HTTPS_PROXY_URL=
 
 # Set a location on local disk which contains X509 certificates to add to the system
 # CA certificate store in each VM.

--- a/bootstrap/shared/shared_prereqs.sh
+++ b/bootstrap/shared/shared_prereqs.sh
@@ -2,7 +2,7 @@
 # Exit immediately if anything goes wrong, instead of making things worse.
 set -e
 
-if [[ ! -z $BOOTSTRAP_HTTP_PROXY ]] || [[ ! -z $BOOTSTRAP_HTTPS_PROXY ]] ; then
+if [[ ! -z $BOOTSTRAP_HTTP_PROXY_URL ]] || [[ ! -z $BOOTSTRAP_HTTPS_PROXY_URL ]] ; then
   echo "Testing configured proxies..."
   source $REPO_ROOT/bootstrap/shared/shared_proxy_setup.sh
 fi

--- a/bootstrap/shared/shared_proxy_setup.sh
+++ b/bootstrap/shared/shared_proxy_setup.sh
@@ -5,26 +5,26 @@
 load_configs
 
 [ -n "$SHARED_PROXY_SETUP" ] || {
-  REQUIRED_VARS=( BOOTSTRAP_HTTP_PROXY BOOTSTRAP_HTTPS_PROXY )
+  REQUIRED_VARS=( BOOTSTRAP_HTTP_PROXY_URL BOOTSTRAP_HTTPS_PROXY_URL )
   check_for_envvars ${REQUIRED_VARS[@]}
 
   set -e
 
-  if [ ! -z "$BOOTSTRAP_HTTP_PROXY" ]; then
-    export http_proxy=http://${BOOTSTRAP_HTTP_PROXY}
+  if [ ! -z "$BOOTSTRAP_HTTP_PROXY_URL" ]; then
+    export http_proxy=${BOOTSTRAP_HTTP_PROXY_URL}
 
     curl -s --connect-timeout 10 http://www.google.com > /dev/null && true
     if [[ $? != 0 ]]; then
-      echo "Error: proxy $BOOTSTRAP_HTTP_PROXY non-functional for HTTP requests" >&2
+      echo "Error: proxy $BOOTSTRAP_HTTP_PROXY_URL non-functional for HTTP requests" >&2
       exit 1
     fi
   fi
 
-  if [ ! -z "$BOOTSTRAP_HTTPS_PROXY" ]; then
-    export https_proxy=https://${BOOTSTRAP_HTTPS_PROXY}
+  if [ ! -z "$BOOTSTRAP_HTTPS_PROXY_URL" ]; then
+    export https_proxy=${BOOTSTRAP_HTTPS_PROXY_URL}
     curl -s --connect-timeout 10 https://github.com > /dev/null && true
     if [[ $? != 0 ]]; then
-      echo "Error: proxy $BOOTSTRAP_HTTPS_PROXY non-functional for HTTPS requests" >&2
+      echo "Error: proxy $BOOTSTRAP_HTTPS_PROXY_URL non-functional for HTTPS requests" >&2
       exit 1
     fi
   fi

--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -87,16 +87,19 @@ $proxy_configuration_script = <<-EOH
   sudo touch /etc/apt/apt.conf
   touch $HOME/proxy_config.sh
 EOH
-unless ENV['BOOTSTRAP_HTTP_PROXY'].nil? or ENV['BOOTSTRAP_HTTP_PROXY'].empty?
+# some ugliness for legacy configs
+BOOTSTRAP_HTTP_PROXY_URL = URI(ENV['BOOTSTRAP_HTTP_PROXY_URL'] || 'http://%s' % ENV['BOOTSTRAP_HTTP_PROXY'])
+BOOTSTRAP_HTTPS_PROXY_URL = URI(ENV['BOOTSTRAP_HTTPS_PROXY_URL'] || 'http://%s' % ENV['BOOTSTRAP_HTTPS_PROXY'])
+unless BOOTSTRAP_HTTP_PROXY_URL.host.nil?
   $proxy_configuration_script << <<-EOH
-    echo 'Acquire::http::Proxy "http://#{ENV['BOOTSTRAP_HTTP_PROXY']}";' | sudo tee -a /etc/apt/apt.conf
-    echo 'export http_proxy=#{ENV['BOOTSTRAP_HTTP_PROXY']}' | tee -a $HOME/proxy_config.sh
+    echo 'Acquire::http::Proxy "#{BOOTSTRAP_HTTP_PROXY_URL.to_s}";' | sudo tee -a /etc/apt/apt.conf
+    echo 'export http_proxy=#{BOOTSTRAP_HTTP_PROXY_URL.to_s}' | tee -a $HOME/proxy_config.sh
   EOH
 end
-unless ENV['BOOTSTRAP_HTTPS_PROXY'].nil? or ENV['BOOTSTRAP_HTTPS_PROXY'].empty?
+unless BOOTSTRAP_HTTPS_PROXY_URL.host.nil?
   $proxy_configuration_script << <<-EOH
-    echo 'Acquire::https::Proxy "https://#{ENV['BOOTSTRAP_HTTPS_PROXY']}";' | sudo tee -a /etc/apt/apt.conf
-    echo 'export https_proxy=#{ENV['BOOTSTRAP_HTTPS_PROXY']}' | tee -a $HOME/proxy_config.sh
+    echo 'Acquire::https::Proxy "#{BOOTSTRAP_HTTPS_PROXY_URL.to_s}";' | sudo tee -a /etc/apt/apt.conf
+    echo 'export https_proxy=#{BOOTSTRAP_HTTPS_PROXY_URL.to_s}' | tee -a $HOME/proxy_config.sh
   EOH
 end
 


### PR DESCRIPTION
Generating proxy urls from hostnames is likely to cause failure, especially in the case where the url for https connections does not use the _https_ scheme.

One should probably verify her config with the following (since config variable names would have changed in a non-backwards-compatible manner):

```
$ ( cd bootstrap/vagrant_scripts && ./dump_config.sh )
ANSIBLE_VM_DIR=/Users/bcpc/.ansible-bcpc-vms
BCPC_HYPERVISOR_DOMAIN=hypervisor-bcpc.example.com
BOOTSTRAP_ADDITIONAL_CACERTS_DIR=/cacerts
BOOTSTRAP_APT_MIRROR=
BOOTSTRAP_CACHE_DIR=/Users/bcpc/.bcpc-cache
BOOTSTRAP_CHEF_DO_CONVERGE=1
BOOTSTRAP_CHEF_ENV=Test-Laptop-Vagrant
BOOTSTRAP_HTTPS_PROXY_URL=<redacted>
BOOTSTRAP_HTTP_PROXY_URL=<redacted>
BOOTSTRAP_VM_CPUS=2
BOOTSTRAP_VM_DRIVE_SIZE=20480
BOOTSTRAP_VM_MEM=2048
CHEF_CLIENT_DEB=
CHEF_SERVER_DEB=
CLUSTER_VM_CPUS=2
CLUSTER_VM_DRIVE_SIZE=20480
CLUSTER_VM_MEM=3072
FILECACHE_MOUNT_POINT=/chef-bcpc-files
MONITORING_NODES=3
REPO_MOUNT_POINT=/chef-bcpc-host
VM_SWAP_SIZE=8192
```