### PR TITLE
add etckeeper cookbook

### DIFF
--- a/cookbooks/bcpc/files/default/etckeeper.conf
+++ b/cookbooks/bcpc/files/default/etckeeper.conf
@@ -1,0 +1,30 @@
+# The VCS to use.
+VCS="git"
+
+# Options passed to git commit when run by etckeeper.
+GIT_COMMIT_OPTIONS=""
+
+# Uncomment to avoid etckeeper committing existing changes
+# to /etc automatically once per day.
+#AVOID_DAILY_AUTOCOMMITS=1
+
+# Uncomment the following to avoid special file warning
+# (the option is enabled automatically by cronjob regardless).
+#AVOID_SPECIAL_FILE_WARNING=1
+
+# Uncomment to avoid etckeeper committing existing changes to
+# /etc before installation. It will cancel the installation,
+# so you can commit the changes by hand.
+#AVOID_COMMIT_BEFORE_INSTALL=1
+
+# The high-level package manager that's being used.
+# (apt, pacman-g2, yum, zypper etc)
+HIGHLEVEL_PACKAGE_MANAGER=apt
+
+# The low-level package manager that's being used.
+# (dpkg, rpm, pacman, pacman-g2, etc)
+LOWLEVEL_PACKAGE_MANAGER=dpkg
+
+# To push each commit to a remote, put the name of the remote here.
+# (eg, "origin" for git).
+PUSH_REMOTE=""

--- a/cookbooks/bcpc/recipes/etckeeper.rb
+++ b/cookbooks/bcpc/recipes/etckeeper.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: etckeeper
+#
+# Copyright 2017, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+etckeeper_packages = ['git', 'etckeeper']
+
+package etckeeper_packages do
+  action :upgrade
+end
+
+cookbook_file 'etckeeper.conf' do
+  path '/etc/etckeeper/etckeeper.conf'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :run, 'execute[etckeeper-init]', :immediately
+end
+
+execute 'etckeeper-init' do
+  command 'etckeeper init'
+  creates '/etc/.git'
+  notifies :create, 'template[etckeeper-gitconfig]', :immediately
+end
+
+template 'etckeeper-gitconfig' do
+  path '/etc/.git/config'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end

--- a/cookbooks/bcpc/templates/default/etckeeper-gitconfig.erb
+++ b/cookbooks/bcpc/templates/default/etckeeper-gitconfig.erb
@@ -1,0 +1,9 @@
+[core]
+    repositoryformatversion = 0
+    filemode = true
+    bare = false
+    logallrefupdates = true
+
+[user]
+    email = root@<%= node['fqdn'] %>
+    name = Enoch Root

--- a/roles/Basic.json
+++ b/roles/Basic.json
@@ -5,6 +5,7 @@
     "json_class": "Chef::Role",
     "run_list": [
       "recipe[ubuntu]",
+      "recipe[bcpc::etckeeper]",
       "recipe[bcpc::packages-common]",
       "recipe[bcpc::packages-debugging]",
       "recipe[bcpc::apport]",


### PR DESCRIPTION
etckeeper puts /etc under version control locally. This allows for local tracking of the history of changes to /etc.