### PR TITLE
enable admin project in keystone

### DIFF
--- a/cookbooks/bcpc/attributes/keystone.rb
+++ b/cookbooks/bcpc/attributes/keystone.rb
@@ -64,6 +64,7 @@ default['bcpc']['keystone']['admin']['email'] = 'admin@bcpc.example.com'
 default['bcpc']['keystone']['admin']['username'] = 'admin'
 default['bcpc']['keystone']['admin']['project_name'] = 'admin'
 default['bcpc']['keystone']['admin']['domain'] = 'local'
+default['bcpc']['keystone']['admin']['enable_admin_project'] = true
 
 default['bcpc']['keystone']['service_project']['name'] = 'service'
 default['bcpc']['keystone']['service_project']['domain'] = 'local'

--- a/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
+++ b/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
@@ -333,6 +333,11 @@ caching = true
 <% else %>
 caching = false
 <% end %>
+
+<% if node['bcpc']['keystone']['admin']['enable_admin_project'] %>
+admin_project_name = <%= node['bcpc']['keystone']['admin']['project_name'] %>
+admin_project_domain_name = <%= node['bcpc']['keystone']['admin']['domain'] %>
+<% end %>
 domain_name_url_safe = strict
 project_name_url_safe = strict
 #cache_time = <None>


### PR DESCRIPTION
Add admin project to allow horizon to work for both domain and project level functions. Without this 
change we will need two accounts to do these two functions.
  