### PR TITLE
Declarative hosts config for Vagrant build

### DIFF
--- a/bootstrap/config/bootstrap_config.sh.defaults
+++ b/bootstrap/config/bootstrap_config.sh.defaults
@@ -7,7 +7,7 @@
 ##############################################
 
 # Sets the cluster configuration to load
-export CLUSTER=multihead
+export CLUSTER=singlehead
 
 # Sets the amount of memory (in MB) given to the bootstrap VM.
 export BOOTSTRAP_VM_MEM=2048

--- a/bootstrap/config/bootstrap_config.sh.defaults
+++ b/bootstrap/config/bootstrap_config.sh.defaults
@@ -6,6 +6,9 @@
 # USED BY BOTH ANSIBLE AND VAGRANT BUILD PATHS
 ##############################################
 
+# Sets the cluster configuration to load
+export CLUSTER=multihead
+
 # Sets the amount of memory (in MB) given to the bootstrap VM.
 export BOOTSTRAP_VM_MEM=2048
 

--- a/bootstrap/config/singlehead.json
+++ b/bootstrap/config/singlehead.json
@@ -1,0 +1,20 @@
+{
+  "cluster_name": "Test-Laptop-Vagrant",
+  "nodes": {
+    "bcpc-dev-bootstrap": {
+      "ip_address": "10.0.100.3",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Bootstrap"
+    },
+    "bcpc-dev-r1n1": {
+      "ip_address": "10.0.100.11",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Headnode"
+    },
+    "bcpc-dev-r1n2": {
+      "ip_address": "10.0.100.12",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Worknode"
+    }
+  }
+}

--- a/bootstrap/shared/shared_build_bins.sh
+++ b/bootstrap/shared/shared_build_bins.sh
@@ -30,7 +30,7 @@ if [[ -d "$BUILD_CACHE_DIR" ]]; then
 fi
 
 # Install tools needed for packaging
-apt-get -y install git ruby-dev make pbuilder python-mock python-configobj python-support cdbs python-all-dev python-stdeb libmysqlclient-dev libldap2-dev libxml2-dev libxslt1-dev libpq-dev build-essential libssl-dev libffi-dev python-dev python-pip
+apt-get -y install git ruby-dev make pbuilder python-mock python-configobj python-support cdbs python-all-dev python-stdeb libmysqlclient-dev libldap2-dev libxml2-dev libxslt1-dev libpq-dev build-essential libssl-dev libffi-dev python-dev python-pip jq
 
 # install fpm and support gems
 if [[ -z "$(gem list --local fpm | awk '/fpm/ {print $1}')" ]]; then

--- a/bootstrap/shared/shared_configure_chef.sh
+++ b/bootstrap/shared/shared_configure_chef.sh
@@ -4,9 +4,10 @@ set -e
 
 . "$REPO_ROOT/bootstrap/shared/shared_functions.sh"
 
-REQUIRED_VARS=( BOOTSTRAP_CHEF_DO_CONVERGE BOOTSTRAP_CHEF_ENV BCPC_HYPERVISOR_DOMAIN FILECACHE_MOUNT_POINT REPO_MOUNT_POINT REPO_ROOT )
+REQUIRED_VARS=( BOOTSTRAP_CHEF_DO_CONVERGE BOOTSTRAP_CHEF_ENV BCPC_HYPERVISOR_DOMAIN FILECACHE_MOUNT_POINT REPO_MOUNT_POINT REPO_ROOT CLUSTER )
 check_for_envvars "${REQUIRED_VARS[@]}"
 
+CLUSTER_CONFIG="$REPO_ROOT/bootstrap/config/$CLUSTER.json"
 # This script does a lot of stuff:
 # - installs Chef Server on the bootstrap node
 # - installs Chef client on all nodes
@@ -37,14 +38,9 @@ else
 fi
 unset debpath
 
-# Remove configuration management software that might be preinstalled in the box
-echo "Removing pre-installed Puppet and Chef..."
-
-do_on_node vm-bootstrap "sudo dpkg -P puppet chef"
-
 echo "Installing Chef server..."
 
