### PR TITLE
Include xinetd dependency from headnodes for haproxy

### DIFF
--- a/cookbooks/bcpc/recipes/haproxy-head.rb
+++ b/cookbooks/bcpc/recipes/haproxy-head.rb
@@ -18,6 +18,8 @@
 #
 
 include_recipe "bcpc::default"
+# There is cyclical dependency upon some of checks - see /etc/xinetd.d/*chk
+include_recipe "bcpc::xinetd"
 include_recipe "bcpc::haproxy-common"
 
 concat_fragment "haproxy-main-config" do


### PR DESCRIPTION
xinetd resources only declared in the xinetd recipe are utilized by the
haproxy-head recipe. This allows the latter recipe to now run in isolation. This addresses an omission from 99d52d0f7f703b4c7cff63e698ae98b97fdb3467

Currently:
```
root@bcpc-vm1:~# chef-shell -z -o 'bcpc::haproxy-head'
loading configuration: /etc/chef/client.rb
Session type: client
Loading..........................[2017-05-02T16:56:55+00:00] WARN: Run List override has been provided.
[2017-05-02T16:56:55+00:00] WARN: Original Run List: [role[BCPC-Hardware-Virtual], role[BCPC-Headnode]]
[2017-05-02T16:56:55+00:00] WARN: Overridden Run List: [recipe[bcpc::haproxy-head]]
resolving cookbooks for run list: ["bcpc::haproxy-head"]
<...snip...>
chef (12.9.41)> run_chef
[2017-05-02T16:57:09+00:00] INFO: Running queued delayed notifications before re-raising exception
Chef::Exceptions::ResourceNotFound: resource concat[/etc/haproxy/haproxy.cfg] is configured to notify resource service[xinetd] with action restart, but service[xinetd] cannot be found in the resource collection. concat[/etc/haproxy/haproxy.cfg] is defined in /var/chef/cache/cookbooks/bcpc/recipes/haproxy-head.rb:37:in `from_file'
```

After patch:
```
root@bcpc-vm1:~# chef-client -obcpc::haproxy-head
Starting Chef Client, version 12.9.41
resolving cookbooks for run list: ["bcpc::haproxy-head"]
<...snip...>
Recipe: bcpc::haproxy-common
  * service[haproxy] action restart
    - restart service service[haproxy]
Recipe: bcpc::xinetd
  * service[xinetd] action restart
    - restart service service[xinetd]

Running handlers:
Running handlers complete
Chef Client finished, 7/22 resources updated in 22 seconds
```