### PR TITLE
First-pass cleanup of current shell provisioning

### DIFF
--- a/bootstrap/shared/shared_validate_env.sh
+++ b/bootstrap/shared/shared_validate_env.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-NEEDED_PROGRAMS=( curl git rsync ssh foobar )
+NEEDED_PROGRAMS=( curl git rsync ssh )
 FAILED=0
 for binary in "${NEEDED_PROGRAMS[@]}"; do
   if ! which "$binary" >/dev/null; then

--- a/bootstrap/shared/shared_validate_env.sh
+++ b/bootstrap/shared/shared_validate_env.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
-NEEDED_PROGRAMS=( curl git rsync ssh )
+NEEDED_PROGRAMS=( curl git rsync ssh foobar )
 FAILED=0
-for binary in ${NEEDED_PROGRAMS[@]}; do
-  if ! which $binary >/dev/null; then
+for binary in "${NEEDED_PROGRAMS[@]}"; do
+  if ! which "$binary" >/dev/null; then
     FAILED=1
-    echo "Unable to locate $binary on the path." >&2
+    echo "ERROR: Unable to locate $binary in this environment's PATH." >&2
   fi
 done
 
 if [[ $FAILED != 0 ]]; then
-  echo "Please see above error output to determine which programs you need to install or make available on your path. Aborting." >&2
+  printf "
+       Please see above error output to determine which program(s) you may
+       need to install or expose into this environment's PATH. Aborting.\n" >&2
   exit 1
 fi
+

--- a/bootstrap/vagrant_scripts/BOOT_GO.sh
+++ b/bootstrap/vagrant_scripts/BOOT_GO.sh
@@ -38,38 +38,38 @@ echo
 # Source common bootstrap functions. This is the only place that uses a
 # relative path; everything henceforth must use $REPO_ROOT.
 source ../shared/shared_functions.sh
-export REPO_ROOT=$REPO_ROOT
+export REPO_ROOT="$REPO_ROOT"
 
 load_configs
 
 # Perform preflight checks to validate environment sanity as much as possible.
 echo "Performing preflight environment validation..."
-source $REPO_ROOT/bootstrap/shared/shared_validate_env.sh
+source "$REPO_ROOT"/bootstrap/shared/shared_validate_env.sh
 
 # Test that Vagrant is really installed and of an appropriate version.
 echo "Checking VirtualBox and Vagrant..."
-source $REPO_ROOT/bootstrap/vagrant_scripts/vagrant_test.sh
+source "$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_test.sh
 
 # Do prerequisite work prior to starting build, downloading files and
 # creating local directories. Proxy configuration is handled there as well.
 echo "Downloading necessary files to local cache..."
-source $REPO_ROOT/bootstrap/shared/shared_prereqs.sh
+source "$REPO_ROOT"/bootstrap/shared/shared_prereqs.sh
 
 # Terminate existing BCPC VMs.
 echo "Shutting down and unregistering VMs from VirtualBox..."
-$REPO_ROOT/bootstrap/vagrant_scripts/vagrant_clean.sh
+"$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_clean.sh
 
 # Create VMs in Vagrant and start them.
 echo "Starting local Vagrant cluster..."
-$REPO_ROOT/bootstrap/vagrant_scripts/vagrant_create.sh
+"$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_create.sh
 
 # Install and configure Chef on all Vagrant hosts.
 echo "Installing and configuring Chef on all nodes..."
-$REPO_ROOT/bootstrap/shared/shared_configure_chef.sh $CLUSTER_TYPE
+"$REPO_ROOT"/bootstrap/shared/shared_configure_chef.sh $CLUSTER_TYPE
 
 # Dump out OpenStack information for users if a converged cluster
 if [[ $CLUSTER_TYPE == 'converged' ]]; then
-  $REPO_ROOT/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
+  "$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
 fi
 
 echo "Finished in $SECONDS seconds"

--- a/bootstrap/vagrant_scripts/dump_config.sh
+++ b/bootstrap/vagrant_scripts/dump_config.sh
@@ -3,7 +3,7 @@
 hash -r
 
 export PATH=/bin:/usr/bin
