### PR TITLE
Force ifup in case of missing dhclient during vm provision

### DIFF
--- a/bootstrap/vagrant_scripts/reconfigure-eth0-on-vms.sh
+++ b/bootstrap/vagrant_scripts/reconfigure-eth0-on-vms.sh
@@ -7,4 +7,4 @@ iface eth0 inet static
 "
 
 echo "$ETH0" > /etc/network/interfaces.d/eth0.cfg
-ifdown eth0 && ifup eth0 && killall -TERM dhclient
+ifdown eth0 && ifup eth0 && killall -TERM dhclient || true


### PR DESCRIPTION
Fixes #1305.

After the fix, provision succeeds:

```
$ vagrant up
Bringing machine 'bootstrap' up with 'virtualbox' provider...
Bringing machine 'r1n1' up with 'virtualbox' provider...
Bringing machine 'r1n2' up with 'virtualbox' provider...
==> bootstrap: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> bootstrap: flag to force provisioning. Provisioners marked to run always will still run.
==> bootstrap: Running provisioner: delete-default-gw-on-eth0 (shell)...
    bootstrap: Running: /var/folders/2d/nj6nk1zn6f15y6zd4kz6qjk40000gp/T/vagrant-shell20171120-6404-1k8fyq0.sh
==> bootstrap: Running provisioner: add-default-gw (shell)...
    bootstrap: Running: inline script
<...>
==> r1n1: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> r1n1: flag to force provisioning. Provisioners marked to run always will still run.
==> r1n1: Running provisioner: delete-default-gw-on-eth0 (shell)...
    r1n1: Running: /var/folders/2d/nj6nk1zn6f15y6zd4kz6qjk40000gp/T/vagrant-shell20171120-6404-84fqb9.sh
==> r1n1: RTNETLINK answers: No such file or directory
==> r1n1: RTNETLINK answers: No such process
==> r1n1: RTNETLINK answers: No such process
==> r1n1: Running provisioner: add-default-gw (shell)...
    r1n1: Running: inline script
```

It can be seen that default gateway is indeed added as specified:
```
$ cat ../config/singlehead.json
{
  "cluster_name": "Test-Laptop-Vagrant",
  "nodes": {
    "bcpc-dev-bootstrap": {
      "ip_address": "10.0.100.3",
      "gateway": "10.0.2.2",
      "chef_role": "BCPC-Bootstrap"
    },
    "bcpc-dev-r1n1": {
      "ip_address": "10.0.100.11",
      "gateway": "10.0.2.2",
      "chef_role": "BCPC-Headnode"
    },
    "bcpc-dev-r1n2": {
      "ip_address": "10.0.100.12",
      "gateway": "10.0.2.2",
      "chef_role": "BCPC-Worknode"
    }
  }
}
$ vagrant ssh -c 'ip route ls dev eth0' r1n1
default via 10.0.2.2
10.0.2.0/24  proto kernel  scope link  src 10.0.2.15
Connection to 127.0.0.1 closed.
```