### PR TITLE
networking fixes and configuration file cleanup

### DIFF
--- a/chef/cookbooks/bcpc/attributes/apt.rb
+++ b/chef/cookbooks/bcpc/attributes/apt.rb
@@ -1,0 +1,11 @@
+###############################################################################
+# apt
+###############################################################################
+
+# go through proxy for apt packages
+default['bcpc']['apt']['proxy']['enabled'] = node['bcpc']['proxy']['enabled']
+default['bcpc']['apt']['proxies']['http'] = node['bcpc']['proxy']['proxies']['http']
+default['bcpc']['apt']['proxies']['https'] = node['bcpc']['proxy']['proxies']['https']
+
+# allow unauthenticated packages to be installed
+default['bcpc']['apt']['allow_unauthenticated'] = false

--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -1,3 +1,10 @@
-default['bcpc']['calico']['bgp']['as_number'] = 65001
-default['bcpc']['calico']['bgp']['workload_interface'] = 'management'
-default['bcpc']['calico']['bgp']['upstream_peer'] = '192.168.100.3'
+###############################################################################
+# calico/calicoctl
+###############################################################################
+
+default['bcpc']['calico']['repo']['enabled'] = true
+default['bcpc']['calico']['repo']['url'] = "http://ppa.launchpad.net/project-calico/calico-3.1/ubuntu"
+
+default['bcpc']['calico']['remote']['file'] = 'calicoctl'
+default['bcpc']['calico']['remote']['source'] = "#{default['bcpc']['file_server']['url']}/calicoctl"
+default['bcpc']['calico']['remote']['checksum'] = '62ae2334f62ca5e5501022845a885efdae8cd10cfbe40293a58e3d85d39bc120'

--- a/chef/cookbooks/bcpc/attributes/default.rb
+++ b/chef/cookbooks/bcpc/attributes/default.rb
@@ -9,7 +9,12 @@ default['bcpc']['cloud']['fqdn'] = "openstack.#{default['bcpc']['cloud']['domain
 default['bcpc']['cloud']['region'] = node.chef_environment
 default['bcpc']['cloud']['vip'] = {'ip': '10.10.254.254/32'}
 
+# list of dns servers to use
 default['bcpc']['dns_servers'] = ["8.8.8.8", "8.8.4.4"]
+
+# list of ntp servers to use
+default['bcpc']['ntp']['servers'] = ["time.google.com"]
+
 default['bcpc']['file_server']['url'] = 'http://bootstrap:8080'
 
 # Hypervisor domain (domain used by actual machines)
@@ -18,6 +23,16 @@ default['bcpc']['hypervisor_domain'] = "hypervisor-bcpc.example.com"
 # convenience variable
 #
 vip = IPAddress(node['bcpc']['cloud']['vip']['ip']).address
+
+###############################################################################
+# ubuntu
+###############################################################################
+
+default['bcpc']['ubuntu']['archive_url'] = 'http://archive.ubuntu.com/ubuntu'
+default['bcpc']['ubuntu']['security_url'] = 'http://security.ubuntu.com/ubuntu'
+default['bcpc']['ubuntu']['codename'] = node['lsb']['codename']
+default['bcpc']['ubuntu']['components'] = ['main','restricted','universe','multiverse']
+default['bcpc']['ubuntu']['arch'] = 'amd64'
 
 ###############################################################################
 # proxy
@@ -228,18 +243,6 @@ default['bcpc']['metadata']['vendordata']['enabled'] = false
 
 default['bcpc']['bird']['repo']['enabled'] = false
 default['bcpc']['bird']['repo']['url'] = ""
-
-
-###############################################################################
-# calico/calicoctl
-###############################################################################
-
-default['bcpc']['calico']['repo']['enabled'] = true
-default['bcpc']['calico']['repo']['url'] = "http://ppa.launchpad.net/project-calico/calico-3.1/ubuntu"
-
-default['bcpc']['calico']['remote']['file'] = 'calicoctl'
-default['bcpc']['calico']['remote']['source'] = "#{default['bcpc']['file_server']['url']}/calicoctl"
-default['bcpc']['calico']['remote']['checksum'] = '62ae2334f62ca5e5501022845a885efdae8cd10cfbe40293a58e3d85d39bc120'
 
 
 ###############################################################################

