### PR TITLE
Monkeypatch URI HTTP/S classes to not strip default port during strin…

### DIFF
--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -13,6 +13,20 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 # if it is not set, set it ourselves
 ENV['REPO_ROOT'] ||= %x{git rev-parse --show-toplevel}.strip
 
+# Modified URI HTTP/S classes to prevent stripping of well-known ports
+module URI
+  class HTTPS
+    def to_s
+      '%s://%s:%s' % [self.scheme, self.host, self.port]
+    end
+  end
+  class HTTP
+    def to_s
+      '%s://%s:%s' % [self.scheme, self.host, self.port]
+    end
+  end
+end
+
 # pull in the bootstrap config defaults and overrides (even though these would already
 # be set by BOOT_GO.sh, do it again here so that Vagrant always has access to all
 # configuration variables)


### PR DESCRIPTION
…gification.

After the patch:
```
$ env BOOTSTRAP_HTTP_PROXY_URL=http://proxy.example.com:80 BOOTSTRAP_HTTPS_PROXY_URL=https://proxy.example.com:443 vagrant up --provision-with=configure-proxy-servers r1n1
Bringing machine 'r1n1' up with 'virtualbox' provider...
==> r1n1: Running provisioner: configure-proxy-servers (shell)...
    r1n1: Running: inline script
==> r1n1: Acquire::http::Proxy "http://proxy.example.com:80";
==> r1n1: export http_proxy=http://proxy.example.com:80
==> r1n1: Acquire::https::Proxy "https://proxy.example.com:443";
==> r1n1: export https_proxy=https://proxy.example.com:443
```

vs before:

```
$ env BOOTSTRAP_HTTP_PROXY_URL=http://proxy.example.com:80 BOOTSTRAP_HTTPS_PROXY_URL=https://proxy.example.com:443 vagrant up --provision-with=configure-proxy-servers r1n1
Bringing machine 'r1n1' up with 'virtualbox' provider...
==> r1n1: Running provisioner: configure-proxy-servers (shell)...
    r1n1: Running: inline script
==> r1n1: Acquire::http::Proxy "http://proxy.example.com";
==> r1n1: export http_proxy=http://proxy.example.com
==> r1n1: Acquire::https::Proxy "https://proxy.example.com";
==> r1n1: export https_proxy=https://proxy.example.com
```