### PR TITLE
Revert "Fix proxy tests on linux "

### DIFF
--- a/bootstrap/shared/shared_prereqs.sh
+++ b/bootstrap/shared/shared_prereqs.sh
@@ -44,18 +44,7 @@ vbox_url="http://download.virtualbox.org/virtualbox"
 # List of binary versions to download
 source "$REPO_ROOT/bootstrap/config/build_bins_versions.sh"
 
-# This is obscure to prevent cert dir test each time
-if [[ -d "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]] && \
-  [[ -x "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]]; then
-  curl_cmd() {
-    curl -f --capath "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" --progress -L \
-      -H 'Accept-encoding: gzip,deflate' "$@"
-  }
-else
-  curl_cmd() {
-    curl -f --progress -L -H 'Accept-encoding: gzip,deflate' "$@"
-  }
-fi
+curl_cmd() { curl -f --progress -L -H 'Accept-encoding: gzip,deflate' "$@"; }
 
 ####################################################################
 # download_file wraps the usual behavior of curling a remote URL to a local file
@@ -108,23 +97,18 @@ cleanup_and_download_cookbook() {
 ####################################################################
 # Clones a repo and attempts to pull updates if requested version does not exist
 clone_repo() {
-  local repo_url="$1"
-  local local_dir="$2"
-  local version="$3"
+  repo_url="$1"
+  local_dir="$2"
+  version="$3"
 
-  local git_args=
-  if [[ -d "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]] && \
-    [[ -x "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]]; then
-    git_args="-c http.sslCAPath=$BOOTSTRAP_ADDITIONAL_CACERTS_DIR"
-  fi
   if [[ -d "$BOOTSTRAP_CACHE_DIR/$local_dir/.git" ]]; then
     pushd "$BOOTSTRAP_CACHE_DIR/$local_dir"
     git log --pretty=format:'%H' | \
     grep -q "$version" || \
-    git $git_args pull
+    git pull
     popd
   else
-    git $git_args clone "$repo_url" "$BOOTSTRAP_CACHE_DIR/$local_dir"
+    git clone "$repo_url" "$BOOTSTRAP_CACHE_DIR/$local_dir"
   fi
 }
 

--- a/bootstrap/shared/shared_proxy_setup.sh
+++ b/bootstrap/shared/shared_proxy_setup.sh
@@ -3,20 +3,6 @@
 source "$REPO_ROOT"/bootstrap/shared/shared_functions.sh
 load_configs
 
-get(){
-  local timeout=10
-  local url="$1"
-
-  [[ -z "$url" ]] && return 1
-  local args="-s --connect-timeout $timeout"
-  # Add the certs for proxy test if available
-  if [[ -d "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]] && \
-      [[ -x "$BOOTSTRAP_ADDITIONAL_CACERTS_DIR" ]]; then
-    args+=" --capath $BOOTSTRAP_ADDITIONAL_CACERTS_DIR"
-  fi
-  curl $args "$url"
-}
-
 [ -n "$SHARED_PROXY_SETUP" ] || {
   REQUIRED_VARS=( BOOTSTRAP_HTTP_PROXY_URL BOOTSTRAP_HTTPS_PROXY_URL )
   check_for_envvars "${REQUIRED_VARS[@]}"
@@ -24,7 +10,7 @@ get(){
   if [[ ! -z "$BOOTSTRAP_HTTP_PROXY_URL" ]]; then
     export http_proxy="${BOOTSTRAP_HTTP_PROXY_URL}"
 
-    get http://www.google.com > /dev/null && true
+    curl -s --connect-timeout 10 http://www.google.com > /dev/null && true
     if [[ $? != 0 ]]; then
       echo "Error: proxy $BOOTSTRAP_HTTP_PROXY_URL non-functional for HTTP requests" >&2
       exit 1
@@ -33,7 +19,7 @@ get(){
 
   if [[ ! -z "$BOOTSTRAP_HTTPS_PROXY_URL" ]]; then
     export https_proxy="${BOOTSTRAP_HTTPS_PROXY_URL}"
-    get https://github.com > /dev/null && true
+    curl -s --connect-timeout 10 https://github.com > /dev/null && true
     if [[ $? != 0 ]]; then
       echo "Error: proxy $BOOTSTRAP_HTTPS_PROXY_URL non-functional for HTTPS requests" >&2
       exit 1


### PR DESCRIPTION
Reverts bloomberg/chef-bcpc#1288 to fix #1294. Build is expected to succeed on a Linux build machine with preinstalled internal certificates if it is behind a proxy.