### PR TITLE
Expand the node space address from /28 to /27

### DIFF
--- a/bootstrap/vagrant_scripts/Vagrantfile
+++ b/bootstrap/vagrant_scripts/Vagrantfile
@@ -231,7 +231,7 @@ Vagrant.configure("2") do |config|
       m.vm.network :private_network,
                    virtualbox__intnet: networks[:management],
                    ip: cluster['nodes'][node]['ip_address'],
-                   netmask: '255.255.255.240'
+                   netmask: '255.255.255.224'
       [networks[:storage], networks[:tenant]].each do |network|
         m.vm.network :private_network,
                      virtualbox__intnet: network,


### PR DESCRIPTION
Allowed address space `10.0.100.6` to `10.0.100.14` both included. .5 is used as a vip node. Check the environment file to see reserved IPs

The ips used for nodes needed fit in /28 space, which was causing issues while deploying. This will ensure we don't use IP addresses that are not configured to use. 

Successful run that is showing the IP addresses configured.

```
"EXECUTING on bootstrap", 
        "10.0.100.14 -----> Existing Chef installation detected", 
        "10.0.100.14 Starting the first Chef Client run...", 
        "10.0.100.14 Starting Chef Client, version 12.9.41\u001b[0m", 
        "10.0.100.14 Creating a new client identity for bcpc-dev-r1n5.hypervisor-bcpc.example.com using the validator key.\u001b[0m", 
        "10.0.100.14 resolving cookbooks for run list: []\u001b[0m", 
        "10.0.100.14 Synchronizing Cookbooks:\u001b[0m", 
        "10.0.100.14 Installing Cookbook Gems:\u001b[0m", 
        "10.0.100.14 Compiling Cookbooks...\u001b[0m", 
        "10.0.100.14 [2018-02-07T21:02:21+00:00] WARN: Node bcpc-dev-r1n5.hypervisor-bcpc.example.com has an empty run list.", 
        "10.0.100.14 Converging 0 resources\u001b[0m", 
        "10.0.100.14 \u001b[0m", 
        "10.0.100.14 Running handlers:\u001b[0m", 
        "10.0.100.14 Running handlers complete", 
        "10.0.100.14 \u001b[0mChef Client finished, 0/0 resources updated in 02 seconds\u001b[0m", 
        "10.0.100.13 -----> Existing Chef installation detected", 
        "10.0.100.13 Starting the first Chef Client run...", 
        "10.0.100.13 Starting Chef Client, version 12.9.41\u001b[0m", 
        "10.0.100.13 Creating a new client identity for bcpc-dev-r1n4.hypervisor-bcpc.example.com using the validator key.\u001b[0m", 
        "10.0.100.13 resolving cookbooks for run list: []\u001b[0m", 
        "10.0.100.13 Synchronizing Cookbooks:\u001b[0m", 
        "10.0.100.13 Installing Cookbook Gems:\u001b[0m", 
        "10.0.100.13 Compiling Cookbooks...\u001b[0m", 
        "10.0.100.13 [2018-02-07T21:02:28+00:00] WARN: Node bcpc-dev-r1n4.hypervisor-bcpc.example.com has an empty run list.", 
        "10.0.100.13 Converging 0 resources\u001b[0m", 
        "10.0.100.13 \u001b[0m", 
        "10.0.100.13 Running handlers:\u001b[0m", 
        "10.0.100.13 Running handlers complete", 
        "10.0.100.13 \u001b[0mChef Client finished, 0/0 resources updated in 02 seconds\u001b[0m", 
        "10.0.100.12 -----> Existing Chef installation detected", 
        "10.0.100.12 Starting the first Chef Client run...", 
        "10.0.100.12 Starting Chef Client, version 12.9.41\u001b[0m", 
        "10.0.100.12 Creating a new client identity for bcpc-dev-r1n3.hypervisor-bcpc.example.com using the validator key.\u001b[0m", 
        "10.0.100.12 resolving cookbooks for run list: []\u001b[0m", 
        "10.0.100.12 Synchronizing Cookbooks:\u001b[0m", 
        "10.0.100.12 Installing Cookbook Gems:\u001b[0m", 
        "10.0.100.12 Compiling Cookbooks...\u001b[0m", 
        "10.0.100.12 [2018-02-07T21:02:35+00:00] WARN: Node bcpc-dev-r1n3.hypervisor-bcpc.example.com has an empty run list.", 
        "10.0.100.12 Converging 0 resources\u001b[0m", 
        "10.0.100.12 \u001b[0m", 
        "10.0.100.12 Running handlers:\u001b[0m", 
        "10.0.100.12 Running handlers complete", 
        "10.0.100.12 \u001b[0mChef Client finished, 0/0 resources updated in 02 seconds\u001b[0m", 
        "10.0.100.11 -----> Existing Chef installation detected", 
        "10.0.100.11 Starting the first Chef Client run...", 
        "10.0.100.11 Starting Chef Client, version 12.9.41\u001b[0m", 
        "10.0.100.11 Creating a new client identity for bcpc-dev-r1n2.hypervisor-bcpc.example.com using the validator key.\u001b[0m", 
        "10.0.100.11 resolving cookbooks for run list: []\u001b[0m", 
        "10.0.100.11 Synchronizing Cookbooks:\u001b[0m", 
        "10.0.100.11 Installing Cookbook Gems:\u001b[0m", 
        "10.0.100.11 Compiling Cookbooks...\u001b[0m", 
        "10.0.100.11 [2018-02-07T21:02:41+00:00] WARN: Node bcpc-dev-r1n2.hypervisor-bcpc.example.com has an empty run list.", 
        "10.0.100.11 Converging 0 resources\u001b[0m", 
        "10.0.100.11 \u001b[0m", 
        "10.0.100.11 Running handlers:\u001b[0m", 
        "10.0.100.11 Running handlers complete", 
        "10.0.100.11 \u001b[0mChef Client finished, 0/0 resources updated in 02 seconds\u001b[0m", 
        "10.0.100.10 -----> Existing Chef installation detected", 
        "10.0.100.10 Starting the first Chef Client run...", 
        "10.0.100.10 Starting Chef Client, version 12.9.41\u001b[0m", 
        "10.0.100.10 Creating a new client identity for bcpc-dev-r1n1.hypervisor-bcpc.example.com using the validator key.\u001b[0m", 
        "10.0.100.10 resolving cookbooks for run list: []\u001b[0m", 
        "10.0.100.10 Synchronizing Cookbooks:\u001b[0m", 
        "10.0.100.10 Installing Cookbook Gems:\u001b[0m", 
        "10.0.100.10 Compiling Cookbooks...\u001b[0m", 
        "10.0.100.10 [2018-02-07T21:02:48+00:00] WARN: Node bcpc-dev-r1n1.hypervisor-bcpc.example.com has an empty run list.", 
        "10.0.100.10 Converging 0 resources\u001b[0m", 
        "10.0.100.10 \u001b[0m", 
        "10.0.100.10 Running handlers:\u001b[0m", 
        "10.0.100.10 Running handlers complete", 
        "10.0.100.10 \u001b[0mChef Client finished, 0/0 resources updated in 02 seconds\u001b[0m", 
        "10.0.100.3 -----> Existing Chef installation detected", 
        "10.0.100.3 Starting the first Chef Client run...", 
        "10.0.100.3 Starting Chef Client, version 12.9.41\u001b[0m", 
        "10.0.100.3 Creating a new client identity for bcpc-dev-bootstrap.hypervisor-bcpc.example.com using the validator key.\u001b[0m", 
        "10.0.100.3 resolving cookbooks for run list: []\u001b[0m", 
        "10.0.100.3 Synchronizing Cookbooks:\u001b[0m", 
        "10.0.100.3 Installing Cookbook Gems:\u001b[0m", 
        "10.0.100.3 Compiling Cookbooks...\u001b[0m", 
        "10.0.100.3 [2018-02-07T21:02:54+00:00] WARN: Node bcpc-dev-bootstrap.hypervisor-bcpc.example.com has an empty run list.", 
        "10.0.100.3 Converging 0 resources\u001b[0m", 
        "10.0.100.3 \u001b[0m", 
        "10.0.100.3 Running handlers:\u001b[0m", 
        "10.0.100.3 Running handlers complete", 
        "10.0.100.3 \u001b[0mChef Client finished, 0/0 resources updated in 02 seconds\u001b[0m", 
. . .
. . .
        "EXECUTING on bootstrap", 
        "EXECUTING on r1n1", 
        "EXECUTING on r1n2", 
        "EXECUTING on r1n3", 
        "EXECUTING on r1n4", 
        "EXECUTING on r1n5", 
        "------------------------------------------------------------", 
        "Everything looks like it's been installed successfully!", 
        "", 
        "Setup SSH tunnel to access BCPC sites:", 
        "./vagrant_tunnel.sh", 
        "", 
        "Sites are reachable via tunnel at:", 
        "Horizon: https://localhost:8443/horizon/", 
        "HAProxy: https://localhost:8443/haproxy/", 
        "RabbitMQ: https://localhost:8443/rabbitmq/", 
        "", 
        "Use these users and passwords to access the different resources:", 
        "", 
        "Horizon: admin / D21hdK0PpQSe49lYp7lj", 
        "HAProxy: haproxy / zEsfa7Nv8vtBwpvAdET0", 
        "RabbitMQ: guest / GwLEaFhvaqez3mpBiysy", 
        "", 
        "Here are a few additional passwords:", 
        "System root password: C8EJGiWfGpEPtSrX5MdH", 
        "MySQL root password: rCsJC9wDJ4ZIIXFjrUMl", 
        "", 
        "Thanks for using BCPC!", 
        "Finished in 7902 seconds (2h:11m:42s)"
```
