### PR TITLE
Move HAProxy maxconns for MySQL in lockstep with max_connections changes

### DIFF
--- a/cookbooks/bcpc/libraries/utils.rb
+++ b/cookbooks/bcpc/libraries/utils.rb
@@ -229,6 +229,14 @@ def get_ceph_optimal_pg_count(pool)
     node['bcpc']['ceph'][pool]['portion'] / 100)
 end
 
+def get_mysql_max_connections
+  if node['bcpc']['mysql-head']['max_connections'].nil? or node['bcpc']['mysql-head']['max_connections'].zero?
+     [get_head_nodes.length*150+get_all_nodes.length*10, 450].max
+  else
+    node['bcpc']['mysql-head']['max_connections']
+  end
+end
+
 def get_bootstrap_node
     filter = {
       :filter_result => {

--- a/cookbooks/bcpc/recipes/haproxy-head.rb
+++ b/cookbooks/bcpc/recipes/haproxy-head.rb
@@ -28,6 +28,7 @@ concat_fragment "haproxy-main-config" do
     lazy {
       {
         :servers => get_head_nodes,
+        :mysql_max_connections => get_mysql_max_connections,
         :radosgw_servers => search_nodes('recipe', 'ceph-rgw')
       }
     }

--- a/cookbooks/bcpc/recipes/mysql-head.rb
+++ b/cookbooks/bcpc/recipes/mysql-head.rb
@@ -57,17 +57,13 @@ template "/etc/mysql/debian.cnf" do
     notifies :reload, "service[mysql]", :immediately
 end
 
-if node['bcpc']['mysql-head']['max_connections'] == 0 then
-    node.default['bcpc']['mysql-head']['max_connections'] = [get_head_nodes.length*150+get_all_nodes.length*10, 450].max
-end
-
 template "/etc/mysql/conf.d/wsrep.cnf" do
     source "wsrep.cnf.erb"
     mode 00644
     variables(
       lazy {
         {
-          :max_connections => node['bcpc']['mysql-head']['max_connections'],
+          :max_connections => get_mysql_max_connections,
           :servers => get_head_nodes,
           :wsrep_cluster_name => node['bcpc']['region_name'],
           :wsrep_port => 4567,

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -40,6 +40,7 @@ listen mysql-galera
   option tcpka
   option httpchk
   option nolinger
+  maxconn <%= @mysql_max_connections %>
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:3306 check port 3307 inter 5s rise 1 fall 1 observe layer4 backup" %>
 <% end -%>


### PR DESCRIPTION
Previously, when setting a value for MySQL max_connections, the HAProxy
frontend for MySQL was not updated and would remain at 2000. This
obviously causes problems if you set max_connections to more than 2000
and the cluster needs to consume more than 2000 database connections.