### PR TITLE
Print build time in hours, minutes and seconds as well as total

### DIFF
--- a/bootstrap/vagrant_scripts/BOOT_GO.sh
+++ b/bootstrap/vagrant_scripts/BOOT_GO.sh
@@ -72,4 +72,4 @@ if [[ $CLUSTER_TYPE == 'converged' ]]; then
   $REPO_ROOT/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
 fi
 
-echo "Finished in $SECONDS seconds"
+printf 'Finished in %d seconds (%dh:%dm:%ds)\n' "$SECONDS" $(($SECONDS/3600)) $(($SECONDS%3600/60)) $(($SECONDS%60))


### PR DESCRIPTION
seconds for a more easily understood built time report.