### PR TITLE
add kexec recipe

### DIFF
--- a/cookbooks/bcpc-extra/files/default/etc-default-kexec
+++ b/cookbooks/bcpc-extra/files/default/etc-default-kexec
@@ -1,0 +1,15 @@
+# Defaults for kexec initscript
+# sourced by /etc/init.d/kexec and /etc/init.d/kexec-load
+
+# Load a kexec kernel (true/false)
+LOAD_KEXEC=true
+
+# Kernel and initrd image
+KERNEL_IMAGE="/vmlinuz"
+INITRD="/initrd.img"
+
+# If empty, use current /proc/cmdline
+APPEND=""
+
+# Load the default kernel from grub config (true/false)
+USE_GRUB_CONFIG=false

--- a/cookbooks/bcpc-extra/recipes/kexec.rb
+++ b/cookbooks/bcpc-extra/recipes/kexec.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: bcpc-extra
+# Recipe:: kexec
+#
+# Copyright 2017, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package 'kexec-tools' do
+  action :upgrade
+end
+
+cookbook_file 'etc-default-kexec' do
+  path '/etc/default/kexec'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+end

--- a/roles/Basic.json
+++ b/roles/Basic.json
@@ -7,6 +7,7 @@
       "recipe[ubuntu]",
       "recipe[bcpc::packages-common]",
       "recipe[bcpc::packages-debugging]",
+      "recipe[bcpc-extra::kexec]",
       "recipe[bcpc::apport]",
       "recipe[bcpc::developer]",
       "recipe[bcpc::cpupower]",


### PR DESCRIPTION
Installs kexec-tools and configures kexec to load on reboot. This makes reboots take less than 30 seconds as the kernel is loaded directly from shutdown sequence by kexec.