### PR TITLE
Add neutron.conf to compute nodes via neutron-common recipe

### DIFF
--- a/cookbooks/bcpc/recipes/calico-compute.rb
+++ b/cookbooks/bcpc/recipes/calico-compute.rb
@@ -21,6 +21,7 @@ return unless node['bcpc']['enabled']['neutron']
 
 include_recipe 'bcpc::etcd-common'
 include_recipe 'bcpc::bird-compute'
+include_recipe 'bcpc::neutron-common'
 include_recipe 'bcpc::packages-calico'
 
 file '/etc/init/neutron-dhcp-agent.override' do
@@ -74,5 +75,6 @@ end
 %w(neutron-metadata-agent calico-dhcp-agent calico-felix).each do |svc|
   service svc do
     action [:start, :enable]
+    subscribes :restart, 'template[/etc/neutron/neutron.conf]', :delayed
   end
 end


### PR DESCRIPTION
Neutron metadata agent needs `neutron.conf` to be configured in order to
connect to AMQP.