### PR TITLE
Recipe for chrony should restart the service.

### DIFF
--- a/chef/cookbooks/bcpc/recipes/calico-apt.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-apt.rb
@@ -22,7 +22,7 @@ remote_file fp do
   mode '755'
   source node['bcpc']['calico']['remote']['source']
   checksum node['bcpc']['calico']['remote']['checksum']
-  notifies :create, 'remote_file[install calicoctl]', :immediate
+  notifies :create, 'remote_file[install calicoctl]', :immediately
 end
 
 remote_file 'install calicoctl' do

--- a/chef/cookbooks/bcpc/recipes/chrony.rb
+++ b/chef/cookbooks/bcpc/recipes/chrony.rb
@@ -24,4 +24,5 @@ template '/etc/chrony/chrony.conf' do
   variables(
     servers: node['bcpc']['ntp']['servers']
   )
+  notifies :restart, 'service[chrony]', :immediately
 end

--- a/chef/cookbooks/bcpc/recipes/consul-package.rb
+++ b/chef/cookbooks/bcpc/recipes/consul-package.rb
@@ -24,8 +24,8 @@ remote_file consul_fp do
   source "#{node['bcpc']['file_server']['url']}/#{consul_fn}"
   mode '755'
   checksum node['bcpc']['consul']['remote_file']['checksum']
-  notifies :run, 'execute[unpack consul]', :immediate
-  notifies :create, 'remote_file[install consul]', :immediate
+  notifies :run, 'execute[unpack consul]', :immediately
+  notifies :create, 'remote_file[install consul]', :immediately
 end
 
 execute 'unpack consul' do

--- a/chef/cookbooks/bcpc/recipes/consul.rb
+++ b/chef/cookbooks/bcpc/recipes/consul.rb
@@ -53,13 +53,13 @@ end
 file "#{node['bcpc']['consul']['conf_dir']}/watches.json" do
   watches = { 'watches' => node['bcpc']['consul']['watches'] }
   content JSON.pretty_generate(watches)
-  notifies :reload, 'service[consul]', :immediate
+  notifies :reload, 'service[consul]', :immediately
 end
 
 file "#{node['bcpc']['consul']['conf_dir']}/services.json" do
   services = { 'services' => node['bcpc']['consul']['services'] }
   content JSON.pretty_generate(services)
-  notifies :restart, 'service[consul]', :immediate
+  notifies :restart, 'service[consul]', :immediately
 end
 
 begin

--- a/chef/cookbooks/bcpc/recipes/etcd-packages.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd-packages.rb
@@ -23,9 +23,9 @@ remote_file fp do
   mode '755'
 
   checksum node['bcpc']['etcd']['remote']['checksum']
-  notifies :run, 'execute[unpack etcd]', :immediate
-  notifies :create, 'remote_file[install etcd]', :immediate
-  notifies :create, 'remote_file[install etcdctl]', :immediate
+  notifies :run, 'execute[unpack etcd]', :immediately
+  notifies :create, 'remote_file[install etcd]', :immediately
+  notifies :create, 'remote_file[install etcdctl]', :immediately
 end
 
 execute 'unpack etcd' do

--- a/chef/cookbooks/bcpc/recipes/memcached.rb
+++ b/chef/cookbooks/bcpc/recipes/memcached.rb
@@ -30,7 +30,7 @@ template '/etc/memcached.conf' do
     verbose: node['bcpc']['memcached']['debug'],
     connections: node['bcpc']['memcached']['connections']
   )
-  notifies :restart, 'service[memcached]', :immediate
+  notifies :restart, 'service[memcached]', :immediately
 end
 
 logrotate_app 'memcached' do

--- a/chef/cookbooks/bcpc/recipes/unbound.rb
+++ b/chef/cookbooks/bcpc/recipes/unbound.rb
@@ -44,5 +44,5 @@ end
 # Disable DNSSEC
 file '/etc/unbound/unbound.conf.d/root-auto-trust-anchor-file.conf' do
   action :delete
-  notifies :restart, 'service[unbound]', :immediate
+  notifies :restart, 'service[unbound]', :immediately
 end

--- a/chef/cookbooks/bcpc/templates/default/apache2/index.html.erb
+++ b/chef/cookbooks/bcpc/templates/default/apache2/index.html.erb
@@ -86,5 +86,5 @@
           <%= @config['ssl']['intermediate'].gsub(/\n/, '<br/>') %>
       </code>
     <% end %>
-	</body>
+  </body>
 </html>

--- a/chef/cookbooks/bcpc/templates/default/etc/hosts.erb
+++ b/chef/cookbooks/bcpc/templates/default/etc/hosts.erb
@@ -7,11 +7,11 @@
 127.0.0.1	localhost
 
 # The following lines are desirable for IPv6 capable hosts
-::1     ip6-localhost ip6-loopback
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters
+::1	ip6-localhost	ip6-loopback
+fe00::0	ip6-localnet
+ff00::0	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
 
 # cloud fqdn
 #
@@ -21,7 +21,7 @@ ff02::2 ip6-allrouters
 #
 <% @nodes.each do |n| -%>
   <% if n['roles'].include? 'bootstrap' %>
-<%= "#{n['ipaddress']}\t#{n['fqdn']}\t#{n['hostname']} bootstrap" %>
+<%= "#{n['ipaddress']}\t#{n['fqdn']}\t#{n['hostname']}\tbootstrap" %>
   <% else %>
 <%= "#{n['ipaddress']}\t#{n['fqdn']}\t#{n['hostname']}" %>
   <% end %>


### PR DESCRIPTION
Use :immediately consistently in Chef notifications.
Address several whitespace nits.