--- a/chef/cookbooks/bcpc/attributes/networking.rb
+++ b/chef/cookbooks/bcpc/attributes/networking.rb
@@ -48,8 +48,8 @@ racks = default['bcpc']['networking']['topology']['racks']
 
 if (match = node['hostname'].match(/.*r(\d+)(\w+)?n(\d+)$/i))
 
-  default['bcpc']['networking']['rack_id'] = match.captures[1].to_i
-  default['bcpc']['networking']['pod_id'] = match.captures[2]
+  default['bcpc']['networking']['rack_id'] = match.captures[0].to_i
+  default['bcpc']['networking']['pod_id'] = match.captures[1]
 
 else
 

--- a/chef/cookbooks/bcpc/recipes/apt.rb
+++ b/chef/cookbooks/bcpc/recipes/apt.rb
@@ -16,18 +16,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-return unless node['bcpc']['proxy']['enabled']
-
-template "/etc/apt/apt.conf.d/00-bcpc-proxy" do
-  source 'apt/00-bcpc-proxy.erb'
+template "/etc/apt/apt.conf.d/00bcpc" do
+  source 'apt/bcpc-apt.conf.erb'
   variables(
-    :proxies => node['bcpc']['proxy']['proxies']
+    :conf => node['bcpc']['apt']
   )
-  notifies :run, 'execute[apt-get update]', :immediately
+end
+
+template "/etc/apt/sources.list" do
+  source 'apt/sources.list.erb'
+  variables(
+    :config => node['bcpc']['ubuntu']
+  )
 end
 
 execute 'apt-get update' do
-  action :nothing
   command 'apt-get update'
 end

--- a/chef/cookbooks/bcpc/recipes/calico-apt.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-apt.rb
@@ -37,6 +37,7 @@ end
 return unless node['bcpc']['calico']['repo']['enabled']
 
 apt_repository "calico" do
+  arch 'amd64'
   uri node['bcpc']['calico']['repo']['url']
   distribution 'xenial'
   components ["main"]

--- a/chef/cookbooks/bcpc/recipes/mysql.rb
+++ b/chef/cookbooks/bcpc/recipes/mysql.rb
@@ -18,6 +18,7 @@
 #
 if node['bcpc']['mysql']['apt']['enabled']
   apt_repository "percona" do
+    arch 'amd64'
     uri node['bcpc']['mysql']['apt']['url']
     distribution node['lsb']['codename']
     components ["main"]

--- a/chef/cookbooks/bcpc/recipes/networking.rb
+++ b/chef/cookbooks/bcpc/recipes/networking.rb
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+service 'systemd-resolved'
+
 vip = get_address(node['bcpc']['cloud']['vip']['ip'])
 
 cookbook_file "/etc/modules-load.d/8021q.conf" do
@@ -118,4 +120,17 @@ end
 
 execute "netplan apply" do
   command "netplan apply"
+end
+
+template "/etc/systemd/resolved.conf" do
+  source 'systemd/resolved.conf.erb'
+
+  vip = get_address(node['bcpc']['cloud']['vip']['ip'])
+
+  variables(
+    :dns => vip,
+    :fallback => node['bcpc']['dns_servers'].dup.join(' ')
+  )
+
+  notifies :restart, 'service[systemd-resolved]', :immediately
 end

--- a/chef/cookbooks/bcpc/recipes/unbound.rb
+++ b/chef/cookbooks/bcpc/recipes/unbound.rb
@@ -44,20 +44,6 @@ template "/etc/unbound/unbound.conf.d/server.conf" do
   notifies :restart, 'service[unbound]', :delayed
 end
 
