### PR TITLE
Add multihead config to allow HA cluster of 3 headnodes and 2 worknode

### DIFF
--- a/bootstrap/config/multihead.json
+++ b/bootstrap/config/multihead.json
@@ -1,0 +1,35 @@
+{
+  "cluster_name": "Test-Laptop-Vagrant",
+  "nodes": {
+    "bcpc-dev-bootstrap": {
+      "ip_address": "10.0.100.3",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Bootstrap"
+    },
+    "bcpc-dev-r1n1": {
+      "ip_address": "10.0.100.11",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Headnode"
+    },
+    "bcpc-dev-r1n2": {
+      "ip_address": "10.0.100.12",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Headnode"
+    },
+    "bcpc-dev-r1n3": {
+      "ip_address": "10.0.100.13",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Headnode"
+    },
+    "bcpc-dev-r1n4": {
+      "ip_address": "10.0.100.14",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Worknode"
+    },
+    "bcpc-dev-r1n5": {
+      "ip_address": "10.0.100.15",
+      "gateway": "10.0.2.2",
+      "chef_role": "BCPC-Worknode"
+    }
+  }
+}


### PR DESCRIPTION
This is 3 headnode-1 worknode which is tested on my iMac

```
Running handlers:
Running handlers complete
Chef Client finished, 14/396 resources updated in 44 seconds
Connection to 127.0.0.1 closed.
Connection to 127.0.0.1 closed.
Connection to 127.0.0.1 closed.
------------------------------------------------------------
Everything looks like it's been installed successfully!

Setup SSH tunnel to access BCPC sites:
./vagrant_tunnel.sh

Sites are reachable via tunnel at:
Horizon: https://localhost:8443/horizon/
HAProxy: https://localhost:8443/haproxy/
RabbitMQ: https://localhost:8443/rabbitmq/

Use these users and passwords to access the different resources:

Horizon: admin / FNITo2YE4HRW5gtWhkWg
HAProxy: haproxy / K7hboCHYsMzbhEUDSn_I
RabbitMQ: guest / wTkKM352H_TKDXLufgKF

Here are a few additional passwords:
System root password: C4oJnIKKUYUQp9Z8upWP
MySQL root password: iHTsBJQE9R4DCepsM7rL

Thanks for using BCPC!
Finished in 5091 seconds (1h:24m:51s)
(venv) ✔ ~/src/upstream/chef-bcpc/bootstrap/vagrant_scripts [master|…17⚑ 8]
15:37 $ vagrant status
Current machine states:

bootstrap                 running (virtualbox)
r1n1                      running (virtualbox)
r1n2                      running (virtualbox)
r1n3                      running (virtualbox)
r1n4                      running (virtualbox)
```