### PR TITLE
Correct dpkg command for printing foreign architectures

### DIFF
--- a/cookbooks/bcpc/recipes/packages-common.rb
+++ b/cookbooks/bcpc/recipes/packages-common.rb
@@ -21,7 +21,7 @@
 bash 'remove-foreign-arch' do
   user 'root'
   code 'dpkg --remove-architecture i386'
-  only_if 'dpkg --print-foreign-architecture | grep i386'
+  only_if 'dpkg --print-foreign-architectures | grep i386'
 end
 
 # run apt-get update at the start of every Chef run if so configured


### PR DESCRIPTION
```
# dpkg --print-foreign-architecture
dpkg: error: unknown option --print-foreign-architecture
...
# dpkg --print-foreign-architectures 
# echo $?
0
```