### PR TITLE
Increase the number of logging days for openstack services

### DIFF
--- a/cookbooks/bcpc/attributes/cinder.rb
+++ b/cookbooks/bcpc/attributes/cinder.rb
@@ -20,3 +20,4 @@ default['bcpc']['cinder']['quota'] = {
 
 # Identity
 default['bcpc']['cinder']['user'] = 'cinder'
+default['bcpc']['cinder']['days_to_keep_logs'] = 14

--- a/cookbooks/bcpc/attributes/glance.rb
+++ b/cookbooks/bcpc/attributes/glance.rb
@@ -12,3 +12,4 @@ default['bcpc']['glance']['database']['max_pool_size'] = 5
 
 # This may need to be rescoped...
 default['bcpc']['glance']['user'] = 'glance'
+default['bcpc']['glance']['days_to_keep_logs'] = 14

--- a/cookbooks/bcpc/attributes/keystone.rb
+++ b/cookbooks/bcpc/attributes/keystone.rb
@@ -69,3 +69,5 @@ default['bcpc']['keystone']['default_domain'] = 'default'
 default['bcpc']['ldap']['admin_user'] = nil
 default['bcpc']['ldap']['admin_pass'] = nil
 default['bcpc']['ldap']['config'] = {}
+
+default['bcpc']['keystone']['days_to_keep_logs'] = 14

--- a/cookbooks/bcpc/attributes/nova.rb
+++ b/cookbooks/bcpc/attributes/nova.rb
@@ -79,3 +79,5 @@ default['bcpc']['nova']['quota'] = {
 # When true, all DNS queries will be forwarded to external DNS servers
 # by each tenant's dnsmasq instance, except fixed zone PTRs.
 default['bcpc']['nova']['conditional_dns'] = false
+
+default['bcpc']['nova']['days_to_keep_logs'] = 14

--- a/cookbooks/bcpc/recipes/cinder.rb
+++ b/cookbooks/bcpc/recipes/cinder.rb
@@ -224,3 +224,10 @@ end
 service "tgt" do
     action [:stop, :disable]
 end
+
+template "/etc/logrotate.d/cinder-common" do
+    source "cinder/cinder-common.logrotate.conf.erb"
+    owner "root"
+    group "root"
+    mode 00644
+end

--- a/cookbooks/bcpc/recipes/glance.rb
+++ b/cookbooks/bcpc/recipes/glance.rb
@@ -233,3 +233,10 @@ bash "glance-cirros-image" do
     EOH
     not_if ". /root/glance-openrc; glance image-list | grep 'Cirros 0.3.4 x86_64'"
 end
+
+template "/etc/logrotate.d/glance-common" do
+    source "glance/glance-common.logrotate.conf.erb"
+    owner "root"
+    group "root"
+    mode 00644
+end

--- a/cookbooks/bcpc/recipes/keystone.rb
+++ b/cookbooks/bcpc/recipes/keystone.rb
@@ -567,3 +567,10 @@ end
 file "/var/lib/keystone/keystone.db" do
   action :delete
 end
+
+template "/etc/logrotate.d/keystone" do
+    source "keystone/keystone.logrotate.conf.erb"
+    owner "root"
+    group "root"
+    mode 00644
+end

--- a/cookbooks/bcpc/recipes/nova-common.rb
+++ b/cookbooks/bcpc/recipes/nova-common.rb
@@ -84,3 +84,10 @@ template "/etc/nova/policy.json" do
     mode 00600
     variables(:policy => JSON.pretty_generate(node['bcpc']['nova']['policy']))
 end
+
+template "/etc/logrotate.d/nova-common" do
+    source "nova/nova-common.logrotate.conf.erb"
+    owner "root"
+    group "root"
+    mode 00644
+end

--- a/cookbooks/bcpc/templates/default/cinder/cinder-common.logrotate.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder/cinder-common.logrotate.conf.erb
@@ -1,0 +1,8 @@
+/var/log/cinder/*.log {
+    rotate <%=node['bcpc']['cinder']['days_to_keep_logs']%>
+    daily
+    missingok
+    compress
+    delaycompress
+    copytruncate
+}

--- a/cookbooks/bcpc/templates/default/glance/glance-common.logrotate.conf.erb
+++ b/cookbooks/bcpc/templates/default/glance/glance-common.logrotate.conf.erb
@@ -1,0 +1,8 @@
+/var/log/glance/*.log {
+    rotate <%=node['bcpc']['glance']['days_to_keep_logs']%>
+    daily
+    missingok
+    compress
+    delaycompress
+    copytruncate
+}

--- a/cookbooks/bcpc/templates/default/keystone/keystone.logrotate.conf.erb
+++ b/cookbooks/bcpc/templates/default/keystone/keystone.logrotate.conf.erb
@@ -1,0 +1,8 @@
+/var/log/keystone/*.log {
+    rotate <%=node['bcpc']['keystone']['days_to_keep_logs']%>
+    daily
+    missingok
+    compress
+    delaycompress
+    copytruncate
+}

--- a/cookbooks/bcpc/templates/default/nova/nova-common.logrotate.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova/nova-common.logrotate.conf.erb
@@ -1,0 +1,8 @@
+/var/log/nova/*.log {
+    rotate <%=node['bcpc']['nova']['days_to_keep_logs']%>
+    daily
+    missingok
+    compress
+    delaycompress
+    copytruncate
+}


### PR DESCRIPTION
```
root@bcpc-dev-r1n1:/etc/logrotate.d# cat nova-common
/var/log/nova/*.log {
    rotate 14
    daily
    missingok
    compress
    delaycompress
    copytruncate
```
After running logrotate --force /etc/logrotate.conf few times
```
root@bcpc-dev-r1n1:/var/log/nova# ls -ls
total 420
0 -rw-r--r-- 1 nova nova   0 Jan 31 19:00 nova-api.log
0 -rw-r--r-- 1 nova nova   0 Jan 31 19:00 nova-api.log.1
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.10.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.11.gz
4 -rw-r--r-- 1 nova nova 171 Jan 31 19:00 nova-api.log.12.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.13.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.14.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.2.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.3.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.4.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.5.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.6.gz
4 -rw-r--r-- 1 nova nova 141 Jan 31 19:00 nova-api.log.7.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.8.gz
4 -rw-r--r-- 1 nova nova  20 Jan 31 19:00 nova-api.log.9.gz
0 -rw-r--r-- 1 nova nova   0 Jan 31 19:00 nova-cert.log

```