-DIR="$( cd ${0%/*} && pwd -P )"
+DIR=$( cd "${0%/*}" && pwd -P )
 confdir="$(cd "$DIR/../config" &&  pwd -P)"
 
 # Relocate and set me

--- a/bootstrap/vagrant_scripts/vagrant_clean.sh
+++ b/bootstrap/vagrant_scripts/vagrant_clean.sh
@@ -2,8 +2,8 @@
 # Exit immediately if anything goes wrong, instead of making things worse.
 set -e
 
-. $REPO_ROOT/bootstrap/shared/shared_functions.sh
+. "$REPO_ROOT"/bootstrap/shared/shared_functions.sh
 
 # Set this to max value to ensure leftover mon VMs are destroyed
 export CLUSTER_NODE_COUNT_OVERRIDE=6
-cd $REPO_ROOT/bootstrap/vagrant_scripts && vagrant destroy -f
+cd "$REPO_ROOT"/bootstrap/vagrant_scripts && vagrant destroy -f

--- a/bootstrap/vagrant_scripts/vagrant_test.sh
+++ b/bootstrap/vagrant_scripts/vagrant_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $REPO_ROOT/bootstrap/shared/shared_functions.sh
+. "$REPO_ROOT"/bootstrap/shared/shared_functions.sh
 
 if ! which vagrant >/dev/null; then
   echo "You must have Vagrant installed to build an environment using Vagrant." >&2

--- a/cookbooks/bcpc/files/default/zabbix_s3test.sh
+++ b/cookbooks/bcpc/files/default/zabbix_s3test.sh
@@ -4,7 +4,7 @@
 # and bucket to validate S3 functionality.
 
 start_time=$(date +%s.%N)
-script="`basename $0`"
+script=$(basename "$0")
 key=$1
 secret=$2
 proto=$3
@@ -23,23 +23,23 @@ function get_signature()
 {
   string=$1
   signature=$(echo -en "${string}" | openssl sha1 -hmac "${secret}" -binary | base64)
-  echo $signature
+  echo "$signature"
 }
 
 function get_date()
 {
-  date=`date -R -u`
-  echo $date
+  date=$(date -R -u)
+  echo "$date"
 }
 
 function log()
 {
   message=$1
-  logger -t s3test -p syslog.notice $message
+  logger -t s3test -p syslog.notice "$message"
 }
 
 # Create a monitoring test file for upload
-echo "$file_content" > $local_path/$filename
+echo "$file_content" > "$local_path/$filename"
 
 # Create bucket
 date=$(get_date)
@@ -50,7 +50,7 @@ $curl_cmd -X $verb \
   -H "Host: $bucket.$fqdn" \
   -H "Date: $date" \
   -H "Authorization: AWS ${key}:$signature" \
-  $proto://$bucket.$fqdn 2>/dev/null
+  "$proto://${bucket}.${fqdn}" 2>/dev/null
 
 [[ $? -eq 0 ]] || { echo -1 && exit 0; }
 
@@ -74,18 +74,18 @@ for verb in PUT GET DELETE; do
     -H "Content-Type: $content_type" \
     -H "$acl" \
     -H "Authorization: AWS ${key}:$signature" \
-    $proto://$bucket.$fqdn$s3_path$filename 2>/dev/null
+    "$proto://${bucket}.${fqdn$s3_path}${filename}" 2>/dev/null
 
   rc="$?"
   log "$verb $filename returned $rc"
   [[ $rc -eq 0 ]] || { echo -1 && exit 0; }
 
   # Ensure monitoring test file does not exist
-  [[ -f $local_path/$filename ]] && rm -f $local_path/$filename
+  [[ -f "$local_path"/"$filename" ]] && rm -f "$local_path"/"$filename"
 
 done
 
 end_time=$(date +%s.%N)
-duration="`echo ${end_time}-${start_time} | bc -l`"
+duration=$(echo "${end_time}"-"${start_time}" | bc -l)
 
-echo $duration
+echo "$duration"


### PR DESCRIPTION
Cleaning up some of the leftover breadcrumbs from previous closed PRs. 

This changeset ensures that vars are correctly quoted ($REPO_ROOT w/spaces, for example) and that we're not leaving any vars exposed to splitting or masking return values. Each file includes its own commit details.

I've run two full builds and this should merge cleanly with bloomberg/master. 