### PR TITLE
Add default domain for horizon

### DIFF
--- a/cookbooks/bcpc/attributes/keystone.rb
+++ b/cookbooks/bcpc/attributes/keystone.rb
@@ -69,8 +69,6 @@ default['bcpc']['keystone']['admin']['enable_admin_project'] = true
 default['bcpc']['keystone']['service_project']['name'] = 'service'
 default['bcpc']['keystone']['service_project']['domain'] = 'local'
 
-default['bcpc']['keystone']['default_domain'] = 'default'
-
 # LDAP credentials used by Keystone
 default['bcpc']['ldap']['admin_user'] = nil
 default['bcpc']['ldap']['admin_pass'] = nil

--- a/cookbooks/bcpc/templates/default/horizon/horizon.local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/horizon/horizon.local_settings.py.erb
@@ -59,7 +59,7 @@ OPENSTACK_API_VERSIONS = {
 
 # Overrides the default domain used when running on single-domain model
 # with Keystone V3. All entities will be created in the default domain.
-# OPENSTACK_KEYSTONE_DEFAULT_DOMAIN = 'Default'
+OPENSTACK_KEYSTONE_DEFAULT_DOMAIN = "<%= node['bcpc']['keystone']['default_domain'] %>"
 
 # Set Console type:
 # valid options would be "AUTO", "VNC", "SPICE" or "RDP"

--- a/environments/Test-Laptop-Vagrant.json
+++ b/environments/Test-Laptop-Vagrant.json
@@ -26,6 +26,9 @@
         "ram_allocation_ratio" : "20.0",
         "cpu_allocation_ratio": "20.0"
       },
+      "keystone": {
+        "default_domain": "local"
+      },
       "domain_name" : "bcpc.example.com",
       "management": {
         "vip" : "10.0.100.5",


### PR DESCRIPTION
- Specify the domain we want to use for Horizon
- Use `domains` hash to extract default domain
