### PR TITLE
remove proposed as the default repo

### DIFF
--- a/cookbooks/bcpc/attributes/default.rb
+++ b/cookbooks/bcpc/attributes/default.rb
@@ -8,8 +8,7 @@ default['bcpc']['state'] = "NY"
 default['bcpc']['location'] = "New York"
 default['bcpc']['organization'] = "Bloomberg"
 default['bcpc']['openstack_release'] = "mitaka"
-# Can be "updates" or "proposed"
-default['bcpc']['openstack_branch'] = "proposed"
+default['bcpc']['openstack_branch'] = "updates"
 # Should be kvm (or qemu if testing in VMs that don't support VT-x)
 default['bcpc']['virt_type'] = "kvm"
 # Define the kernel to be installed. By default, track latest LTS kernel

--- a/docs/example_apt_mirror_config.list
+++ b/docs/example_apt_mirror_config.list
@@ -61,13 +61,9 @@ deb-i386 http://ppa.launchpad.net/vbernat/haproxy-1.5/ubuntu trusty main
 clean http://ppa.launchpad.net/vbernat/haproxy-1.5/ubuntu
 
 # openstack repository in BCPC
-deb http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-proposed/liberty main
 deb http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-updates/liberty main
-deb-i386 http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-proposed/liberty main
 deb-i386 http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-updates/liberty main
-deb http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-proposed/mitaka main
 deb http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-updates/mitaka main
-deb-i386 http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-proposed/mitaka main
 deb-i386 http://ubuntu-cloud.archive.canonical.com/ubuntu trusty-updates/mitaka main
 clean http://ubuntu-cloud.archive.canonical.com/ubuntu
 


### PR DESCRIPTION
'proposed' is not a stable repository, it is a testing ground for packages
to enter the 'updates' repository.