### PR TITLE
remove nova policy duplication to remove warnings

### DIFF
--- a/cookbooks/bcpc/attributes/nova.policy.rb
+++ b/cookbooks/bcpc/attributes/nova.policy.rb
@@ -83,9 +83,6 @@ default['bcpc']['nova']['policy'] = {
 
   "compute:rebuild" => "role:admin",
   "compute:reboot" => "rule:admin_or_owner",
-  "compute:delete" => "rule:admin_or_owner",
-  "compute:soft_delete" => "rule:admin_or_owner",
-  "compute:force_delete" => "rule:admin_or_owner",
 
   "compute:security_groups:add_to_instance" => "rule:admin_or_owner",
   "compute:security_groups:remove_from_instance" => "rule:admin_or_owner",


### PR DESCRIPTION
This removes the following warnings:

/var/chef/cache/cookbooks/bcpc/attributes/nova.policy.rb:86: warning: key "compute:delete" is duplicated and overwritten on line 93
/var/chef/cache/cookbooks/bcpc/attributes/nova.policy.rb:87: warning: key "compute:soft_delete" is duplicated and overwritten on line 94
/var/chef/cache/cookbooks/bcpc/attributes/nova.policy.rb:88: warning: key "compute:force_delete" is duplicated and overwritten on line 95