### PR TITLE
Fix proxy tests on linux 

### DIFF
--- a/bootstrap/shared/shared_prereqs.sh
+++ b/bootstrap/shared/shared_prereqs.sh
@@ -44,7 +44,18 @@ vbox_url="http://download.virtualbox.org/virtualbox"
 # List of binary versions to download
 source "$REPO_ROOT/bootstrap/config/build_bins_versions.sh"
 
-curl_cmd() { curl -f --progress -L -H 'Accept-encoding: gzip,deflate' "$@"; }
+# This is obscure to prevent cert dir test each time
+if [[ -d "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]] && \
+  [[ -x "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]]; then
+  curl_cmd() {
+    curl -f --capath "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" --progress -L \
+      -H 'Accept-encoding: gzip,deflate' "$@"
+  }
+else
+  curl_cmd() {
+    curl -f --progress -L -H 'Accept-encoding: gzip,deflate' "$@"
+  }
+fi
 
 ####################################################################
 # download_file wraps the usual behavior of curling a remote URL to a local file
@@ -97,18 +108,23 @@ cleanup_and_download_cookbook() {
 ####################################################################
 # Clones a repo and attempts to pull updates if requested version does not exist
 clone_repo() {
-  repo_url="$1"
-  local_dir="$2"
-  version="$3"
+  local repo_url="$1"
+  local local_dir="$2"
+  local version="$3"
 
+  local git_args=
+  if [[ -d "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]] && \
+    [[ -x "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]]; then
+    git_args="-c http.sslCAPath=$BOOTSTRAP_ADDITIONAL_CACERTS_DIR"
+  fi
   if [[ -d "$BOOTSTRAP_CACHE_DIR/$local_dir/.git" ]]; then
     pushd "$BOOTSTRAP_CACHE_DIR/$local_dir"
     git log --pretty=format:'%H' | \
     grep -q "$version" || \
-    git pull
+    git $git_args pull
     popd
   else
-    git clone "$repo_url" "$BOOTSTRAP_CACHE_DIR/$local_dir"
+    git $git_args clone "$repo_url" "$BOOTSTRAP_CACHE_DIR/$local_dir"
   fi
 }
 

--- a/bootstrap/shared/shared_proxy_setup.sh
+++ b/bootstrap/shared/shared_proxy_setup.sh
@@ -3,6 +3,20 @@
 source "$REPO_ROOT"/bootstrap/shared/shared_functions.sh
 load_configs
 
+get(){
+  local timeout=10
+  local url="$1"
+
+  [[ -z "$url" ]] && return 1
+  local args="-s --connect-timeout $timeout"
+  # Add the certs for proxy test if available
+  if [[ -d "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]] && \
+      [[ -x "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]]; then
+    args+=" --capath $BOOTSTRAP_ADDITIONAL_CACERTS_DIR"
+  fi
+  curl $args "$url"
+}
+
 [ -n "$SHARED_PROXY_SETUP" ] || {
   REQUIRED_VARS=( BOOTSTRAP_HTTP_PROXY_URL BOOTSTRAP_HTTPS_PROXY_URL )
   check_for_envvars "${REQUIRED_VARS[@]}"
@@ -10,7 +24,7 @@ load_configs
   if [[ ! -z "$BOOTSTRAP_HTTP_PROXY_URL" ]]; then
     export http_proxy="${BOOTSTRAP_HTTP_PROXY_URL}"
 
-    curl -s --connect-timeout 10 http://www.google.com > /dev/null && true
+    get http://www.google.com > /dev/null && true
     if [[ $? != 0 ]]; then
       echo "Error: proxy $BOOTSTRAP_HTTP_PROXY_URL non-functional for HTTP requests" >&2
       exit 1
@@ -19,7 +33,7 @@ load_configs
 
   if [[ ! -z "$BOOTSTRAP_HTTPS_PROXY_URL" ]]; then
     export https_proxy="${BOOTSTRAP_HTTPS_PROXY_URL}"
-    curl -s --connect-timeout 10 https://github.com > /dev/null && true
+    get https://github.com > /dev/null && true
     if [[ $? != 0 ]]; then
       echo "Error: proxy $BOOTSTRAP_HTTPS_PROXY_URL non-functional for HTTPS requests" >&2
       exit 1


### PR DESCRIPTION
If building on linux (maybe Mac OS X as well?) behind a proxy, the build is likely to fail with something like

```
 ____   ____ ____   ____
| __ ) / ___|  _ \ / ___|
|  _ \| |   | |_) | |
| |_) | |___|  __/| |___
|____/ \____|_|    \____|

BCPC Vagrant BootstrapV2 0.2
--------------------------------------------
Bootstrapping local Vagrant environment...

Building a BCPC cluster of type converged

Performing preflight environment validation...
Checking VirtualBox and Vagrant...
Downloading necessary files to local cache...
Testing configured proxies...
Error: proxy http://intrusive.proxy.example.com:8082 non-functional for HTTPS requests
```

This fixes such that similar such output does not appear.