-template "/etc/systemd/resolved.conf" do
-  source 'systemd/resolved.conf.erb'
-
-  vip = get_address(node['bcpc']['cloud']['vip']['ip'])
-  dns = [vip] + node['bcpc']['dns_servers'].dup
-  dns.join(' ')
-
-  variables(
-    :dns => dns
-  )
-
-  notifies :restart, 'service[systemd-resolved]', :immediately
-end
-
 # Disable DNSSEC
 file '/etc/unbound/unbound.conf.d/root-auto-trust-anchor-file.conf' do
   action :delete

--- a/chef/cookbooks/bcpc/templates/default/apt/00-bcpc-proxy.erb
+++ b/chef/cookbooks/bcpc/templates/default/apt/00-bcpc-proxy.erb
@@ -1,3 +1,0 @@
-<% @proxies.each do |schema,url| -%>
-Acquire::<%= schema %>::Proxy "<%= url %>";
-<% end -%>

--- a/chef/cookbooks/bcpc/templates/default/apt/bcpc-apt.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/apt/bcpc-apt.conf.erb
@@ -1,0 +1,6 @@
+<% if @conf['proxy']['enabled'] %>
+<% @conf['proxies'].each do |schema,url| -%>
+Acquire::<%= schema %>::Proxy "<%= url %>";
+<% end %>
+<% end -%>
+APT::Get::AllowUnauthenticated "<%= @conf['allow_unauthenticated'] %>";

--- a/chef/cookbooks/bcpc/templates/default/apt/sources.list.erb
+++ b/chef/cookbooks/bcpc/templates/default/apt/sources.list.erb
@@ -1,0 +1,4 @@
+deb [ <%= "arch=#{@config['arch']}" %> ] <%= @config['archive_url'] %> <%= @config['codename'] %> <%= @config['components'].join(' ') %>
+deb [ <%= "arch=#{@config['arch']}" %> ] <%= @config['archive_url'] %> <%= "#{@config['codename']}-updates" %> <%= @config['components'].join(' ') %>
+deb [ <%= "arch=#{@config['arch']}" %> ] <%= @config['archive_url'] %> <%= "#{@config['codename']}-backports" %> <%= @config['components'].join(' ') %>
+deb [ <%= "arch=#{@config['arch']}" %> ] <%= @config['security_url'] %> <%= "#{@config['codename']}-security" %> <%= @config['components'].join(' ') %>

--- a/chef/cookbooks/bcpc/templates/default/systemd/resolved.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/systemd/resolved.conf.erb
@@ -3,7 +3,7 @@
 ###############################################################################
 [Resolve]
 DNS=<%= @dns %>
-#FallbackDNS=
+FallbackDNS=<%= @fallback %>
 #Domains=
 #LLMNR=no
 #MulticastDNS=no

--- a/chef/environments/virtual.json
+++ b/chef/environments/virtual.json
@@ -10,17 +10,6 @@
           "net.ifnames=0",
           "biosdevname=0"
         ]
-      },
-      "proxy": {
-        "enabled": false,
-        "proxies": {
-          "http": "",
-          "https": ""
-        }
-      },
-      "dns_servers" : [ "10.10.10.10" ],
-      "ntp": {
-        "servers" : [ "10.10.10.10" ]
       }
     }
   }


### PR DESCRIPTION
  - apt
    - added apt attributes file for apt specific configuration
    - updated apt.conf.d/00-bcpc to accept all apt config as template
      variable
    - added support for customized sources.list contents
  - calico
    - removed old calico config
    - moved calico config from default into attributes/calico.rb
    - added arch amd64 to apt_repository resource
  - networking
    - fixed incorrect array indexing from regex capture
    - moved systemd-resolved dns configuration to networking.rb recipe
  - mysql
    - added arch amd64 to apt_repository resource
  - systemd-resolved
    - added configuration option for fallback dns servers
  - virtual environment
    - removed proxy,dns_servers and ntp configuration. defaults are now in
      defaults.rb