### PR TITLE
Deprecate unnecessary/redundant vagrant script

### DIFF
--- a/bootstrap/shared/shared_validate_env.sh
+++ b/bootstrap/shared/shared_validate_env.sh
@@ -1,17 +1,10 @@
 #!/bin/bash
-NEEDED_PROGRAMS=( curl git rsync ssh )
-FAILED=0
-for binary in "${NEEDED_PROGRAMS[@]}"; do
-  if ! which "$binary" >/dev/null; then
-    FAILED=1
-    echo "ERROR: Unable to locate $binary in this environment's PATH." >&2
-  fi
+
+required_bins=( curl git jq rsync ssh vagrant )
+
+for binary in "${required_bins[@]}"; do
+    if ! [ -x "$(command -v $binary)" ]; then
+        printf "\n\nError: Necessary program '$binary' is not installed or available on your path.\nPlease fix by installing or correcting your PATH. Aborting now.\n\n" >&2
+        exit 1
+    fi
 done
-
-if [[ $FAILED != 0 ]]; then
-  printf "
-       Please see above error output to determine which program(s) you may
-       need to install or expose into this environment's PATH. Aborting.\n" >&2
-  exit 1
-fi
-

--- a/bootstrap/vagrant_scripts/BOOT_GO.sh
+++ b/bootstrap/vagrant_scripts/BOOT_GO.sh
@@ -28,10 +28,6 @@ load_configs
 echo "Performing preflight environment validation..."
 source "$REPO_ROOT"/bootstrap/shared/shared_validate_env.sh
 
-# Test that Vagrant is really installed and of an appropriate version.
-echo "Checking VirtualBox and Vagrant..."
-source "$REPO_ROOT"/bootstrap/vagrant_scripts/vagrant_test.sh
-
 # Do prerequisite work prior to starting build, downloading files and
 # creating local directories. Proxy configuration is handled there as well.
 echo "Downloading necessary files to local cache..."

--- a/bootstrap/vagrant_scripts/vagrant_test.sh
+++ b/bootstrap/vagrant_scripts/vagrant_test.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-. "$REPO_ROOT"/bootstrap/shared/shared_functions.sh
-
-if ! which vagrant >/dev/null; then
-  echo "You must have Vagrant installed to build an environment using Vagrant." >&2
-  exit 1
-fi


### PR DESCRIPTION
Since we're checking for needed programs/binaries elsewhere, and the vagrant_test.sh wasn't doing anything intelligent except checking that the binary existed, we can deprecate that, remove the check from BOOT.sh, and fold it into the list of other bins we need for bootstrap. Also rewrote the check for binaries.