### PR TITLE
Exclude /var/lib/ceph from updatedb search paths

### DIFF
--- a/cookbooks/bcpc/recipes/system.rb
+++ b/cookbooks/bcpc/recipes/system.rb
@@ -131,3 +131,10 @@ ruby_block 'converge-io-scheduler' do
     devices_to_converge.length.zero?
   end
 end
+
+template '/etc/updatedb.conf' do
+  source 'updatedb.conf.erb'
+  owner 'root'
+  group 'root'
+  mode 00644
+end

--- a/cookbooks/bcpc/templates/default/updatedb.conf.erb
+++ b/cookbooks/bcpc/templates/default/updatedb.conf.erb
@@ -1,0 +1,4 @@
+PRUNE_BIND_MOUNTS="yes"
+# PRUNENAMES=".git .bzr .hg .svn"
+PRUNEPATHS="/tmp /var/spool /media /home/.ecryptfs /var/lib/ceph"
+PRUNEFS="NFS nfs nfs4 rpc_pipefs afs binfmt_misc proc smbfs autofs iso9660 ncpfs coda devpts ftpfs devfs mfs shfs sysfs cifs lustre tmpfs usbfs udf fuse.glusterfs fuse.sshfs curlftpfs ecryptfs fusesmb devtmpfs"


### PR DESCRIPTION
This is to reduce I/O load on Ceph nodes whenever `updatedb` runs. Before deploying to an existing cluster, run `updatedb.mlocate ; locate /var/lib/ceph/` on any Ceph monitor/OSD node. It should return a large list of files. Re-running the commands after deploy should return an empty result.