### PR TITLE
removed checked in ansible bootstrap inventory

### DIFF
--- a/virtual/ansible/inventory
+++ b/virtual/ansible/inventory
@@ -1,6 +1,0 @@
-all:
-  children:
-    localhost:
-      hosts:
-        127.0.0.1:
-          ansible_connection: local


### PR DESCRIPTION
  - used in previous versions of v8
  - old idea that didn't workout very well
  - this file is ignored by git and generated on vagrant up