-do_on_node vm-bootstrap "$CHEF_SERVER_INSTALL_CMD \
+do_on_node bootstrap "$CHEF_SERVER_INSTALL_CMD \
   && sudo sh -c \"echo nginx[\'non_ssl_port\'] = 4000 > /etc/opscode/chef-server.rb\" \
   && sudo chef-server-ctl reconfigure \
   && sudo chef-server-ctl user-create admin admin admin admin@localhost.com welcome --filename /etc/opscode/admin.pem \
@@ -55,22 +51,14 @@ do_on_node vm-bootstrap "$CHEF_SERVER_INSTALL_CMD \
 # configure knife on the bootstrap node and perform a knife bootstrap to create the bootstrap node in Chef
 echo "Configuring Knife on bootstrap node..."
 
-do_on_node vm-bootstrap "mkdir -p \$HOME/.chef && echo -e \"chef_server_url 'https://bcpc-vm-bootstrap.$BCPC_HYPERVISOR_DOMAIN/organizations/bcpc'\\\nvalidation_client_name 'bcpc-validator'\\\nvalidation_key '/etc/opscode/bcpc-validator.pem'\\\nnode_name 'admin'\\\nclient_key '/etc/opscode/admin.pem'\\\nknife['editor'] = 'vim'\\\ncookbook_path [ \\\"#{ENV['HOME']}/chef-bcpc/cookbooks\\\" ]\" > \$HOME/.chef/knife.rb \
-  && $KNIFE ssl fetch \
-  && $KNIFE bootstrap -x vagrant -P vagrant --sudo 10.0.100.3"
-
-# Initialize VM lists
-vms="vm1 vm2 vm3"
-for ((i=1; i <= MONITORING_NODES; i++)); do
-    mon_vm="vm$((3 + i))"
-    mon_vms="$mon_vms $mon_vm"
-done
+do_on_node bootstrap "mkdir -p \$HOME/.chef && echo -e \"chef_server_url 'https://bcpc-dev-bootstrap.$BCPC_HYPERVISOR_DOMAIN/organizations/bcpc'\\\nvalidation_client_name 'bcpc-validator'\\\nvalidation_key '/etc/opscode/bcpc-validator.pem'\\\nnode_name 'admin'\\\nclient_key '/etc/opscode/admin.pem'\\\nknife['editor'] = 'vim'\\\ncookbook_path [ \\\"#{ENV['HOME']}/chef-bcpc/cookbooks\\\" ]\" > \$HOME/.chef/knife.rb \
+  && $KNIFE ssl fetch"
 
 # install the knife-acl plugin into embedded knife, rsync the Chef repository into the non-root user
 # (vagrant)'s home directory, and add the dependency cookbooks from the file cache
 echo "Installing knife-acl plugin..."
 
