### PR TITLE
Switch to 4-byte AS numbers.

### DIFF
--- a/chef/cookbooks/bcpc/attributes/networking.rb
+++ b/chef/cookbooks/bcpc/attributes/networking.rb
@@ -14,7 +14,7 @@ default['bcpc']['networking']['topology'] = {
     {
       'id' => 1,
       'pod' => 'a',
-      'bgp_as' => 64_111,
+      'bgp_as' => 4_200_858_701,
       'networks' => {
         'primary' => { 'cidr' => '10.121.84.0/28', 'gateway' => '10.121.84.1' },
         'storage' => { 'cidr' => '10.121.88.0/28', 'gateway' => '10.121.88.1' }
@@ -23,7 +23,7 @@ default['bcpc']['networking']['topology'] = {
     {
       'id' => 2,
       'pod' => 'a',
-      'bgp_as' => 64_112,
+      'bgp_as' => 4_200_858_702,
       'networks' => {
         'primary' => { 'cidr' => '10.121.85.0/28', 'gateway' => '10.121.85.1' },
         'storage' => { 'cidr' => '10.121.89.0/28', 'gateway' => '10.121.89.1' }
@@ -32,7 +32,7 @@ default['bcpc']['networking']['topology'] = {
     {
       'id' => 3,
       'pod' => 'a',
-      'bgp_as' => 64_113,
+      'bgp_as' => 4_200_858_703,
       'networks' => {
         'primary' => { 'cidr' => '10.121.86.0/28', 'gateway' => '10.121.86.1' },
         'storage' => { 'cidr' => '10.121.90.0/28', 'gateway' => '10.121.90.1' }

--- a/chef/cookbooks/bcpc/templates/default/bird/bird.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/bird/bird.conf.erb
@@ -55,7 +55,7 @@ protocol device {
 }
 
 protocol bgp {
-  description "connection to leaf";
+  description "connection to tor";
   local <%= node['ipaddress'] %> as <%= @as_number %>;
   neighbor <%= @upstream_peer %> as <%= @as_number %>;
   multihop;


### PR DESCRIPTION
This commit aligns the AS numbers used by the TORs (or leaf routers) to the default of several virtualized leafy-spine implementations.