### PR TITLE
update rally pip install to use system certs

### DIFF
--- a/cookbooks/bcpc-extra/recipes/rally.rb
+++ b/cookbooks/bcpc-extra/recipes/rally.rb
@@ -47,6 +47,7 @@ directory "#{rally_install_dir}" do
 end
 
 bash 'create virtual env for rally' do
+  environment ({'REQUESTS_CA_BUNDLE' => '/etc/ssl/certs/ca-certificates.crt'})
   code <<-EOH
     pip install --user --upgrade virtualenv
     #{rally_home_dir}/.local/bin/virtualenv "#{rally_venv_dir}"
@@ -55,6 +56,7 @@ bash 'create virtual env for rally' do
 end
 
 bash 'install-rally' do
+  environment ({'REQUESTS_CA_BUNDLE' => '/etc/ssl/certs/ca-certificates.crt'})
   code <<-EOH
     #{rally_venv_dir}/bin/pip install pbr cffi
     #{rally_venv_dir}/bin/pip install rally==#{rally_version}


### PR DESCRIPTION
  - updated rally pip install bash resources to have 'REQUESTS_CA_BUNDLE'
    available to their environment so that pip can use the system certs
    when dealing with https urls