### PR TITLE
Fix cinder quota functions to allow policy to be respected

### DIFF
--- a/cookbooks/bcpc/files/default/cinder-policy-AFTER.SHASUMS
+++ b/cookbooks/bcpc/files/default/cinder-policy-AFTER.SHASUMS
@@ -1,0 +1,1 @@
+7f5b58e542ea39eb2b1b25ed98406f5abf614599  ./cinder/api/contrib/quotas.py

--- a/cookbooks/bcpc/files/default/cinder-policy-BEFORE.SHASUMS
+++ b/cookbooks/bcpc/files/default/cinder-policy-BEFORE.SHASUMS
@@ -1,0 +1,1 @@
+6c0b0113a21ab794639e924e7f7d50e85ab8f41d  ./cinder/api/contrib/quotas.py

--- a/cookbooks/bcpc/files/default/cinder-policy.patch
+++ b/cookbooks/bcpc/files/default/cinder-policy.patch
@@ -1,0 +1,103 @@
+From a59ef7dd023a7ea95fe8ea9250feabe831f6dbc2 Mon Sep 17 00:00:00 2001
+From: Kundai Andrew Midzi <kmidzi@bloomberg.net>
+Date: Thu, 13 Jul 2017 19:18:56 +0000
+Subject: [PATCH 1/2] Pass through target project_id for os-quota-sets:show
+ authorisation.
+
+---
+ cinder/api/contrib/quotas.py | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/cinder/api/contrib/quotas.py b/cinder/api/contrib/quotas.py
+index ce60066..efb8f54 100644
+--- a/cinder/api/contrib/quotas.py
++++ b/cinder/api/contrib/quotas.py
+@@ -177,9 +177,9 @@ class QuotaSetsController(wsgi.Controller):
+         :param id: target project id that needs to be shown
+         """
+         context = req.environ['cinder.context']
+-        authorize_show(context)
+         params = req.params
+         target_project_id = id
++        authorize_show(context, target={'project_id': target_project_id})
+
+         if not hasattr(params, '__call__') and 'usage' in params:
+             usage = strutils.bool_from_string(params['usage'])
+@@ -198,12 +198,6 @@ class QuotaSetsController(wsgi.Controller):
+
+             self._authorize_show(context_project, target_project)
+
+-        try:
+-            sqlalchemy_api.authorize_project_context(context,
+-                                                     target_project_id)
+-        except exception.NotAuthorized:
+-            raise webob.exc.HTTPForbidden()
+-
+         quotas = self._get_quotas(context, target_project_id, usage)
+         return self._format_quota_set(target_project_id, quotas)
+
+--
+2.7.4
+
+
+From 3bc126b52797aed8e47dbc6d799a3ed9844002ee Mon Sep 17 00:00:00 2001
+From: Srinivas Sakhamuri <ssakhamuri@bloomberg.net>
+Date: Fri, 6 Apr 2018 19:14:54 +0000
+Subject: [PATCH 2/2] Fix quotas to use policy
+
+---
+ cinder/api/contrib/quotas.py | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/cinder/api/contrib/quotas.py b/cinder/api/contrib/quotas.py
+index efb8f54..9565b28 100644
+--- a/cinder/api/contrib/quotas.py
++++ b/cinder/api/contrib/quotas.py
+@@ -177,9 +177,13 @@ class QuotaSetsController(wsgi.Controller):
+         :param id: target project id that needs to be shown
+         """
+         context = req.environ['cinder.context']
++        authorize_show(context)
++        prev_is_admin = context.is_admin
++        # policy check is successful, the following line makes sure
++        # cinder checks are successful as well
++        context.is_admin = True
+         params = req.params
+         target_project_id = id
+-        authorize_show(context, target={'project_id': target_project_id})
+
+         if not hasattr(params, '__call__') and 'usage' in params:
+             usage = strutils.bool_from_string(params['usage'])
+@@ -199,6 +203,7 @@ class QuotaSetsController(wsgi.Controller):
+             self._authorize_show(context_project, target_project)
+
+         quotas = self._get_quotas(context, target_project_id, usage)
++        context.is_admin = prev_is_admin
+         return self._format_quota_set(target_project_id, quotas)
+
+     @wsgi.serializers(xml=QuotaTemplate)
+@@ -217,6 +222,10 @@ class QuotaSetsController(wsgi.Controller):
+         """
+         context = req.environ['cinder.context']
+         authorize_update(context)
++        prev_is_admin = context.is_admin
++        # policy check is successful, the following line makes sure
++        # cinder checks are successful as well
++        context.is_admin = True
+         self.validate_string_length(id, 'quota_set_name',
+                                     min_length=1, max_length=255)
+
+@@ -310,7 +319,9 @@ class QuotaSetsController(wsgi.Controller):
+
+         if reservations:
+             db.reservation_commit(context, reservations)
+-        return {'quota_set': self._get_quotas(context, target_project_id)}
++        return_val = {'quota_set': self._get_quotas(context, target_project_id)}
++        context.is_admin = prev_is_admin
++        return return_val
+
+     def _get_quota_usage(self, quota_obj):
+         return (quota_obj.get('in_use', 0) + quota_obj.get('allocated', 0) +
+--
+2.7.4
+

--- a/cookbooks/bcpc/recipes/cinder.rb
+++ b/cookbooks/bcpc/recipes/cinder.rb
@@ -79,6 +79,15 @@ end
   end
 end
 
+# Patch cinder to prevent throwing 403 even policy is successful
+bcpc_patch 'cinder-policy-patch' do
+  patch_file           'cinder-policy.patch'
+  patch_root_dir       '/usr/lib/python2.7/dist-packages'
+  shasums_before_apply 'cinder-policy-BEFORE.SHASUMS'
+  shasums_after_apply  'cinder-policy-AFTER.SHASUMS'
+  only_if "dpkg --compare-versions $(dpkg-query --showformat='${Version}' --show cinder-api) ge 2:0 && dpkg --compare-versions $(dpkg-query --showformat='${Version}' --show cinder-api) le 2:9"
+end
+
 service "cinder-api" do
     restart_command "service cinder-api restart; sleep 5"
 end


### PR DESCRIPTION
Cinder in Mitaka implicitly assumes quota modifications are only to be performed by admin, which defeats the purpose of policy files. This patch after passing the policy checks forces cinder to think we are admin.

Warning: Make sure there is proper policy in place while this patch is used.