### PR TITLE
Bump chef-client to 12.19.36

### DIFF
--- a/bootstrap/shared/shared_prereqs.sh
+++ b/bootstrap/shared/shared_prereqs.sh
@@ -20,7 +20,7 @@ mkdir -p "$BOOTSTRAP_CACHE_DIR"
 ubuntu_url="http://us.archive.ubuntu.com/ubuntu/dists/trusty-updates"
 
 chef_url="https://packages.chef.io/files/stable"
-chef_client_ver=12.9.41
+chef_client_ver=12.19.36
 chef_server_ver=12.6.0
 CHEF_CLIENT_DEB=${CHEF_CLIENT_DEB:-chef_${chef_client_ver}-1_amd64.deb}
 CHEF_SERVER_DEB=${CHEF_SERVER_DEB:-chef-server-core_${chef_server_ver}-1_amd64.deb}


### PR DESCRIPTION
```
Sites are reachable via tunnel at:
Horizon: https://localhost:8443/horizon/
HAProxy: https://localhost:8443/haproxy/
RabbitMQ: https://localhost:8443/rabbitmq/

Use these users and passwords to access the different resources:

Horizon: admin / oLlLpW3o2jgNONXcJyCq
HAProxy: haproxy / zObChIZ0trshWqSGYnkc
RabbitMQ: guest / D8Ntio5YuCJnbDYMBm2G

Here are a few additional passwords:
System root password: MzBV04ufWt4gwGp6imxB
MySQL root password: uZ2eN9FEiP9phaOIDQWB

Thanks for using BCPC!
Finished in 2502 seconds (0h:41m:42s)


~/src/upstream/chef-bcpc/bootstrap/vagrant_scripts [feature/upgrade-chef-client|…20⚑ 9]
11:49 $ for c in bootstrap r1n1 r1n2; do vagrant ssh $c -c "chef-client --version"; done
Chef: 12.19.36
Connection to 127.0.0.1 closed.
Chef: 12.19.36
Connection to 127.0.0.1 closed.
Chef: 12.19.36
Connection to 127.0.0.1 closed.
```