### PR TITLE
Toggle for conditional DNS forwarding

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -391,6 +391,13 @@ default['bcpc']['nova']['quota'] = {
   "instances" => -1,
   "ram" => 8192
 }
+# Conditionally forwards queries to external DNS servers.
+# When false, all DNS queries will be resolved via nameservers defined in
+# /etc/resolv.conf.
+# When true, all DNS queries will be forwarded to external DNS servers
+# by each tenant's dnsmasq instance, except fixed zone PTRs.
+default['bcpc']['nova']['conditional_dns'] = false
+
 # load a custom vendor driver,
 # e.g. "nova.api.metadata.bcpc_metadata.BcpcMetadata",
 # comment out to use default

--- a/cookbooks/bcpc/recipes/nova-common.rb
+++ b/cookbooks/bcpc/recipes/nova-common.rb
@@ -52,6 +52,9 @@ template "/etc/nova/nova.conf" do
     variables(
       lazy {
         {
+          :dns_servers => node['bcpc']['dns_servers'],
+          :fixed_reverse_zone => \
+            calc_reverse_dns_zone(node['bcpc']['fixed']['cidr']).first,
           :servers => get_head_nodes
         }
       }

--- a/cookbooks/bcpc/templates/default/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova.conf.erb
@@ -133,7 +133,14 @@ multi_host=True
 fixed_range=<%=node['bcpc']['fixed']['cidr']%>
 floating_range=<%=node['bcpc']['floating']['cidr']%>
 network_size=<%=node['bcpc']['fixed']['network_size']%>
+<% if node['bcpc']['nova']['conditional_dns'] %>
+<% @dns_servers.each do |dns_server| %>
+dns_server=<%= dns_server %>
+<% end %>
+dns_server=/<%= @fixed_reverse_zone %>/<%= node['bcpc']['management']['vip'] %>
+<% else %>
 flat_network_dns=<%=node['bcpc']['management']['vip']%>
+<% end %>
 dhcpbridge_flagfile=/etc/nova/nova.conf
 dhcpbridge=/usr/bin/nova-dhcpbridge
 force_dhcp_release=False


### PR DESCRIPTION
When DNS is hosted externally, there is no need to use in-cluster PowerDNS for resolving queries. However, it may be useful to retain its use for resolving non-routable fixed PTRs.

This should not normally be enabled on a development build since `*.bcpc.example.com` is only hosted in-cluster.