### PR TITLE
More minor cleanup, rewrites of binary and apt package version detection

### DIFF
--- a/bootstrap/shared/shared_configure_chef.sh
+++ b/bootstrap/shared/shared_configure_chef.sh
@@ -55,7 +55,8 @@ do_on_node vm-bootstrap "$CHEF_SERVER_INSTALL_CMD \
 # configure knife on the bootstrap node and perform a knife bootstrap to create the bootstrap node in Chef
 echo "Configuring Knife on bootstrap node..."
 
-do_on_node vm-bootstrap "mkdir -p \$HOME/.chef && echo -e \"chef_server_url 'https://bcpc-vm-bootstrap.$BCPC_HYPERVISOR_DOMAIN/organizations/bcpc'\\\nvalidation_client_name 'bcpc-validator'\\\nvalidation_key '/etc/opscode/bcpc-validator.pem'\\\nnode_name 'admin'\\\nclient_key '/etc/opscode/admin.pem'\\\nknife['editor'] = 'vim'\\\ncookbook_path [ \\\"#{ENV['HOME']}/chef-bcpc/cookbooks\\\" ]\" > \$HOME/.chef/knife.rb \
+do_on_node vm-bootstrap "mkdir -p \$HOME/.chef \
+  && echo -e \"chef_server_url 'https://bcpc-vm-bootstrap.$BCPC_HYPERVISOR_DOMAIN/organizations/bcpc'\\\nvalidation_client_name 'bcpc-validator'\\\nvalidation_key '/etc/opscode/bcpc-validator.pem'\\\nnode_name 'admin'\\\nclient_key '/etc/opscode/admin.pem'\\\nknife['editor'] = 'vim'\\\ncookbook_path [ \\\"#{ENV['HOME']}/chef-bcpc/cookbooks\\\" ]\" > \$HOME/.chef/knife.rb \
   && $KNIFE ssl fetch \
   && $KNIFE bootstrap -x vagrant -P vagrant --sudo 10.0.100.3"
 
@@ -73,7 +74,8 @@ echo "Installing knife-acl plugin..."
 do_on_node vm-bootstrap "sudo /opt/opscode/embedded/bin/gem install -l $FILECACHE_MOUNT_POINT/knife-acl-1.0.2.gem \
   && rsync -a $REPO_MOUNT_POINT/* \$HOME/chef-bcpc \
   && cp $FILECACHE_MOUNT_POINT/cookbooks/*.tar.gz \$HOME/chef-bcpc/cookbooks \
-  && cd \$HOME/chef-bcpc/cookbooks && ls -1 *.tar.gz | xargs -I% tar xvzf %"
+  && cd \$HOME/chef-bcpc/cookbooks \
+  && ls -1 *.tar.gz | xargs -I% tar xvzf %"
 
 # build binaries before uploading the bcpc cookbook
 # (this step will change later but using the existing build_bins script for now)
@@ -83,13 +85,16 @@ do_on_node vm-bootstrap "sudo apt-get update \
   && sudo apt-get -y autoremove \
   && cd \$HOME/chef-bcpc \
   && sudo bash -c 'export FILECACHE_MOUNT_POINT=$FILECACHE_MOUNT_POINT \
-  && source \$HOME/proxy_config.sh && bootstrap/shared/shared_build_bins.sh'"
+  && source \$HOME/proxy_config.sh \
+  && bootstrap/shared/shared_build_bins.sh'"
 
 # upload all cookbooks, roles and our chosen environment to the Chef server
 # (cookbook upload uses the cookbook_path set when configuring knife on the bootstrap node)
 do_on_node vm-bootstrap "$KNIFE cookbook upload -a \
-  && cd \$HOME/chef-bcpc/roles && $KNIFE role from file *.json \
-  && cd \$HOME/chef-bcpc/environments && $KNIFE environment from file $BOOTSTRAP_CHEF_ENV.json"
+  && cd \$HOME/chef-bcpc/roles \
+  && $KNIFE role from file *.json \
+  && cd \$HOME/chef-bcpc/environments \
+  && $KNIFE environment from file $BOOTSTRAP_CHEF_ENV.json"
 
 # install and bootstrap Chef on cluster nodes
 echo "Installing Chef client on cluster nodes..."