-do_on_node vm-bootstrap "sudo /opt/opscode/embedded/bin/gem install -l $FILECACHE_MOUNT_POINT/knife-acl-1.0.2.gem \
+do_on_node bootstrap "sudo /opt/opscode/embedded/bin/gem install -l $FILECACHE_MOUNT_POINT/knife-acl-1.0.2.gem \
   && rsync -a $REPO_MOUNT_POINT/* \$HOME/chef-bcpc \
   && cp $FILECACHE_MOUNT_POINT/cookbooks/*.tar.gz \$HOME/chef-bcpc/cookbooks \
   && cd \$HOME/chef-bcpc/cookbooks && ls -1 *.tar.gz | xargs -I% tar xvzf %"
@@ -79,7 +67,7 @@ do_on_node vm-bootstrap "sudo /opt/opscode/embedded/bin/gem install -l $FILECACH
 # (this step will change later but using the existing build_bins script for now)
 echo "Building binaries..."
 
-do_on_node vm-bootstrap "sudo apt-get update \
+do_on_node bootstrap "sudo apt-get update \
   && sudo apt-get -y autoremove \
   && cd \$HOME/chef-bcpc \
   && sudo bash -c 'export FILECACHE_MOUNT_POINT=$FILECACHE_MOUNT_POINT \
@@ -87,15 +75,15 @@ do_on_node vm-bootstrap "sudo apt-get update \
 
 # upload all cookbooks, roles and our chosen environment to the Chef server
 # (cookbook upload uses the cookbook_path set when configuring knife on the bootstrap node)
-do_on_node vm-bootstrap "$KNIFE cookbook upload -a \
+do_on_node bootstrap "$KNIFE cookbook upload -a \
   && cd \$HOME/chef-bcpc/roles && $KNIFE role from file *.json \
   && cd \$HOME/chef-bcpc/environments && $KNIFE environment from file $BOOTSTRAP_CHEF_ENV.json"
 
 # install and bootstrap Chef on cluster nodes
 echo "Installing Chef client on cluster nodes..."
 
-i=1
-for vm in $vms $mon_vms; do
+vms="`cat $CLUSTER_CONFIG | egrep -o bcpc-dev-[a-z0-9]+ | sed 's/bcpc-dev-//g'`"
+for vm in $vms; do
   # Remove configuration management software that might be preinstalled in the box
   do_on_node "$vm" "sudo dpkg -P puppet chef"
   # Try to install a specific version, or just the latest
@@ -103,92 +91,9 @@ for vm in $vms $mon_vms; do
     echo "Installing latest chef-client found in $vm:$FILECACHE_MOUNT_POINT"
   fi
   do_on_node "$vm" "$CHEF_CLIENT_INSTALL_CMD"
-  do_on_node vm-bootstrap "$KNIFE bootstrap -x vagrant -P vagrant --sudo 10.0.100.1${i}"
-  ((i+=1))
 done
 
-# augment the previously configured nodes with our newly uploaded environments and roles
-ENVIRONMENT_SET=""
-for vm in vm-bootstrap $vms $mon_vms; do
-  ENVIRONMENT_SET="$ENVIRONMENT_SET $KNIFE node environment set bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN $BOOTSTRAP_CHEF_ENV && "
-done
-ENVIRONMENT_SET="$ENVIRONMENT_SET :"
-
-echo "Setting Chef environment and roles on cluster nodes..."
-
-do_on_node vm-bootstrap "$ENVIRONMENT_SET"
-
-if [[ $CLUSTER_TYPE == 'converged' ]]; then
-  do_on_node vm-bootstrap "$KNIFE node run_list set bcpc-vm-bootstrap.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Bootstrap],recipe[bcpc::bird-false-tor]' \
-    && $KNIFE node run_list set bcpc-vm1.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Headnode]' \
-    && $KNIFE node run_list set bcpc-vm2.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Worknode]' \
-    && $KNIFE node run_list set bcpc-vm3.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Worknode]'"
-elif [[ $CLUSTER_TYPE = 'storage' ]]; then
-  do_on_node vm-bootstrap "$KNIFE node run_list set bcpc-vm-bootstrap.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-Bootstrap]' \
-    && $KNIFE node run_list set bcpc-vm1.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-CephMonitorNode]' \
-    && $KNIFE node run_list set bcpc-vm2.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-CephOSDNode]' \
-    && $KNIFE node run_list set bcpc-vm3.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Hardware-Virtual],role[BCPC-CephOSDNode]'"
-fi
-
-# set bootstrap, vm1 and mon vms (if any) as admins so that they can write into the data bag
-ADMIN_SET="true && "
-for vm in vm-bootstrap vm1 $mon_vms; do
-  ADMIN_SET="$ADMIN_SET $KNIFE group add client bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN admins && "
-done
-ADMIN_SET="$ADMIN_SET :"
-
-echo "Setting admin privileges for head and monitoring nodes..."
-
-do_on_node vm-bootstrap "$ADMIN_SET"
-
-# Clustered monitoring setup (>1 mon VM) requires completely initialized node attributes for chef to run
-# on each node successfully. If we are not converging automatically, set run_list (for mon VMs) and exit.
-# Otherwise, each mon VM needs to complete chef run first before setting the next node's run_list.
-if [[ $BOOTSTRAP_CHEF_DO_CONVERGE -eq 0 ]]; then
-  for vm in $mon_vms; do
-    do_on_node vm-bootstrap "$KNIFE node run_list set bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Monitoring]'"
-  done
-  echo "BOOTSTRAP_CHEF_DO_CONVERGE is set to 0, skipping automatic convergence."
-  exit 0
-else
-  echo "Cheffing cluster nodes..."
-  # run Chef on each node
-  do_on_node vm-bootstrap "sudo chef-client"
-  for vm in $vms; do
-    do_on_node "$vm" "sudo chef-client"
-  done
-  # run on head node one last time to update HAProxy with work node IPs
-  do_on_node vm1 "sudo chef-client"
-  # run on bootstrap node again if it needs to be configured as a false TOR for Neutron+Calico
-  do_on_node vm-bootstrap "sudo chef-client"
-  # HUP OpenStack services on each node to ensure everything's in a working state if converged
-  if [[ $CLUSTER_TYPE == 'converged' ]]; then
-    for vm in $vms; do
-      do_on_node "$vm" "sudo hup_openstack || true"
-    done
-  fi
-  # Run chef on each mon VM before assigning next node for monitoring.
-  for vm in $mon_vms; do
-    do_on_node vm-bootstrap "$KNIFE node run_list set bcpc-$vm.$BCPC_HYPERVISOR_DOMAIN 'role[BCPC-Monitoring]'"
-    do_on_node "$vm" "sudo chef-client"
-  done
-  # Run chef on each mon VM except the last node to update cluster components
-  for vm in $(echo "$mon_vms" | awk '{$NF=""}1'); do
-    do_on_node "$vm" "sudo chef-client"
-  done
-
-  if [ "$VERIFY_CLUSTER" = "1" ]; then
-    # Do rally setup at the end without polluting the main run lists
-    # also this will make sure the cluster is fully provisioned and ready for sanity checks
-    do_on_node vm-bootstrap "sudo chef-client -o bcpc::rally,bcpc::rally-deployments"
-    if [ -z "$RALLY_SCENARIOS_DIR" ]; then
-      echo "Not copying RALLY scenario files, set RALLY_SCENARIOS_DIR pointing to your custom rally scenarios repo"
-    else
-      OPTIONS=$(vagrant ssh-config vm-bootstrap | awk -v ORS=' ' 'NF && !/Host / {print "-o " $1 "=" $2}')
-      # Remove / at the end
-      RALLY_SCENARIOS_DIR="${RALLY_SCENARIOS_DIR%/}"
-      rsync -avz --delete --exclude=.git -e "ssh $OPTIONS" "$RALLY_SCENARIOS_DIR" vm-bootstrap:rally
-      do_on_node vm-bootstrap "sudo chef-client -o bcpc::rally-run"
-    fi
-  fi
-fi
+# Configure Chef clients/nodes
+do_on_node bootstrap "cd $REPO_MOUNT_POINT \
+  && sudo bash -c 'export REPO_MOUNT_POINT=$REPO_MOUNT_POINT \
+  && bootstrap/shared/shared_configure_chef_clients.sh'"

--- a/bootstrap/shared/shared_configure_chef.sh
+++ b/bootstrap/shared/shared_configure_chef.sh
@@ -97,3 +97,8 @@ done
 do_on_node bootstrap "cd $REPO_MOUNT_POINT \
   && sudo bash -c 'export REPO_MOUNT_POINT=$REPO_MOUNT_POINT \
   && bootstrap/shared/shared_configure_chef_clients.sh'"
+
+# Run chef-client on nodes if we want auto-convergence
+if [[ $BOOTSTRAP_CHEF_DO_CONVERGE -eq 1 ]]; then
+  "$REPO_ROOT"/bootstrap/shared/shared_converge_chef.sh
+fi

--- a/bootstrap/shared/shared_configure_chef_clients.sh
+++ b/bootstrap/shared/shared_configure_chef_clients.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Exit immediately if anything goes wrong, instead of making things worse.
+set -e
+
+source "$REPO_MOUNT_POINT/bootstrap/shared/shared_functions.sh"
+load_configs
+REQUIRED_VARS=( BOOTSTRAP_CHEF_ENV BCPC_HYPERVISOR_DOMAIN CLUSTER )
+check_for_envvars "${REQUIRED_VARS[@]}"
+
+CLUSTER_CONFIG="$REPO_MOUNT_POINT/bootstrap/config/$CLUSTER.json"
+
+# use Chef Server embedded knife instead of the one in /usr/bin
+KNIFE=/opt/opscode/embedded/bin/knife
+
+# Bootstrap chef client
+vm_ips="`cat $CLUSTER_CONFIG | jq -r '.nodes | .[] | .ip_address'`"
+for ip in $vm_ips; do
+  $KNIFE bootstrap -x vagrant -P vagrant --sudo $ip
+done
+
+# Set Chef environment, run lists and admin privileges
+vms="`cat $CLUSTER_CONFIG | jq -r '.nodes | keys | .[]'`"
+for vm in $vms; do
+  $KNIFE node environment set $vm.$BCPC_HYPERVISOR_DOMAIN $BOOTSTRAP_CHEF_ENV
+  chef_role=`cat $CLUSTER_CONFIG | jq -r ".nodes | to_entries[] | select(.key == \"$vm\") | .value.chef_role"`
+  $KNIFE node run_list set $vm.$BCPC_HYPERVISOR_DOMAIN "role[BCPC-Hardware-Virtual],role[$chef_role]"
+  if [ "$chef_role" == 'BCPC-Bootstrap' ] || \
+     [ "$chef_role" == 'BCPC-Headnode' ] || \
+     [ "$chef_role" == 'BCPC-CephMonitorNode' ] || \
+     [ "$chef_role" == 'BCPC-Monitoring' ]
+  then
+    $KNIFE group add client $vm.$BCPC_HYPERVISOR_DOMAIN admins
+  fi
+done

--- a/bootstrap/shared/shared_converge_chef.sh
+++ b/bootstrap/shared/shared_converge_chef.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Exit immediately if anything goes wrong, instead of making things worse.
+set -e
+
+source "$REPO_ROOT/bootstrap/shared/shared_functions.sh"
+load_configs
+REQUIRED_VARS=( BOOTSTRAP_CHEF_ENV BCPC_HYPERVISOR_DOMAIN CLUSTER )
+check_for_envvars "${REQUIRED_VARS[@]}"
+
+CLUSTER_CONFIG="$REPO_ROOT/bootstrap/config/$CLUSTER.json"
+
+# Run chef-client on nodes, twice
+do_on_node bootstrap "sudo chef-client"
+vms="`cat $CLUSTER_CONFIG | jq -r '.nodes | to_entries[] | select(.value.chef_role != \"BCPC-Bootstrap\") | .key' | awk -F'-' '{print $NF}'`"
+for i in `seq 1 2`; do
+  for vm in $vms; do
+    do_on_node $vm "sudo chef-client"
+  done
+done

--- a/bootstrap/vagrant_scripts/BOOT_GO.sh
+++ b/bootstrap/vagrant_scripts/BOOT_GO.sh
@@ -17,24 +17,6 @@ echo "BCPC Vagrant BootstrapV2 0.2"
 echo "--------------------------------------------"
 echo "Bootstrapping local Vagrant environment..."
 
-
-while getopts "vs" opt; do
-  case $opt in
-    # verbose
-    v)
-      set -x
-      ;;
-    # build a storage cluster instead of converged
-    s)
-      export CLUSTER_TYPE=storage
-      ;;
-  esac
-done
-
-echo
-echo "Building a BCPC cluster of type $CLUSTER_TYPE"
-echo
-
 # Source common bootstrap functions. This is the only place that uses a
 # relative path; everything henceforth must use $REPO_ROOT.
 source ../shared/shared_functions.sh
@@ -65,7 +47,7 @@ echo "Starting local Vagrant cluster..."
 
 # Install and configure Chef on all Vagrant hosts.
 echo "Installing and configuring Chef on all nodes..."
-"$REPO_ROOT"/bootstrap/shared/shared_configure_chef.sh $CLUSTER_TYPE
+"$REPO_ROOT"/bootstrap/shared/shared_configure_chef.sh
 
 # Dump out OpenStack information for users if a converged cluster
 if [[ $CLUSTER_TYPE == 'converged' ]]; then

--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -4,6 +4,7 @@
 
 require 'openssl' # used to validate CA certificates
 require 'uri' # used to parse the local mirror if one is given
+require 'json' # used to parse cluster machines configuration
 
 Vagrant.require_version ">= 1.7.0"
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
@@ -176,36 +177,40 @@ $add_swap_script = <<-EOH
 EOH
 
 Vagrant.configure("2") do |config|
-  # build list of all machines to provision at once
-  cluster_nodes = 3
-  monitoring_node_count = ENV['MONITORING_NODES'].to_i
-  # nil.to_i is 0, so no need to check for nil explicitly
-  unless monitoring_node_count == 0
-    if (1..3).include? monitoring_node_count
-      cluster_nodes += monitoring_node_count
-    else
-      fail "Invalid number of monitoring nodes specified (1-3 allowed)"
-    end
-  end
-  # ENV['CLUSTER_NODE_COUNT_OVERRIDE'] is a safety valve used by vagrant_clean.sh
-  # to always clean up the maximal count of VMs (e.g., try to clean monitoring
-  # nodes even if the script isn't sure any were made)
-  if ENV['CLUSTER_NODE_COUNT_OVERRIDE'].to_i > 0
-    cluster_nodes = ENV['CLUSTER_NODE_COUNT_OVERRIDE'].to_i
-    # puts "Cluster node count is being overridden to #{cluster_nodes} via CLUSTER_NODE_COUNT_OVERRIDE"
-  end
+  cluster_config = File.join(config_path, ENV['CLUSTER'] + '.json')
+  cluster = JSON.parse(File.read(cluster_config))
+  bootstrap_node = cluster['nodes']['bcpc-dev-bootstrap']['ip_address']
 
-  vms_to_build = ['vm-bootstrap', (1..cluster_nodes).collect {|x| "vm#{x}"}].flatten
-
-  vms_to_build.each_with_index do |vm, idx|
+  cluster['nodes'].each do |node, key|
+    vm = node
+    # Remove name prefix for shorter Vagrant hostnames
+    vm = vm.sub('bcpc-dev-', '')
+    config.ssh.forward_x11 = true
     config.vm.define vm do |m|
-      # use .3 as the final octet for the bootstrap node, otherwise 11, 12, etc.
-      final_octet = (vm == 'vm-bootstrap' ? 3 : 10+idx)
       bootstrap_domain = (ENV['BCPC_HYPERVISOR_DOMAIN'] or "bcpc.example.com")
-      m.vm.hostname = "bcpc-#{vm}.#{bootstrap_domain}"
-      m.vm.network :private_network, ip: "10.0.100.#{final_octet}", netmask: "255.255.255.0", adapter_ip: "10.0.100.2"
-      m.vm.network :private_network, ip: "172.16.100.#{final_octet}", netmask: "255.255.255.0", adapter_ip: "172.16.100.2"
-      m.vm.network :private_network, ip: "192.168.100.#{final_octet}", netmask: "255.255.255.0", adapter_ip: "192.168.100.2"
+      m.vm.hostname = "bcpc-dev-#{vm}.#{bootstrap_domain}"
+      m.vm.network :private_network,
+                   virtualbox__intnet: 'management',
+                   ip: cluster['nodes'][node]['ip_address'],
+                   netmask: '255.255.255.240'
+      ['storage', 'tenant'].each do |network|
+        m.vm.network :private_network,
+                     virtualbox__intnet: network,
+                     auto_config: false
+      end
+
+      # reconfigure eth0 as static to remove default route via Virtualbox NAT
+      config.vm.provision "delete-default-gw-on-eth0", type: "shell",
+        run: "always",
+        path: 'reconfigure-eth0-on-vms.sh',
+        privileged: true
+
+      # add temporary default router to faciliate convergence without virtual
+      # router
+      config.vm.provision "add-default-gw", type: "shell",
+        run: "always",
+        inline: "route add default gw #{cluster['nodes'][node]['gateway']}"
+
       if ENV['REPO_ROOT'].nil? or ENV['REPO_MOUNT_POINT'].nil?
         fail "REPO_ROOT and REPO_MOUNT_POINT must be set in the environment."
       end
@@ -244,7 +249,7 @@ Vagrant.configure("2") do |config|
 
       # from bootstrap node only: test proxy servers from inside to determine whether
       # everything's set up properly
-      if vm == 'vm-bootstrap'
+      if vm == 'bootstrap'
         m.vm.provision "testing-proxy-servers", type: "shell" do |s|
           s.privileged = false
           s.inline = $testing_proxy_servers_script
@@ -258,7 +263,7 @@ Vagrant.configure("2") do |config|
 
       # configure a hostfile entry with the IP of the bootstrap node (for Chef)
       m.vm.provision "configure-bootstrap-hostfile-entry", type: "shell" do |s|
-        s.inline = "echo -e '10.0.100.3\tbcpc-vm-bootstrap.#{bootstrap_domain}\n' >> /etc/hosts"
+        s.inline = "echo -e '#{bootstrap_node}\tbcpc-dev-bootstrap.#{bootstrap_domain}\n' >> /etc/hosts"
       end
 
       # clean up some packages installed in this image by default
@@ -274,7 +279,7 @@ Vagrant.configure("2") do |config|
       m.vm.box = "trusty64"
       m.vm.box_url = "#{ENV['BOOTSTRAP_CACHE_DIR']}/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
-      if vm == 'vm-bootstrap'
+      if vm == 'bootstrap'
         memory = ( ENV["BOOTSTRAP_VM_MEM"] or "2048" )
         cpus = ( ENV["BOOTSTRAP_VM_CPUS"] or "2" )
       else
@@ -284,7 +289,7 @@ Vagrant.configure("2") do |config|
       end
 
       m.vm.provider :virtualbox do |vb|
-        vb.name = "bcpc-#{vm}"
+        vb.name = node
         vb.memory = memory
         vb.cpus = cpus
 
@@ -310,7 +315,7 @@ Vagrant.configure("2") do |config|
           fail "Unable to locate VM #{vm} on disk, terminating"
         end
 
-        if idx.zero?
+        if vm == 'bootstrap'
           # on the bootstrap node these disks are not used by pure Vagrant, but will be used by Ansible scripts
           # sdb is /mnt and sdc is /bcpc
           disks = {'b' => ( ENV["BOOTSTRAP_VM_DRIVE_SIZE"] or "20480" ), 'c' => 204800}

--- a/bootstrap/vagrant_scripts/reconfigure-eth0-on-vms.sh
+++ b/bootstrap/vagrant_scripts/reconfigure-eth0-on-vms.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+ETH0="# The primary network interface
+auto eth0
+iface eth0 inet static
+  address 10.0.2.15
+  netmask 255.255.255.0
+"
+
+echo "$ETH0" > /etc/network/interfaces.d/eth0.cfg
+ifdown eth0 && ifup eth0 && killall -TERM dhclient

--- a/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
+++ b/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
@@ -11,9 +11,9 @@ cd "$REPO_ROOT"/bootstrap/vagrant_scripts
 
 KNIFE=/opt/opscode/embedded/bin/knife
 # Dump the data bag contents to a variable.
-DATA_BAG=$(vagrant ssh vm-bootstrap -c "$KNIFE data bag show configs $BOOTSTRAP_CHEF_ENV -F yaml")
+DATA_BAG=$(vagrant ssh bootstrap -c "$KNIFE data bag show configs $BOOTSTRAP_CHEF_ENV -F yaml")
 # Get the management VIP.
-MANAGEMENT_VIP=$(vagrant ssh vm-bootstrap -c "$KNIFE environment show $BOOTSTRAP_CHEF_ENV -a override_attributes.bcpc.management.vip | tail -n +2 | awk '{ print \$2 }'")
+MANAGEMENT_VIP=$(vagrant ssh bootstrap -c "$KNIFE environment show $BOOTSTRAP_CHEF_ENV -a override_attributes.bcpc.management.vip | tail -n +2 | awk '{ print \$2 }'")
 
 # this is highly naive for obvious reasons (will break on multi-line keys, spaces)
 # but is sufficient for the items to be extracted here

--- a/cookbooks/bcpc/recipes/networking.rb
+++ b/cookbooks/bcpc/recipes/networking.rb
@@ -103,7 +103,7 @@ bash "setup-interfaces-source" do
     code <<-EOH
         echo "source /etc/network/interfaces.d/iface-*" >> /etc/network/interfaces
     EOH
-    not_if "grep '^source /etc/network/interfaces.d/' /etc/network/interfaces"
+    not_if "grep '^source /etc/network/interfaces.d/iface-' /etc/network/interfaces"
 end
 
 [['management', 100], ['storage', 300]].each do |net, metric|

--- a/cookbooks/bcpc/recipes/networking_functions.rb
+++ b/cookbooks/bcpc/recipes/networking_functions.rb
@@ -1,0 +1,75 @@
+#
+# Cookbook Name:: bcpc
+# Recipe:: networking_functions
+#
+# Copyright 2017, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+bash 'routing-management' do
+  user 'root'
+  code "echo '1 mgmt' >> /etc/iproute2/rt_tables"
+  not_if "grep -e '^1 mgmt' /etc/iproute2/rt_tables"
+end
+
+bash 'routing-storage' do
+  user 'root'
+  code "echo '2 storage' >> /etc/iproute2/rt_tables"
+  not_if "grep -e '^2 storage' /etc/iproute2/rt_tables"
+end
+
+if node['bcpc']['monitoring']['provider']
+  function = 'ipset-monitoring'
+  # ipset is used to maintain largish block(s) of IP addresses to be referred
+  # to by iptables
+  package 'ipset'
+
+  # Insert numbering so it runs before /etc/network/if-up.d/bcpc-firewall
+  template "/etc/network/if-up.d/001bcpc-#{function}" do
+    mode 775
+    source "bcpc-#{function}.erb"
+    notifies :run, "execute[run-#{function}-script]", :delayed
+  end
+
+  template "/etc/#{function}-clients.conf" do
+    mode 600
+    source "#{function}-clients.conf.erb"
+    variables(
+      :clients => node['bcpc']['monitoring']['external_clients'].sort
+    )
+    notifies :run, "execute[run-#{function}-script]", :immediately
+  end
+
+  execute "run-#{function}-script" do
+    action :nothing
+    command "/etc/network/if-up.d/001bcpc-#{function}"
+  end
+
+end
+
+network_functions = ['firewall']
+network_functions += ['routing'] unless node['bcpc']['enabled']['neutron']
+
+network_functions.each do |function|
+  template "/etc/network/if-up.d/bcpc-#{function}" do
+    mode 775
+    source "bcpc-#{function}.erb"
+    notifies :run, "execute[run-#{function}-script-once]", :immediately
+  end
+
+  execute "run-#{function}-script-once" do
+    action :nothing
+    command "/etc/network/if-up.d/bcpc-#{function}"
+  end
+end

--- a/roles/BCPC-Bootstrap.json
+++ b/roles/BCPC-Bootstrap.json
@@ -5,6 +5,7 @@
     "json_class": "Chef::Role",
     "run_list": [
       "role[Basic]",
+      "recipe[bcpc::networking]",
       "recipe[bcpc::certs]",
       "recipe[bcpc::cobbler]",
       "recipe[bcpc::bootstrap]",


### PR DESCRIPTION
The current Vagrantfile is not sufficiently flexible to produce clusters of non-default sizes and architecture (i.e. multi-head). While there may be potential for further normalization of the project's build processes, this step provides an intermediate step to facilitate quicker iterations for developing chef-bcpc v8. The success criteria here is being able to produce a 3 VM build with all nodes enrolled into Chef server. 
```
$ ./BOOT_GO.sh
...
bcpc-dev-bootstrap.hypervisor-bcpc.example.com:
  chef_environment: Test-Laptop-Vagrant
bcpc-dev-bootstrap.hypervisor-bcpc.example.com:
  run_list:
    role[BCPC-Hardware-Virtual]
    role[BCPC-Bootstrap]
Adding 'bcpc-dev-bootstrap.hypervisor-bcpc.example.com' to 'admins' group
bcpc-dev-r1n1.hypervisor-bcpc.example.com:
  chef_environment: Test-Laptop-Vagrant
bcpc-dev-r1n1.hypervisor-bcpc.example.com:
  run_list:
    role[BCPC-Hardware-Virtual]
    role[BCPC-Headnode]
Adding 'bcpc-dev-r1n1.hypervisor-bcpc.example.com' to 'admins' group
bcpc-dev-r1n2.hypervisor-bcpc.example.com:
  chef_environment: Test-Laptop-Vagrant
bcpc-dev-r1n2.hypervisor-bcpc.example.com:
  run_list:
    role[BCPC-Hardware-Virtual]
    role[BCPC-Worknode]
```
This is expected to break some functionality, hence this is a PR against the unstable branch.
