### PR TITLE
added support for additional fixed networks

### DIFF
--- a/cookbooks/bcpc/templates/default/bcpc-routing.erb
+++ b/cookbooks/bcpc/templates/default/bcpc-routing.erb
@@ -47,17 +47,46 @@ ip rule del pref 0
 <% if node['bcpc']['enabled']['secure_fixed_networks'] -%>
 # Prevent any fixed network traffic from seeing our management and storage
 # by skipping past the local table and using the main routing table
-ip rule del pref 100
-ip rule del pref 200
-ip rule add from <%=@node["bcpc"]["fixed"]["cidr"]%> to <%=@node["bcpc"]["management"]["cidr"]%> pref 100 table main
-ip rule add from <%=@node["bcpc"]["fixed"]["cidr"]%> to <%=@node["bcpc"]["storage"]["cidr"]%> pref 200 table main
+<% @mgm_pref = 100 %>
+<% @stg_pref = 200 %>
+ip rule del pref <%= @mgm_pref %>
+ip rule del pref <%= @stg_pref %>
+ip rule add from <%=@node["bcpc"]["fixed"]["cidr"]%> to <%=@node["bcpc"]["management"]["cidr"]%> pref <%= @mgm_pref %> table main
+ip rule add from <%=@node["bcpc"]["fixed"]["cidr"]%> to <%=@node["bcpc"]["storage"]["cidr"]%> pref <%= @stg_pref %> table main
+  <% if node["bcpc"]["additional_fixed"] -%>
+    <% @pref = 200 %>
+    <% @node["bcpc"]["additional_fixed"].each do |id,network| %>
+# Prevent any <%= id %> network traffic from seeing our management and storage
+# by skipping past the local table and using the main routing table
+      <% @pref += 1 %>
+ip rule del pref <%= @pref %>
+ip rule add from <%= network["cidr"] %> to <%= @node["bcpc"]["management"]["cidr"] %> pref <%= @pref %> table main
+      <% @pref += 1 %>
+ip rule del pref <%= @pref %>
+ip rule add from <%= network["cidr"] %> to <%= @node["bcpc"]["storage"]["cidr"] %> pref <%= @pref %> table main
+    <% end %>
+  <% end -%>
 <% end -%>
 
 # Let traffic to/from fixed IPs route via main table
-ip rule del pref 9000
-ip rule del pref 9001
-ip rule add from <%=@node["bcpc"]["fixed"]["cidr"]%> pref 9000 table main
-ip rule add to <%=@node["bcpc"]["fixed"]["cidr"]%> pref 9001 table main
+<% @fixed_from_pref = 9000 %>
+<% @fixed_to_pref = 9001 %>
+ip rule del pref <%= @fixed_from_pref %>
+ip rule del pref <%= @fixed_to_pref %>
+ip rule add from <%= @node["bcpc"]["fixed"]["cidr"] %> pref <%= @fixed_from_pref %> table main
+ip rule add to <%= @node["bcpc"]["fixed"]["cidr"] %> pref <%= @fixed_to_pref %> table main
+<% if node["bcpc"]["additional_fixed"] -%>
+  <% @fixed_pref = 9001 %>
+  <% @node["bcpc"]["additional_fixed"].each do |id,network| %>
+# Let traffic to/from <%= id %> IPs route via main table
+    <% @fixed_pref += 1 %>
+ip rule del pref <%= @fixed_pref %>
+ip rule add from <%= network["cidr"] %> pref <%= @fixed_pref %> table main
+    <% @fixed_pref += 1 %>
+ip rule del pref <%= @fixed_pref %>
+ip rule add to <%= network["cidr"] %> pref <%= @fixed_pref %> table main
+  <% end %>
+<% end -%>
 
 # Activate this routing table for management traffic
 ip rule del pref 10000

