### PR TITLE
Fix parsing of mysql ping item to detect crashes

### DIFF
--- a/cookbooks/bcpc/files/default/zabbix_bcpc_template.xml
+++ b/cookbooks/bcpc/files/default/zabbix_bcpc_template.xml
@@ -4299,7 +4299,7 @@
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{BCPC-Headnode:mysql.ping.str(1,#1)}&lt;&gt;1</expression>
+            <expression>{BCPC-Headnode:mysql.ping.regexp(^1,#1)}&lt;&gt;1</expression>
             <name>MySQL is not pingable from {HOST.NAME}</name>
             <url/>
             <status>0</status>


### PR DESCRIPTION
Update the trigger to use regex as the former expression fails to detect a crashed MySQL instance when the item returns below output.

```
mysqladmin: connect to server at 'localhost' failed
error: 'Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (111)'
Check that mysqld is running and that the socket: '/var/run/mysqld/mysqld.sock' exists!
0
```
