### PR TITLE
add pod support

### DIFF
--- a/chef/cookbooks/bcpc/recipes/bird.rb
+++ b/chef/cookbooks/bcpc/recipes/bird.rb
@@ -39,8 +39,16 @@ template '/etc/bird/bird.conf' do
   racks = topology['racks']
   networks = topology['networks']
 
+  pod_id = node['bcpc']['networking']['pod_id']
   rack_id = node['bcpc']['networking']['rack_id']
-  rack = racks[rack_id]
+
+  rack = racks.find{ |r|
+    r['id'] == rack_id and r['pod'] == pod_id
+  }
+
+  if rack.nil?
+    raise "no rack found with an ID #{rack_id} and POD #{pod_id}"
+  end
 
   variables(
     :is_worknode => is_worknode(node),

--- a/virtual/topology/1h1w.json
+++ b/virtual/topology/1h1w.json
@@ -33,7 +33,7 @@
       }
     },
     {
-      "host": "r1n1",
+      "host": "r1an1",
       "group": "headnodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -55,7 +55,7 @@
       }
     },
     {
-      "host": "r1n2",
+      "host": "r1an2",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [

--- a/virtual/topology/3h3w.json
+++ b/virtual/topology/3h3w.json
@@ -33,7 +33,7 @@
       }
     },
     {
-      "host": "r1n1",
+      "host": "r1an1",
       "group": "headnodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -55,7 +55,7 @@
       }
     },
     {
-      "host": "r2n1",
+      "host": "r2an1",
       "group": "headnodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -77,7 +77,7 @@
       }
     },
     {
-      "host": "r3n1",
+      "host": "r3an1",
       "group": "headnodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -99,7 +99,7 @@
       }
     },
     {
-      "host": "r1n2",
+      "host": "r1an2",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -121,7 +121,7 @@
       }
     },
     {
-      "host": "r2n2",
+      "host": "r2an2",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -143,7 +143,7 @@
       }
     },
     {
-      "host": "r3n2",
+      "host": "r3an2",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [

--- a/virtual/topology/3h6w.json
+++ b/virtual/topology/3h6w.json
@@ -33,7 +33,7 @@
       }
     },
     {
-      "host": "r1n1",
+      "host": "r1an1",
       "group": "headnodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -55,7 +55,7 @@
       }
     },
     {
-      "host": "r2n1",
+      "host": "r2an1",
       "group": "headnodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -77,7 +77,7 @@
       }
     },
     {
-      "host": "r3n1",
+      "host": "r3an1",
       "group": "headnodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -99,7 +99,7 @@
       }
     },
     {
-      "host": "r1n2",
+      "host": "r1an2",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -121,7 +121,7 @@
       }
     },
     {
-      "host": "r1n3",
+      "host": "r1an3",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -143,7 +143,7 @@
       }
     },
     {
-      "host": "r2n2",
+      "host": "r2an2",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -165,7 +165,7 @@
       }
     },
     {
-      "host": "r2n3",
+      "host": "r2an3",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -187,7 +187,7 @@
       }
     },
     {
-      "host": "r3n2",
+      "host": "r3an2",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [
@@ -209,7 +209,7 @@
       }
     },
     {
-      "host": "r3n3",
+      "host": "r3an3",
       "group": "worknodes",
       "hardware_profile": "cloudnode",
       "run_list": [


### PR DESCRIPTION
  - update the vagrant host definitions to include pod information
  - parse pod id out of hostname and use it to locate the correct pod
    networking information in the networking topology