### PR TITLE
added modprobe.d/nf_conntrack.conf

### DIFF
--- a/cookbooks/bcpc/templates/default/modprobe.d/nf_conntrack.conf.erb
+++ b/cookbooks/bcpc/templates/default/modprobe.d/nf_conntrack.conf.erb
@@ -1,0 +1,1 @@
+options ip_conntrack hashsize=<%= @hashsize %>


### PR DESCRIPTION
used to store nf_conntrack module changes that need to persist across reboots