### PR TITLE
add a preference for the max supported version of erlang

### DIFF
--- a/cookbooks/bcpc/recipes/rabbitmq.rb
+++ b/cookbooks/bcpc/recipes/rabbitmq.rb
@@ -34,6 +34,12 @@ apt_repository "erlang" do
     key "erlang.key"
 end
 
+apt_preference 'erlang' do
+  glob 'erlang*'
+  pin 'version 1:20.3-1'
+  pin_priority '900'
+end
+
 apt_repository "rabbitmq" do
     uri node['bcpc']['repos']['rabbitmq']
     distribution 'testing'


### PR DESCRIPTION
See https://www.rabbitmq.com/which-erlang.html

Currently have rabbitmq-server 3.6.15 installed but the erlang
repo has released 21.0 which causes rabbitmq to fail to start
and the build to fail. Adding the preference fixes this issue.