--- a/cookbooks/bcpc/templates/default/powerdns_generate_fixed_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_fixed_records.sql.erb
@@ -3,5 +3,5 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
     (SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), 'A', address, 'STATIC' FROM nova.fixed_ips
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name=concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), type='A', content=address, bcpc_record_type='STATIC';
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) SELECT
-    (SELECT id FROM domains WHERE name='<%=@reverse_fixed_zone%>'), ip4_to_ptr_name(address), 'PTR', concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), 'STATIC' FROM nova.fixed_ips
-    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@reverse_fixed_zone%>'), name=ip4_to_ptr_name(address), type='PTR', content=concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), bcpc_record_type='STATIC';
+    (SELECT id FROM domains WHERE name IN (<%= @reverse_fixed_zones %>)), ip4_to_ptr_name(address), 'PTR', concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), 'STATIC' FROM nova.fixed_ips
+    ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name IN (<%= @reverse_fixed_zones %>)), name=ip4_to_ptr_name(address), type='PTR', content=concat('ip-', replace(address, '.', '-'), '.', '<%=@cluster_domain%>'), bcpc_record_type='STATIC';

--- a/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
@@ -9,7 +9,7 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
 -- MySQL does not allow deleting from a table and selecting from that same table in a subquery, so ids of old SOA records are written to a temporary table, records are deleted,
 -- then the temporary table is cleaned up
 CREATE TEMPORARY TABLE soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%> (id int);
-<% [@cluster_domain, @reverse_float_zone, @reverse_fixed_zone, @management_zone].flatten.each do |zone| %>
+<% [@cluster_domain, @reverse_float_zone, @reverse_fixed_zones, @management_zone].flatten.each do |zone| %>
 
 -- delete malformed NS record where the content is the management VIP instead of cluster domain
 DELETE FROM <%= @database_name %>.records WHERE type='NS' and content='<%= @management_vip %>';


### PR DESCRIPTION
This patch adds support for having additional fixed nova networks outside of the default fixed network described in the environment or in default attributes. A key under node['bcpc'] (additional_fixed) will allow for any number of new private networks to be added to the cluster while also setting up the appropriate IP rules and powerdns entries. 

Example: 
```
node['bcpc']['additional_fixed'] = {
  "my_new_network": {
    "cidr": "1.74.0.0/16",
    "network_size": "256",
    "num_networks": "256",
    "vlan_start": "2000"
  }
}
```

**Testing:**

**Scenario**: apply patch and run automation after adding new subnet via nova-manage
**Desired outcome**: new ip rules applied

**Steps to reproduce:**

1. build BCC from master
2. vagrant ssh into vm1
```
> vagrant ssh r1n1
```
3. become root and source adminrc
```
> sudo bash
> source /root/adminrc
```
4. use nova-manage to add new subnet
```
> nova-manage network create --label my_new_network --fixed_range_v4=1.74.0.0/16 --num_networks=256 --multi_host=T --network_size=256 --vlan_start 2000 --bridge_interface=eth3
```

**before patching:**

```
root@bcpc-dev-r1n1:~# ip rule
1000:   from all lookup local
9000:   from 1.127.0.0/16 lookup main
9001:   from all to 1.127.0.0/16 lookup main
10000:  from 10.0.100.0/24 lookup mgmt
10001:  from all to 10.0.100.0/24 lookup mgmt
10002:  from 172.16.100.0/24 lookup storage
10003:  from all to 172.16.100.0/24 lookup storage
32766:  from all lookup main
32767:  from all lookup default
```

**after patching:** (and updating environment to include new fixed network)

```
root@bcpc-dev-r1n1:~# ip rule
100:    from 1.127.0.0/16 to 10.0.100.0/24 lookup main
200:    from 1.127.0.0/16 to 172.16.100.0/24 lookup main
201:    from 1.74.0.0/16 to 10.0.100.0/24 lookup main
202:    from 1.74.0.0/16 to 172.16.100.0/24 lookup main
1000:   from all lookup local
9000:   from 1.127.0.0/16 lookup main
9001:   from all to 1.127.0.0/16 lookup main
9002:   from 1.74.0.0/16 lookup main
9003:   from all to 1.74.0.0/16 lookup main
10000:  from 10.0.100.0/24 lookup mgmt
10001:  from all to 10.0.100.0/24 lookup mgmt
10002:  from 172.16.100.0/24 lookup storage
10003:  from all to 172.16.100.0/24 lookup storage
32766:  from all lookup main
32767:  from all lookup default
```