### PR TITLE
Align VirtualBox (5.1 or 5.2) VM configuration with V7 settings.

### DIFF
--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -49,6 +49,7 @@ Vagrant.configure("2") do |config|
 
         args = {}.tap do |args|
           args[:virtualbox__intnet] = n['network']
+          args[:nic_type] = '82543GC'
           args[:auto_config] = false
         end
 
@@ -67,6 +68,11 @@ Vagrant.configure("2") do |config|
         vb.cpus = hw_profile['cpus']
         vb.memory = hw_profile['ram_gb'] * 1024
         vb.customize ['modifyvm', :id, '--groups', project_name]
+        vb.customize ['modifyvm', :id, '--uart1', '0x3F8', '4']
+        vb.customize ['modifyvm', :id, '--uart2', '0x2F8', '3']
+        vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
+        vb.customize ['modifyvm', :id, '--uartmode2', 'disconnected']
+        vb.customize ['modifyvm', :id, '--vram', '16']
 
         # extra hard drives
         #


### PR DESCRIPTION
With this change, the VMs created by VirtualBox via Vagrant will have the same optimizations that the ones under V7 did. Most of the latter settings are already the default in VirtualBox 5.1 and 5.2 so this only sets the ones that need to be changed.