### PR TITLE
update horizon to use memcached for session storage

### DIFF
--- a/cookbooks/bcpc/templates/default/horizon/horizon.local_settings.py.erb
+++ b/cookbooks/bcpc/templates/default/horizon/horizon.local_settings.py.erb
@@ -114,6 +114,7 @@ SECRET_KEY = '<%=get_config('horizon-secret-key')%>'
 # We recommend you use memcached for development; otherwise after every reload
 # of the django development server, you will have to login again. To use
 # memcached set CACHES to something like
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 CACHES = {
    'default': {
        'BACKEND' : 'django.core.cache.backends.memcached.MemcachedCache',


### PR DESCRIPTION
- in multidomain environments, this change will prevent horizon from creating cookies > 4k in size