### PR TITLE
Make example ansible inventory file compliant with ansible >= 2.0

### DIFF
--- a/bootstrap/ansible_scripts/inventory-ansible
+++ b/bootstrap/ansible_scripts/inventory-ansible
@@ -2,7 +2,7 @@
 127.0.0.1 ansible_connection=local
 
 [Test-Laptop-Ansible:vars]
-ansible_ssh_user=operations
+ansible_user=operations
 hardware_type=Virtual
 
 [Test-Laptop-Ansible:children]
@@ -15,16 +15,16 @@ Test-Laptop-Ansible-worknodes
 Test-Laptop-Ansible-ephemeral-worknodes
 
 [Test-Laptop-Ansible-worknodes]
-bcpc-vm2 ansible_ssh_host=10.0.100.12
+bcpc-vm2 ansible_host=10.0.100.12
 
 [Test-Laptop-Ansible-ephemeral-worknodes]
-bcpc-vm3 ansible_ssh_host=10.0.100.13
+bcpc-vm3 ansible_host=10.0.100.13
 
 [Test-Laptop-Ansible-headnodes]
-bcpc-vm1 ansible_ssh_host=10.0.100.11
+bcpc-vm1 ansible_host=10.0.100.11
 
 [Test-Laptop-Ansible-bootstraps]
-ansible-bcpc-bootstrap ansible_ssh_host=10.0.100.3
+ansible-bcpc-bootstrap ansible_host=10.0.100.3
 
 [cluster:children]
 headnodes


### PR DESCRIPTION
syntax - ansible_ssh_user becomes ansible_user and ansible_ssh_host
becomes ansible_host

see http://docs.ansible.com/ansible/latest/intro_inventory.html#hosts-and-groups

fixes https://github.com/bloomberg/chef-bcpc/issues/1276