### PR TITLE
Add unique internal network names.

### DIFF
--- a/bootstrap/config/examples/singlehead.networks.json
+++ b/bootstrap/config/examples/singlehead.networks.json
@@ -1,0 +1,31 @@
+{
+  "cluster_name": "Test-Laptop-Vagrant",
+  "nodes": {
+    "bcpc-dev-bootstrap": {
+      "ip_address": "10.0.100.3",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Bootstrap"
+    },
+    "bcpc-dev-r1n1": {
+      "ip_address": "10.0.100.11",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Headnode"
+    },
+    "bcpc-dev-r1n2": {
+      "ip_address": "10.0.100.12",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Worknode"
+    }
+  },
+  "networks":{
+    "management":{
+      "name": "management-from-config"
+    },
+    "storage":{
+      "name": "storage-from-config"
+    },
+    "tenant":{
+      "name": "tenant-from-config"
+    }
+  }
+}

--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -180,7 +180,15 @@ Vagrant.configure("2") do |config|
   cluster_config = File.join(config_path, ENV['CLUSTER'] + '.json')
   cluster = JSON.parse(File.read(cluster_config))
   bootstrap_node = cluster['nodes']['bcpc-dev-bootstrap']['ip_address']
-
+  # Define the network names (random) here. There will be 3 classes of networks:
+  #   - management
+  #   - storage
+  #   - tenant
+  networks = {
+    management: SecureRandom.uuid,
+    storage: SecureRandom.uuid,
+    tenant: SecureRandom.uuid,
+  }
   cluster['nodes'].each do |node, key|
     vm = node
     # Remove name prefix for shorter Vagrant hostnames
@@ -190,10 +198,10 @@ Vagrant.configure("2") do |config|
       bootstrap_domain = (ENV['BCPC_HYPERVISOR_DOMAIN'] or "bcpc.example.com")
       m.vm.hostname = "bcpc-dev-#{vm}.#{bootstrap_domain}"
       m.vm.network :private_network,
-                   virtualbox__intnet: 'management',
+                   virtualbox__intnet: networks[:management],
                    ip: cluster['nodes'][node]['ip_address'],
                    netmask: '255.255.255.240'
-      ['storage', 'tenant'].each do |network|
+      [networks[:storage], networks[:tenant]].each do |network|
         m.vm.network :private_network,
                      virtualbox__intnet: network,
                      auto_config: false

--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -9,6 +9,15 @@ require 'json' # used to parse cluster machines configuration
 Vagrant.require_version ">= 1.7.0"
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
 
+# Load some other vagrantfiles, user libs
+current_dir = File.expand_path File.dirname(__FILE__)
+libdir = File.join current_dir, 'lib'
+Dir.foreach(libdir) {|f|
+  # Check extensions?
+  libpath = File.join libdir, f
+  load libpath if File.ftype(libpath) == 'file'
+}
+
 # if being run via BOOT_GO.sh, ENV['REPO_ROOT'] will be the root of the repo;
 # if it is not set, set it ourselves
 ENV['REPO_ROOT'] ||= %x{git rev-parse --show-toplevel}.strip
@@ -184,10 +193,18 @@ Vagrant.configure("2") do |config|
   #   - management
   #   - storage
   #   - tenant
+  # Attempt to get from cluster configuration file or generate if absent
+  netname = Proc.new {|label|
+    begin
+      cluster['networks'][label]['name']
+    rescue
+      nil
+    end
+  }
   networks = {
-    management: SecureRandom.uuid,
-    storage: SecureRandom.uuid,
-    tenant: SecureRandom.uuid,
+    management: netname['management'] || generate_network_name('management'),
+    storage: netname['storage'] || generate_network_name('storage'),
+    tenant: netname['tenant'] || generate_network_name('tenant'),
   }
   cluster['nodes'].each do |node, key|
     vm = node

--- a/bootstrap/vagrant_scripts/lib/bcpc.rb
+++ b/bootstrap/vagrant_scripts/lib/bcpc.rb
@@ -1,0 +1,4 @@
+module BCPC
+end
+
+require_relative 'bcpc/network_id_generator.rb'

