### PR TITLE
disable warnings on trusty

### DIFF
--- a/cookbooks/bcpc/files/default/dns-update-zone.sh
+++ b/cookbooks/bcpc/files/default/dns-update-zone.sh
@@ -12,8 +12,8 @@ test -n "$ZONE" && COND="WHERE name = '$ZONE'"
 mysql --defaults-file=/etc/mysql/debian.cnf -N -s -D pdns -e \
 "SELECT name FROM domains $COND" | \
 while read zone; do
-  pdnssec increase-serial $zone || exit 1
+  pdnssec increase-serial $zone >/dev/null
   for slave in $SLAVES; do
-    pdns_control notify-host $zone $slave >/dev/null 2>&1 || exit 1
+    pdns_control notify-host $zone $slave >/dev/null
   done
 done

--- a/cookbooks/bcpc/files/default/dns_fill.py
+++ b/cookbooks/bcpc/files/default/dns_fill.py
@@ -11,9 +11,18 @@ import json
 import keystoneclient
 from keystoneclient import exceptions as kc_exceptions
 import MySQLdb as mdb
+import platform
 import re
+import requests
 import subprocess
 import syslog
+
+if platform.python_version() == '2.7.6':
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning, \
+        InsecurePlatformWarning, SNIMissingWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+    requests.packages.urllib3.disable_warnings(InsecurePlatformWarning)
+    requests.packages.urllib3.disable_warnings(SNIMissingWarning)
 
 
 class dns_popper(object):


### PR DESCRIPTION
Cron generates these and emails the output each time when email is enabled:

/usr/lib/python2.7/dist-packages/urllib3/util/ssl_.py:315: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#snimissingwarning.
  SNIMissingWarning
/usr/lib/python2.7/dist-packages/urllib3/util/ssl_.py:120: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py:794: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)