### PR TITLE
Fix incorrect memcache configuration

### DIFF
--- a/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -237,6 +237,7 @@ cpu_model = <%= node['bcpc']['nova']['cpu_config']['cpu_model'] %>
 <% end %>
 <% end %>
 
-[oslo_cache]
+[cache]
 enabled = true
-memcached_servers=<%=@servers.map{|x| x['bcpc']['management']['ip'] + ":11211"}.join(",")%>
+backend = oslo_cache.memcache_pool
+memcache_servers=<%=@servers.map{|x| x['bcpc']['management']['ip'] + ":11211"}.join(",")%>


### PR DESCRIPTION
In a multi head node setup, VNC console for instances fail to connect until you refresh the page a few times. This is fixed by updating nova configuration per https://docs.openstack.org/mitaka/config-reference/compute/config-options.html. Once applied, VNC console for instances is expected to work without browser refreshes.