### PR TITLE
python package installation fixes

### DIFF
--- a/bootstrap/shared/shared_prereqs.sh
+++ b/bootstrap/shared/shared_prereqs.sh
@@ -165,6 +165,6 @@ download_file requests-aws-0.1.6.tar.gz https://pypi.python.org/packages/source/
 download_file pyzabbix-0.7.3.tar.gz https://pypi.python.org/packages/source/p/pyzabbix/pyzabbix-0.7.3.tar.gz
 download_file pagerduty-zabbix-proxy.py https://gist.githubusercontent.com/ryanhoskin/202a1497c97b0072a83a/raw/96e54cecdd78e7990bb2a6cc8f84070599bdaf06/pd-zabbix-proxy.py
 
-download_file carbon-${VER_GRAPHITE_CARBON}.tar.gz http://pypi.python.org/packages/source/c/carbon/carbon-${VER_GRAPHITE_CARBON}.tar.gz
-download_file whisper-${VER_GRAPHITE_WHISPER}.tar.gz http://pypi.python.org/packages/source/w/whisper/whisper-${VER_GRAPHITE_WHISPER}.tar.gz
-download_file graphite-web-${VER_GRAPHITE_WEB}.tar.gz http://pypi.python.org/packages/source/g/graphite-web/graphite-web-${VER_GRAPHITE_WEB}.tar.gz
+download_file carbon-${VER_GRAPHITE_CARBON}.tar.gz https://pypi.python.org/packages/source/c/carbon/carbon-${VER_GRAPHITE_CARBON}.tar.gz
+download_file whisper-${VER_GRAPHITE_WHISPER}.tar.gz https://pypi.python.org/packages/source/w/whisper/whisper-${VER_GRAPHITE_WHISPER}.tar.gz
+download_file graphite-web-${VER_GRAPHITE_WEB}.tar.gz https://pypi.python.org/packages/source/g/graphite-web/graphite-web-${VER_GRAPHITE_WEB}.tar.gz

--- a/cookbooks/bcpc/recipes/rally.rb
+++ b/cookbooks/bcpc/recipes/rally.rb
@@ -42,6 +42,7 @@ rally_version = node['bcpc']['rally']['version']
 end
 
 bash 'create virtual env for rally' do
+  environment ({'REQUESTS_CA_BUNDLE' => '/etc/ssl/certs/ca-certificates.crt'})
   code <<-EOH
     mkdir "#{rally_install_dir}"
     pip install --user --upgrade virtualenv
@@ -51,6 +52,7 @@ bash 'create virtual env for rally' do
 end
 
 bash 'install-rally' do
+  environment ({'REQUESTS_CA_BUNDLE' => '/etc/ssl/certs/ca-certificates.crt'})
   code <<-EOH
     #{rally_venv_dir}/bin/pip install pbr cffi
     #{rally_venv_dir}/bin/pip install rally==#{rally_version}


### PR DESCRIPTION
  - updated to use https vs. http for pypi package links
    - http requests to pypi prevents curl from downloading the package because
      the server returns 4XX responses (should be 3XX)

  - updated rally pip install bash resources to have 'REQUESTS_CA_BUNDLE'
    available to their environment so that pip can use the system certs
    when dealing with https urls