### PR TITLE
Use .key? syntax to check key existence

### DIFF
--- a/cookbooks/bcpc/recipes/flavors.rb
+++ b/cookbooks/bcpc/recipes/flavors.rb
@@ -32,7 +32,7 @@ node['bcpc']['flavors'].each do |name, flavor|
     if flavor['swap_gb']
       swap_gb flavor['swap_gb']
     end
-    if flavor['is_public']
+    if flavor.key?('is_public')
       is_public flavor['is_public']
     end
     if flavor['id']


### PR DESCRIPTION
The old syntax checks for the value and evaluates to false, causing the `osflavor` resource to default to true for is_public