### PR TITLE
Anycast address should only be exported by Consul leader.

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/consul/dns-watch.erb
+++ b/chef/cookbooks/bcpc/templates/default/consul/dns-watch.erb
@@ -1,11 +1,45 @@
 #!/bin/bash
 
+#
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+disable_bgp() {
+    /usr/sbin/birdc 'disable bgp1'
+}
+
+enable_bgp() {
+    /usr/sbin/birdc 'enable bgp1'
+}
+
+self_ip="<%= node['ipaddress'] %>"
+leader=$(curl -qs http://localhost:8500/v1/status/leader | jq -r '.')
+if [ "${self_ip}" != "${leader%:8300}" ]; then
+    disable_bgp
+    exit 0
+fi
+
 status="`cat`"
 self="<%= node['hostname'] %>"
 echo "$status" > /tmp/dns-handler.log
-echo "$status" | jq ".[] | select((.Node==\"$self\") and (.CheckID==\"service:dns\")) | .Status" | grep -q passing
+echo "$status" | jq ".[] |
+  select((.Node==\"$self\") and (.CheckID==\"service:dns\")) | .Status" |
+  grep -q passing
 if [ $? -eq 0 ]; then
-  sudo /usr/sbin/birdc 'enable bgp1'
+    enable_bgp
 else
-  sudo /usr/sbin/birdc 'disable bgp1'
+    disable_bgp
 fi
+exit 0

--- a/chef/cookbooks/bcpc/templates/default/consul/haproxy-watch.erb
+++ b/chef/cookbooks/bcpc/templates/default/consul/haproxy-watch.erb
@@ -1,11 +1,45 @@
 #!/bin/bash
 
+#
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+disable_bgp() {
+    /usr/sbin/birdc 'disable bgp1'
+}
+
+enable_bgp() {
+    /usr/sbin/birdc 'enable bgp1'
+}
+
+self_ip="<%= node['ipaddress'] %>"
+leader=$(curl -qs http://localhost:8500/v1/status/leader | jq -r '.')
+if [ "${self_ip}" != "${leader%:8300}" ]; then
+    disable_bgp
+    exit 0
+fi
+
 status="`cat`"
 self="<%= node['hostname'] %>"
 echo "$status" > /tmp/haproxy-handler.log
-echo "$status" | jq ".[] | select((.Node==\"$self\") and (.CheckID==\"service:haproxy\")) | .Status" | grep -q passing
+echo "$status" | jq ".[] |
+  select((.Node==\"$self\") and (.CheckID==\"service:haproxy\")) | .Status" |
+  grep -q passing
 if [ $? -eq 0 ]; then
-  sudo /usr/sbin/birdc 'enable bgp1'
+    enable_bgp
 else
-  sudo /usr/sbin/birdc 'disable bgp1'
+    disable_bgp
 fi
+exit 0


### PR DESCRIPTION
The checks in the DNS and haproxy watch scripts don't actually check whether a node is the Consul leader before enabling or disabling BGP. After checking this, only one of the head nodes will end up exporting its routes (in particular any Anycast addresses) to the TOR in the rack.

This was tested by manually resetting the Consul services on the leader causing a new election and then observing a new head node becomes the node exporting the Anycast routes.