--- a/bootstrap/shared/shared_validate_env.sh
+++ b/bootstrap/shared/shared_validate_env.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
-NEEDED_PROGRAMS=( curl git rsync ssh )
-FAILED=0
-for binary in "${NEEDED_PROGRAMS[@]}"; do
-  if ! which "$binary" >/dev/null; then
-    FAILED=1
-    echo "ERROR: Unable to locate $binary in this environment's PATH." >&2
-  fi
-done
+required_bins=( curl git rsync ssh )
 
-if [[ $FAILED != 0 ]]; then
-  printf "
-       Please see above error output to determine which program(s) you may
-       need to install or expose into this environment's PATH. Aborting.\n" >&2
-  exit 1
-fi
+for binary in "${required_bins[@]}"; do
+	if ! [ -x "$(command -v $binary)" ]; then
+		printf "\n\nError: Necessary program '$binary' is not installed or available on your path.\nPlease fix by installing or correcting your PATH. Aborting now.\n\n" >&2
+		exit 1
+	fi
+done
 

--- a/bootstrap/vagrant_scripts/BOOT_GO.sh
+++ b/bootstrap/vagrant_scripts/BOOT_GO.sh
@@ -44,24 +44,24 @@ load_configs
 
 # Perform preflight checks to validate environment sanity as much as possible.
 echo "Performing preflight environment validation..."
-source "$REPO_ROOT"/bootstrap/shared/shared_validate_env.sh
+source "$REPO_ROOT"/bootstrap/shared/shared_validate_env.sh || exit 1
 
 # Test that Vagrant is really installed and of an appropriate version.
 echo "Checking VirtualBox and Vagrant..."
-source "$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_test.sh
+source "$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_test.sh || exit 1
 
 # Do prerequisite work prior to starting build, downloading files and
 # creating local directories. Proxy configuration is handled there as well.
 echo "Downloading necessary files to local cache..."
-source "$REPO_ROOT"/bootstrap/shared/shared_prereqs.sh
+source "$REPO_ROOT"/bootstrap/shared/shared_prereqs.sh || exit 1
 
 # Terminate existing BCPC VMs.
 echo "Shutting down and unregistering VMs from VirtualBox..."
-"$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_clean.sh
+"$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_clean.sh || exit 1
 
 # Create VMs in Vagrant and start them.
 echo "Starting local Vagrant cluster..."
-"$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_create.sh
+"$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_create.sh || exit 1
 
 # Install and configure Chef on all Vagrant hosts.
 echo "Installing and configuring Chef on all nodes..."

--- a/cookbooks/bcpc/files/default/apt-pkg-check-version
+++ b/cookbooks/bcpc/files/default/apt-pkg-check-version
@@ -2,19 +2,23 @@
 # A tool to check the available version of an apt package
 # Usage : apt-pkg-check-version <pkg> <version>
 #
-# where <pkg> is the name of the package and
-#       <version> is the minimum acceptable version
+# where <package> is the name of the package and
+#       <minversion> is the minimum acceptable version
 #
 # If the available version of the named package is less than the
 # specified minimum version, then return 1 (check failed).
 #
-PKG="$1"
-MINVERS="$2"
-VERS=`apt-cache madison $PKG | grep $PKG | head -1 | cut -f2 -d\| | cut -f1 -d-`
-if [ $(echo "$VERS >= $MINVERS" | bc -l ) ]; then
-    echo "$PKG is too old ($VERS)"
-    exit 1;
+package="$1"
+minversion="$2"
+
+while read -r _ _ version _; do 
+	dpkg --compare-versions "$version" gt "$newest" && newest=$version; 
+done < <(apt-cache madison "$package")
+
+if dpkg --compare-versions "$newest" ge "$minversion"; then
+	echo "$package version acceptable ($newest)"
+	exit 0;
 else
-    echo "$PKG version acceptable ($VERS)"
-    exit 0;
+	echo "$package is too old ($newest)"
+	exit 1;
 fi


### PR DESCRIPTION
Small fixes to add some error checking, exit codes, rewrote the checks for required binaries, apt package version comparison, pulling things closer to the bash style guide with regard to variable naming conventions and syntax. Merges clean with bloomberg/master at the time of this PR. 