### PR TITLE
fix: test timeout must exceed OSD heartbeat grace

### DIFF
--- a/cookbooks/bcpc/attributes/monitoring.rb
+++ b/cookbooks/bcpc/attributes/monitoring.rb
@@ -121,7 +121,7 @@ default['bcpc']['zabbix']['php_settings'] = {
 # https://www.zabbix.com/documentation/2.4/manual/api/reference/usermedia/object
 default['bcpc']['zabbix']['severity'] = 63
 # Timeout for Zabbix agentd
-default['bcpc']['zabbix']['agentd_timeout'] = 10
+default['bcpc']['zabbix']['agentd_timeout'] = 25
 # Zabbix cache sizes
 default['bcpc']['zabbix']['server_cachesize'] = '16M'
 default['bcpc']['zabbix']['server_historycachesize'] = '8M'

--- a/cookbooks/bcpc/files/default/zabbix_s3test.sh
+++ b/cookbooks/bcpc/files/default/zabbix_s3test.sh
@@ -16,7 +16,7 @@ filename="$script-$(hostname -s)-$fqdn-$start_time"
 file_content="$(uuidgen) $date"
 content_type='application/x-compressed-tar'
 acl="x-amz-acl:private"
-curl_cmd='curl -q -f --max-time 10'
+curl_cmd='curl -q -f --max-time 25'
 [[ $proto == 'https' ]] && curl_cmd="$curl_cmd -k"
 
 function get_signature()


### PR DESCRIPTION
The default osd heartbeat grace value in ceph is 20s this must be higher otherwise we will get false positives.