### PR TITLE
Enforce timeout on pdns_control execution

### DIFF
--- a/cookbooks/bcpc/files/default/diamond-collector-powerdns.patch
+++ b/cookbooks/bcpc/files/default/diamond-collector-powerdns.patch
@@ -1,0 +1,11 @@
+--- collectors/powerdns/powerdns.py.orig	2017-09-05 14:43:49.511625749 -0400
++++ collectors/powerdns/powerdns.py	2017-09-05 14:49:23.059110680 -0400
+@@ -53,7 +53,7 @@
+             self.log.error("%s is not executable", self.config['bin'])
+             return False
+ 
+-        command = [self.config['bin'], 'list']
++        command = ['timeout', '-s', '9', '5', self.config['bin'], 'list']
+ 
+         if str_to_bool(self.config['use_sudo']):
+             command.insert(0, self.config['sudo_cmd'])

--- a/cookbooks/bcpc/files/default/diamond-collector-powerdns.patch.AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/diamond-collector-powerdns.patch.AFTER.SHASUMS
@@ -1,0 +1,1 @@
+49b2fadd885d0eee47b1b8e7b621cdd73147d8fe  powerdns/powerdns.py

--- a/cookbooks/bcpc/files/default/diamond-collector-powerdns.patch.BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/diamond-collector-powerdns.patch.BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+da804c873d02b4f22e9e537e57decc1f089a8819  powerdns/powerdns.py

--- a/cookbooks/bcpc/recipes/diamond.rb
+++ b/cookbooks/bcpc/recipes/diamond.rb
@@ -40,6 +40,14 @@ if node['bcpc']['enabled']['metrics'] then
         action :upgrade
     end
 
+    bcpc_patch '/usr/share/diamond/collectors/powerdns/powerdns.py' do
+        patch_file           'diamond-collector-powerdns.patch'
+        patch_root_dir       '/usr/share/diamond/collectors'
+        shasums_before_apply 'diamond-collector-powerdns.patch.BEFORE.SHASUMS'
+        shasums_after_apply  'diamond-collector-powerdns.patch.AFTER.SHASUMS'
+        notifies             :restart, "service[diamond]", :delayed
+    end
+
     if node['bcpc']['virt_type'] == "kvm"
         package "ipmitool" do
             action :upgrade


### PR DESCRIPTION
This prevents a build up of `pdns_control` processes when PowerDNS is unresponsive. This can be tested by recheffing and stopping the PowerDNS process via `kill -STOP <powerdns instance PID>`. then verifying the process listing. No more than one `pdns_control` process should be running.

```
root     3363858  0.0  0.0   8624   780 ?        S    16:06   0:00 timeout -s 9 5 /usr/bin/pdns_control list
```