### PR TITLE
Use SSH tunneling to access BCPC sites

### DIFF
--- a/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
+++ b/bootstrap/vagrant_scripts/vagrant_print_useful_info.sh
@@ -35,7 +35,14 @@ KEYSTONE_ADMIN_PASSWORD=$(extract_value 'keystone-admin-password')
 echo "------------------------------------------------------------"
 echo "Everything looks like it's been installed successfully!"
 echo
-echo "Access the BCPC landing page at https://$MANAGEMENT_VIP"
+echo "Setup SSH tunnel to access BCPC sites:"
+echo "./vagrant_tunnel.sh"
+echo
+echo "Sites are reachable via tunnel at:"
+echo "Horizon: https://localhost:8443/horizon/"
+echo "HAProxy: https://localhost:8443/haproxy/"
+echo "RabbitMQ: https://localhost:8443/rabbitmq/"
+echo
 echo "Use these users and passwords to access the different resources:"
 echo
 echo "Horizon: $KEYSTONE_ADMIN_USER / $KEYSTONE_ADMIN_PASSWORD"

--- a/bootstrap/vagrant_scripts/vagrant_tunnel.sh
+++ b/bootstrap/vagrant_scripts/vagrant_tunnel.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+source ../shared/shared_functions.sh
+export REPO_ROOT="$REPO_ROOT"
+
+load_configs
+
+KNIFE=/opt/opscode/embedded/bin/knife
+
+# Get the management VIP.
+MANAGEMENT_VIP=$(vagrant ssh bootstrap -c "$KNIFE environment show $BOOTSTRAP_CHEF_ENV -a override_attributes.bcpc.management.vip | tail -n +2 | awk '{ print \$2 }'")
+
+# Setup SSH tunnel
+vagrant ssh-config bootstrap > /tmp/$BOOTSTRAP_CHEF_ENV-bootstrap.ssh.config
+ssh -F /tmp/$BOOTSTRAP_CHEF_ENV-bootstrap.ssh.config \
+-L 8443:$MANAGEMENT_VIP:443 \
+-L 6080:$MANAGEMENT_VIP:6080 bootstrap


### PR DESCRIPTION
Since changing the Virtualbox network interfaces to `internal`, accessing BCPC sites from build machine require some form of tunneling. Instructions and script are provided to facilitate access.