--- a/bootstrap/vagrant_scripts/lib/bcpc/network_id_generator.rb
+++ b/bootstrap/vagrant_scripts/lib/bcpc/network_id_generator.rb
@@ -1,0 +1,32 @@
+require 'digest'
+
+module BCPC
+  class NetworkIDGenerator
+    def generate_id(mapping)
+      hash = Digest::SHA256.new
+      mapping.keys.sort.each {|k|
+        hash.update mapping[k].to_s.force_encoding(Encoding::UTF_8)
+      }
+      hash.hexdigest
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  mapping_file = ARGV[0]
+  if mapping_file.nil?
+     $stderr.puts 'Supply a mapping file.'
+     exit! 1
+  end
+
+  require 'json'
+  g = BCPC::NetworkIDGenerator.new
+  begin
+    File.open(mapping_file) {|f|
+      mapping = JSON::load f
+      puts g.generate_id mapping
+    }
+  rescue Exception => e
+    $stderr.puts e
+  end
+end

--- a/bootstrap/vagrant_scripts/lib/utils.rb
+++ b/bootstrap/vagrant_scripts/lib/utils.rb
@@ -1,0 +1,31 @@
+require_relative 'bcpc'
+include BCPC
+
+def get_virtualbox_property(name)
+  @_vbox_properties ||= begin
+    out = %x[ VBoxManage list systemproperties ]
+    lines = out.split("\n")
+    pairs = lines.collect {|l|
+      raw_key, val = l.split(':')
+      key = raw_key.downcase.gsub(/ /,'_')
+      [key, val.strip]
+    }
+    Hash[pairs]
+  rescue Exception => e
+    raise "Failed to enumerate Virtualbox properties: #{e}"
+  end
+  # Make sure to hard fail
+  @_vbox_properties.fetch name
+end
+
+def generate_network_name(label)
+  @vmdir ||=  get_virtualbox_property('default_machine_folder')
+  mapping = {
+    label: label,
+    uid: Process.euid,
+    virtualbox_vm_dir: @vmdir,
+  }
+  @g ||= NetworkIDGenerator.new
+  id = @g.generate_id mapping
+  [label, id].join('-')
+end

--- a/bootstrap/vagrant_scripts/netid.py
+++ b/bootstrap/vagrant_scripts/netid.py
@@ -1,0 +1,31 @@
+import hashlib
+
+# See
+# https://github.com/openstack/keystone/blob/stable/pike/keystone/identity/id_generators/sha256.py
+class NetworkIDGenerator(object):
+    def __init__(self):
+        pass
+
+    def generate_id(self, mapping):
+        h = hashlib.sha256()
+        for k in sorted(mapping.keys()):
+            h.update(str(mapping[k]).encode('utf-8'))
+        return h.hexdigest()
+
+
+if __name__ == '__main__':
+    import sys
+    try:
+        import simplejson as json
+    except ImportError:
+        import json
+
+    try:
+        mapping_file = sys.argv[1]
+    except IndexError:
+        sys.exit('Supply a mapping file')
+
+    g = NetworkIDGenerator()
+    with open(mapping_file, 'r') as f:
+        mapping = json.load(f)
+        print(g.generate_id(mapping))


### PR DESCRIPTION
Currently, since the network names are hard-coded, it's not possible to have multiple bcpc builds on the same host (on Linux -- OS X probably suffers the same issue, but it is untested), due to Virtualbox internal network permissions. See:

 - https://www.virtualbox.org/manual/ch06.html#network_internal
 - https://www.vagrantup.com/docs/virtualbox/networking.html

Attempting multiple builds _even under different user ids_ would result in error such as:

```
$ time ./BOOT_GO.sh
<...>
==> bootstrap: Booting VM...
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["startvm", "468c136e-23bd-4485-b7a0-e513e129ecd0", "--type", "headless"]

Stderr: VBoxManage: error: Failed to open/create the internal network 'management' (VERR_PERMISSION_DENIED).
VBoxManage: error: Failed to attach the network LUN (VERR_PERMISSION_DENIED)
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component ConsoleWrap, interface IConsole
```

This patch fixes the issue for multiple builds on same host under different user ids