### PR TITLE
az and ha support

### DIFF
--- a/ansible/playbooks/roles/chef-workstation/tasks/upload-bcpc.yml
+++ b/ansible/playbooks/roles/chef-workstation/tasks/upload-bcpc.yml
@@ -2,11 +2,12 @@
   synchronize:
     src: "{{ item }}"
     dest: "/var/bcpc/chef/{{ chef_org_short_name }}/"
+    delete: yes
     recursive: yes
     rsync_opts:
-      - --copy-links
-      - --exclude="*.swp"
-      - --exclude=".git"
+      - "--copy-links"
+      - "--exclude=*.swp"
+      - "--exclude=.git"
   with_items:
     - "{{ chef_cookbooks_dir }}"
 

--- a/chef/cookbooks/bcpc/libraries/utils.rb
+++ b/chef/cookbooks/bcpc/libraries/utils.rb
@@ -177,3 +177,31 @@ end
 def get_address(cidr)
   return IPAddress(cidr).address
 end
+
+def get_availability_zones()
+
+  az = []
+  racks = node['bcpc']['networking']['topology']['racks']
+
+  racks.each do |rack|
+    az.append("AZ-#{rack['id']}")
+  end
+
+  return az
+
+end
+
+def get_availability_zone()
+
+  az = nil
+
+  if (match = node['hostname'].match(/.*r(\d+)(\w+)?n(\d+)$/i))
+    rack_id = match.captures[0].to_i
+    az = "AZ-#{rack_id}"
+  else
+    raise "Unable to get availability zone for #{node['hostname']}"
+  end
+
+  return az
+
+end

--- a/chef/cookbooks/bcpc/libraries/utils.rb
+++ b/chef/cookbooks/bcpc/libraries/utils.rb
@@ -191,7 +191,7 @@ def get_availability_zones()
 
 end
 
-def get_availability_zone()
+def get_local_availability_zone()
 
   az = nil
 

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -174,7 +174,7 @@ execute 'wait for compute host' do
 end
 
 begin
-  az = get_availability_zone()
+  az = get_local_availability_zone()
 
   execute "add #{node['hostname']} to the #{az} availability zone" do
     environment (os_adminrc())

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -172,3 +172,16 @@ execute 'wait for compute host' do
       --service nova-compute | grep #{node['hostname']}
   EOH
 end
+
+begin
+  az = get_availability_zone()
+
+  execute "add #{node['hostname']} to the #{az} availability zone" do
+    environment (os_adminrc())
+    command "openstack aggregate add host #{az} #{node['hostname']}"
+    not_if "
+      aggregates=$(openstack hypervisor show #{node['fqdn']} -f value -c aggregates)
+      echo ${aggregates} | grep -w #{az}
+    "
+  end
+end

--- a/chef/cookbooks/bcpc/recipes/nova-head.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-head.rb
@@ -391,3 +391,16 @@ execute 'wait for nova to come online' do
   retries 30
   command 'openstack compute service list'
 end
+
+begin
+  zones = get_availability_zones()
+
+  zones.each do | zone |
+    execute "creating the #{zone} availability zone" do
+      environment (os_adminrc())
+      command "openstack aggregate create #{zone}"
+      not_if "openstack aggregate show #{zone}"
+    end
+  end
+
+end


### PR DESCRIPTION
  - availability zones
    - created for each rack listed in the network topology

  - host aggregates
    - each compute node is added to the az for its rack

  - ansible
    - upload-bcpc tag
      - corrected rsync options to properly ignore .swp and .git
      - use delete attribute on syncronize module