### PR TITLE
fix for vagrant 2.0.1 return values

### DIFF
--- a/bootstrap/vagrant_scripts/vagrant_clean.sh
+++ b/bootstrap/vagrant_scripts/vagrant_clean.sh
@@ -6,4 +6,4 @@ set -e
 
 # Set this to max value to ensure leftover mon VMs are destroyed
 export CLUSTER_NODE_COUNT_OVERRIDE=6
-cd "$REPO_ROOT"/bootstrap/vagrant_scripts && vagrant destroy -f
+cd "$REPO_ROOT"/bootstrap/vagrant_scripts && vagrant destroy -f || true


### PR DESCRIPTION
Port from l-to-m to ignore vagrant 2.0.1 failures otherwise the chef-bcpc with vagrant 2.0.1 doesn't build from clean state