### PR TITLE
fix liberty-deprecated neutron options

### DIFF
--- a/cookbooks/bcpc/recipes/calico-compute.rb
+++ b/cookbooks/bcpc/recipes/calico-compute.rb
@@ -22,6 +22,7 @@ return unless node['bcpc']['enabled']['neutron']
 include_recipe 'bcpc::etcd-common'
 include_recipe 'bcpc::bird-compute'
 include_recipe 'bcpc::packages-calico'
+include_recipe 'bcpc::neutron-common'
 
 file '/etc/init/neutron-dhcp-agent.override' do
   content 'manual'

--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -63,7 +63,7 @@ end
 # Configure the glance keystone bits
 # https://docs.openstack.org/mitaka/install-guide-ubuntu/glance-install.html
 domain = node['bcpc']['keystone']['service_project']['domain']
-glance_username = 'glance'
+glance_username = node['bcpc']['glance']['user']
 glance_project_name = node['bcpc']['keystone']['service_project']['name']
 admin_role_name = node['bcpc']['keystone']['admin_role']
 

--- a/cookbooks/bcpc/recipes/neutron-common.rb
+++ b/cookbooks/bcpc/recipes/neutron-common.rb
@@ -26,6 +26,7 @@ ruby_block "initialize-neutron-config" do
     make_config('mysql-neutron-user', "neutron")
     make_config('mysql-neutron-password', secure_password)
     make_config('keystone-neutron-password', secure_password)
+    make_config('neutron-metadata-proxy-shared-secret', secure_password)
   end
 end
 

--- a/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/cookbooks/bcpc/recipes/neutron-head.rb
@@ -55,6 +55,7 @@ end
 domain = node['bcpc']['keystone']['service_project']['domain']
 neutron_username = node['bcpc']['neutron']['user']
 neutron_project_name = node['bcpc']['keystone']['service_project']['name']
+admin_role_name = node['bcpc']['keystone']['admin_role']
 
 ruby_block 'keystone-create-neutron-user' do
   block do

--- a/cookbooks/bcpc/recipes/nova-common.rb
+++ b/cookbooks/bcpc/recipes/nova-common.rb
@@ -19,6 +19,7 @@
 require 'ipaddr'
 
 include_recipe "bcpc::openstack"
+include_recipe "bcpc::neutron-common"
 
 ruby_block "initialize-nova-config" do
     block do

--- a/cookbooks/bcpc/templates/default/neutron/neutron.metadata_agent.ini.erb
+++ b/cookbooks/bcpc/templates/default/neutron/neutron.metadata_agent.ini.erb
@@ -42,7 +42,7 @@ nova_metadata_ip = <%= node['bcpc']['management']['ip'] %>
 # shared secret to prevent spoofing.  You may select any string for a secret,
 # but it must match here and in the configuration used by the Nova Metadata
 # Server. NOTE: Nova uses the same config key, but in [neutron] section.
-# metadata_proxy_shared_secret =
+metadata_proxy_shared_secret = <%= get_config('neutron-metadata-proxy-shared-secret') %>
 
 # Location of Metadata Proxy UNIX domain socket
 # metadata_proxy_socket = $state_path/metadata_proxy

--- a/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -106,11 +106,12 @@ vif_plugging_timeout = 0
 
 [neutron]
 url = <%= node['bcpc']['protocol']['neutron'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:9696
-admin_tenant_name = <%= node['bcpc']['keystone']['admin']['project_name'] %>
-auth_strategy = keystone
-admin_auth_url = <%= node['bcpc']['protocol']['keystone'] %>://openstack.<%= node['bcpc']['cluster_domain'] %>:35357/v2.0/
-admin_username = <%= get_config('keystone-admin-user') %>
-admin_password = <%= get_config('keystone-admin-password') %>
+<% snippet = 'keystone/keystone_authtoken.snippet.erb' %>
+<%# add the node for chef nonsense... see https://github.com/chef/chef/issues/1506 %>
+<% vars = @partials[snippet]['variables'].merge({node: @node}) %>
+<%= render snippet, :variables => vars %>
+service_metadata_proxy = True
+metadata_proxy_shared_secret = <%= get_config('neutron-metadata-proxy-shared-secret') %>
 <% else %>
 network_manager=nova.network.manager.VlanManager
 firewall_driver=nova.virt.libvirt.firewall.IptablesFirewallDriver


### PR DESCRIPTION
Neutron is currently broken on master, this fixes it by using mitaka options.