### PR TITLE
dns zone creation/fill, misc fixes/updates

### DIFF
--- a/ansible/playbooks/file_vars/chef/headnode.yml
+++ b/ansible/playbooks/file_vars/chef/headnode.yml
@@ -18,7 +18,6 @@ run_list:
   - recipe[bcpc::powerdns]
   - recipe[bcpc::apache2]
   - recipe[bcpc::keystone]
-  - recipe[bcpc::designate]
   - recipe[bcpc::glance]
   - recipe[bcpc::neutron-head]
   - recipe[bcpc::nova-head]

--- a/ansible/playbooks/roles/headnode/tasks/register-compute-nodes.yml
+++ b/ansible/playbooks/roles/headnode/tasks/register-compute-nodes.yml
@@ -15,7 +15,7 @@
 
     # filter status results for only hosts that have disabled services
     disabled=$(echo ${services} | \
-      jq -r '.[] | select(.Status | contains("disabled")) .Host')
+      jq -r '.[] | select(.Status == "disabled") .Host')
 
     # enable nova-compute services on disabled hosts
     echo "${disabled}" | \

--- a/chef/cookbooks/bcpc/attributes/keystone.rb
+++ b/chef/cookbooks/bcpc/attributes/keystone.rb
@@ -51,7 +51,7 @@ default['bcpc']['keystone']['identity']['domain_configurations_from_database'] =
 default['bcpc']['keystone']['roles']['admin'] = 'admin'
 default['bcpc']['keystone']['roles']['member'] = '_member_'
 
-default['bcpc']['keystone']['admin']['email'] = 'admin@bcpc.example.com'
+default['bcpc']['keystone']['admin']['email'] = "admin@#{node['bcpc']['cloud']['domain']}"
 default['bcpc']['keystone']['admin']['username'] = 'admin'
 default['bcpc']['keystone']['admin']['project_name'] = 'admin'
 default['bcpc']['keystone']['admin']['domain'] = 'default'

--- a/chef/cookbooks/bcpc/attributes/neutron.rb
+++ b/chef/cookbooks/bcpc/attributes/neutron.rb
@@ -1,6 +1,7 @@
 ###############################################################################
 #  neutron
 ###############################################################################
+require 'ipaddress'
 
 default['bcpc']['neutron']['debug'] = false
 default['bcpc']['neutron']['db']['dbname'] = 'neutron'
@@ -11,10 +12,22 @@ default['bcpc']['neutron']['networks'] = [
   {
     'name' => 'ext1',
     'fixed' => [
-      { 'cidr' => '10.64.0.0/16' },
+      {
+        'cidr' => IPAddress('10.64.0.0/16'),
+        'dns' => {
+          'hostname_prefix' => 'ext1',
+          'reverse_zone' => '64.10.in-addr.arpa',
+        },
+      },
     ],
     'float' => [
-      { 'cidr' => '10.65.0.0/16' },
+      {
+        'cidr' => IPAddress('10.65.0.0/16'),
+        'dns' => {
+          'hostname_prefix' => 'float',
+          'reverse_zone' => '65.10.in-addr.arpa',
+        },
+      },
     ],
   },
 ]

--- a/chef/cookbooks/bcpc/attributes/neutron.rb
+++ b/chef/cookbooks/bcpc/attributes/neutron.rb
@@ -13,7 +13,7 @@ default['bcpc']['neutron']['networks'] = [
     'name' => 'ext1',
     'fixed' => [
       {
-        'cidr' => IPAddress('10.64.0.0/16'),
+        'allocation' => IPAddress('10.64.0.0/16'),
         'dns' => {
           'hostname_prefix' => 'ext1',
           'reverse_zone' => '64.10.in-addr.arpa',
@@ -22,7 +22,7 @@ default['bcpc']['neutron']['networks'] = [
     ],
     'float' => [
       {
-        'cidr' => IPAddress('10.65.0.0/16'),
+        'allocation' => IPAddress('10.65.0.0/16'),
         'dns' => {
           'hostname_prefix' => 'float',
           'reverse_zone' => '65.10.in-addr.arpa',

--- a/chef/cookbooks/bcpc/attributes/neutron.rb
+++ b/chef/cookbooks/bcpc/attributes/neutron.rb
@@ -7,14 +7,14 @@ default['bcpc']['neutron']['db']['dbname'] = 'neutron'
 
 # networks
 #
-default['bcpc']['neutron']['network']['ext1'] = {
-  'subnets' => [
-    { 'name' => 'primary', 'cidr' => '10.64.0.0/18' },
-  ],
-}
-
-default['bcpc']['neutron']['network']['ext2'] = {
-  'subnets' => [
-    { 'name' => 'primary', 'cidr' => '10.65.0.0/18' },
-  ],
-}
+default['bcpc']['neutron']['networks'] = [
+  {
+    'name' => 'ext1',
+    'fixed' => [
+      { 'cidr' => '10.64.0.0/16' },
+    ],
+    'float' => [
+      { 'cidr' => '10.65.0.0/16' },
+    ],
+  },
+]

--- a/chef/cookbooks/bcpc/attributes/powerdns.rb
+++ b/chef/cookbooks/bcpc/attributes/powerdns.rb
@@ -14,5 +14,5 @@ default['bcpc']['powerdns']['axfr']['allow_axfr_ips'] = []
 default['bcpc']['powerdns']['receiver_threads'] = 3
 
 # webserver
-default['bcpc']['powerdns']['webserver']['address'] = '127.0.0.1'
+default['bcpc']['powerdns']['webserver']['address'] = node['ipaddress']
 default['bcpc']['powerdns']['webserver']['port'] = 8081

--- a/chef/cookbooks/bcpc/attributes/unbound.rb
+++ b/chef/cookbooks/bcpc/attributes/unbound.rb
@@ -4,6 +4,7 @@
 
 vip = node['bcpc']['cloud']['vip']
 cloud_domain = node['bcpc']['cloud']['domain']
+powerdns_address = node['bcpc']['powerdns']['local_address']
 powerdns_port = node['bcpc']['powerdns']['local_port']
 
 default['bcpc']['unbound']['default']['root_trust_anchor_update'] = false
@@ -25,8 +26,5 @@ default['bcpc']['unbound']['server']['verbosity'] = 1
 # TLD quieries to forward to other name servers
 #
 default['bcpc']['unbound']['forward-zone']['consul'] = [vip + '@8600']
-default['bcpc']['unbound']['forward-zone'][cloud_domain] = ["#{vip}@#{powerdns_port}"]
+default['bcpc']['unbound']['forward-zone'][cloud_domain] = ["#{powerdns_address}@#{powerdns_port}"]
 default['bcpc']['unbound']['forward-zone']['.'] = node['bcpc']['dns_servers']
-
-default['bcpc']['powerdns']['local_address'] = node['ipaddress']
-default['bcpc']['powerdns']['local_port'] = 5300

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -203,7 +203,7 @@ node['bcpc']['neutron']['networks'].each do |network|
 
   # create fixed subnets
   network.fetch('fixed', []).each do |fixed|
-    cidr = "#{fixed['cidr'].network.address}/#{fixed['cidr'].prefix}"
+    cidr = "#{fixed['allocation'].network.address}/#{fixed['allocation'].prefix}"
     subnet_name = "#{fixed_network}-fixed-#{cidr}"
 
     execute "create the #{fixed_network} network #{subnet_name} subnet" do
@@ -237,7 +237,7 @@ node['bcpc']['neutron']['networks'].each do |network|
 
   # create float subnets
   network.fetch('float', []).each do |float|
-    cidr = "#{float['cidr'].network.address}/#{float['cidr'].prefix}"
+    cidr = "#{float['allocation'].network.address}/#{float['allocation'].prefix}"
     subnet_name = "#{float_network}-#{cidr}"
 
     execute "create the #{float_network} network #{subnet_name} subnet" do

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -174,6 +174,8 @@ template '/etc/neutron/neutron.conf' do
   )
   notifies :restart, 'service[neutron-server]', :immediately
 end
+#
+# configure neutron ends
 
 execute 'wait for neutron to come online' do
   environment os_adminrc
@@ -181,43 +183,128 @@ execute 'wait for neutron to come online' do
   command 'openstack network list'
 end
 
-node['bcpc']['neutron']['network'].each do |network, spec|
-  subnets = spec['subnets']
+# create networks starts
+node['bcpc']['neutron']['networks'].each do |network|
+  fixed_network = network['name']
 
-  execute "create #{network} network" do
+  raise "#{fixed_network}: no subnets defined" unless network.key?('fixed')
+
+  # create fixed network
+  execute "create the #{fixed_network} network" do
     environment os_adminrc
 
     command <<-DOC
-      openstack network create #{network} \
+      openstack network create #{fixed_network} \
         --share --provider-network-type local
     DOC
 
-    not_if "openstack network show #{network}"
+    not_if "openstack network show #{fixed_network}"
   end
 
-  subnets.each do |subnet|
-    subnet_name = subnet['name']
-    cidr = subnet['cidr']
+  # create fixed subnets
+  network.fetch('fixed', []).each do |fixed|
+    cidr = fixed['cidr']
+    subnet_name = "#{fixed_network}-fixed-#{cidr}"
 
-    execute "create #{network} network #{subnet_name} subnet" do
+    execute "create the #{fixed_network} network #{subnet_name} subnet" do
       environment os_adminrc
 
       command <<-DOC
         openstack subnet create #{subnet_name} \
-          --network #{network} --subnet-range #{cidr}
+          --network #{fixed_network} --subnet-range #{cidr}
       DOC
 
       not_if <<-DOC
-        openstack subnet list --network #{network} | grep -w #{subnet_name}
+        openstack subnet list -c Subnet -f value | grep -w #{cidr}
       DOC
     end
   end
+
+  next unless network.key?('float')
+
+  # create float network
+  float_network = "#{network['name']}-float"
+
+  execute "create the #{float_network} network" do
+    environment os_adminrc
+
+    command <<-DOC
+      openstack network create #{float_network} --external
+    DOC
+
+    not_if "openstack network show #{float_network}"
+  end
+
+  # create float subnets
+  network.fetch('float', []).each do |float|
+    cidr = float['cidr']
+    subnet_name = "#{float_network}-#{cidr}"
+
+    execute "create the #{float_network} network #{subnet_name} subnet" do
+      environment os_adminrc
+
+      command <<-DOC
+        openstack subnet create #{subnet_name} \
+          --network #{float_network} --subnet-range #{cidr}
+      DOC
+
+      not_if <<-DOC
+        openstack subnet list -c Subnet -f value | grep -w #{cidr}
+      DOC
+    end
+  end
+
+  # create router
+  router_name = fixed_network
+
+  execute "create the #{fixed_network} network router (#{router_name})" do
+    environment os_adminrc
+
+    command <<-DOC
+      openstack router create #{router_name}
+    DOC
+
+    not_if "openstack router show #{router_name}"
+  end
+
+  # add subnets to router
+  bash 'add subnets to router' do
+    environment os_adminrc
+    code <<-EOH
+      set -e
+
+      subnets=$(openstack subnet list --network #{fixed_network} -c ID -f value)
+      ifaces=$(openstack router show #{router_name} -f json | jq -r .interfaces_info)
+
+      for subnet in ${subnets}; do
+        exists=$(echo $ifaces | jq --arg SUBNETID "$subnet" '.[] | select(.subnet_id == $SUBNETID)')
+
+        if [ ${#exists} -eq 0 ]; then
+          openstack router add subnet #{router_name} ${subnet}
+        fi
+      done
+    EOH
+  end
+
+  # set router external gateway
+  bash 'set external gateway for router' do
+    environment os_adminrc
+
+    code <<-EOH
+      set -e
+
+      router=$(openstack router show #{router_name} -f json)
+      gateway=$(echo ${router} | jq -r .external_gateway_info)
+
+      if [ "${gateway}" = "null" ]; then
+        openstack router set #{router_name} --external-gateway #{float_network}
+      fi
+    EOH
+  end
 end
-#
-# configure neutron ends
+# create networks ends
 
 # configure default security group starts
-#
 bash 'update admin project default security group to allow ping' do
   environment os_adminrc
 
@@ -253,5 +340,4 @@ bash 'update admin project default security group to allow ssh' do
     openstack security group rule list $group_id --proto tcp | grep '22:22'
   ", environment: os_adminrc
 end
-#
 # configure default security group ends

--- a/chef/cookbooks/bcpc/recipes/powerdns.rb
+++ b/chef/cookbooks/bcpc/recipes/powerdns.rb
@@ -79,44 +79,65 @@ template '/etc/powerdns/pdns.conf' do
   notifies :restart, 'service[pdns]', :immediately
 end
 
+# DNS forward zone creation/population
+#
+serial = Time.now.strftime('%Y%m%d01')
+email = node['bcpc']['keystone']['admin']['email'].tr('@', '.')
+networks = node['bcpc']['neutron']['networks']
+
 begin
-  require 'ipaddress'
-
-  # build an array of network objects that have their fixed cidr
-  # information expanded via 'IPAddress' which can be iterated on
-  # in the zone.erb template file
-  networks = []
-  node['bcpc']['neutron']['networks'].each do |network|
-    data = { 'name' => network['name'], 'cidrs' => [] }
-    network['fixed'].each do |fixed|
-      data['cidrs'].push(IPAddress(fixed['cidr']))
-    end
-    networks.push(data)
-  end
-
   zone = node['bcpc']['cloud']['domain']
-  zone_file = "/tmp/#{zone}.zone"
+  zone_file = "#{Chef::Config[:file_cache_path]}/#{zone}.zone"
 
+  # create dns zone for the cloud domain and setup forward lookups for
+  # fixed and float ip ranges
   template zone_file do
     source 'powerdns/zone.erb'
-
-    serial_number = Time.now.strftime('%Y%m%d01')
-    admin_email = node['bcpc']['keystone']['admin']['email'].tr('@', '.')
-
     variables(
-      networks: networks,
-      admin_email: admin_email,
-      serial_number: serial_number
+      email: email,
+      serial: serial,
+      networks: networks
     )
-
-    not_if "pdnsutil list-all-zones | grep #{zone}"
-    notifies :run, 'execute[load zone]', :immediately
   end
 
   execute 'load zone' do
-    action :nothing
     command <<-EOH
       pdnsutil load-zone #{zone} #{zone_file}
     EOH
+    not_if "pdnsutil list-all-zones | grep #{zone}"
+  end
+end
+
+# DNS reverse zone for each fixed/float network
+#
+begin
+  networks.each do |network|
+    %w(fixed float).each do |type|
+      network.fetch(type, []).each do |subnet|
+        next unless subnet.key?('dns') && subnet['dns'].key?('reverse_zone')
+
+        reverse_zone = subnet['dns']['reverse_zone']
+        reverse_zone_file = "#{Chef::Config[:file_cache_path]}/#{reverse_zone}.zone"
+
+        template reverse_zone_file do
+          source 'powerdns/reverse-zone.erb'
+          variables(
+            email: email,
+            serial: serial,
+            subnet: subnet,
+            reverse_zone: reverse_zone,
+            hostname_prefix: subnet['dns']['hostname_prefix']
+          )
+          not_if "pdnsutil list-all-zones | grep #{reverse_zone}"
+        end
+
+        execute 'load reverse zone' do
+          command <<-EOH
+            pdnsutil load-zone #{reverse_zone} #{reverse_zone_file}
+          EOH
+          not_if "pdnsutil list-all-zones | grep #{reverse_zone}"
+        end
+      end
+    end
   end
 end

--- a/chef/cookbooks/bcpc/recipes/powerdns.rb
+++ b/chef/cookbooks/bcpc/recipes/powerdns.rb
@@ -98,6 +98,7 @@ begin
       serial: serial,
       networks: networks
     )
+    not_if "pdnsutil list-all-zones | grep #{zone}"
   end
 
   execute 'load zone' do

--- a/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
@@ -20,11 +20,11 @@ local-port = <%= node['bcpc']['powerdns']['local_port'] %>
 
 # master    Act as a master
 #
-master = no
+master = yes
 
 # slave    Act as a slave
 #
-slave = yes
+slave = no
 
 # guardian  Run within a guardian process
 #

--- a/chef/cookbooks/bcpc/templates/default/powerdns/reverse-zone.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/reverse-zone.erb
@@ -11,6 +11,6 @@ $TTL 3600
 
 <%= @reverse_zone %> IN NS ns1.<%= node['bcpc']['cloud']['domain'] %>.
 
-<% @subnet['cidr'].each_host do |ip| %>
+<% @subnet['allocation'].each_host do |ip| %>
 <%= ip.reverse %> IN PTR <%= @hostname_prefix %>-<%= ip.octets.join('-') %>.<%= node['bcpc']['cloud']['domain'] %>
 <% end %>

--- a/chef/cookbooks/bcpc/templates/default/powerdns/reverse-zone.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/reverse-zone.erb
@@ -1,0 +1,16 @@
+$ORIGIN .
+$TTL 3600
+
+<%= @reverse_zone %> IN SOA ns1.<%= node['bcpc']['cloud']['domain'] %>. <%= @email %>. (
+    <%= @serial %> ; serial
+    3559 ; refresh
+    600 ; retry
+    86400 ; expire
+    3600 ; minimum
+)
+
+<%= @reverse_zone %> IN NS ns1.<%= node['bcpc']['cloud']['domain'] %>.
+
+<% @subnet['cidr'].each_host do |ip| %>
+<%= ip.reverse %> IN PTR <%= @hostname_prefix %>-<%= ip.octets.join('-') %>.<%= node['bcpc']['cloud']['domain'] %>
+<% end %>

--- a/chef/cookbooks/bcpc/templates/default/powerdns/zone.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/zone.erb
@@ -1,0 +1,13 @@
+$ORIGIN <%= node['bcpc']['cloud']['domain'] %>.
+$TTL 3600
+
+@  IN SOA ns1.<%= node['bcpc']['cloud']['domain'] %>. <%= @admin_email %>. <%= @serial_number %> 3559 600 86400 3600
+@  IN NS ns1.<%= node['bcpc']['cloud']['domain'] %>.
+
+<% @networks.each do |network| %>
+<% network['cidrs'].each do |cidr| %>
+<% cidr.each_host do |ip| %>
+<%= network['name'] %>-<%= ip.octets.join('-') %> IN A <%= ip %>
+<% end %>
+<% end %>
+<% end %>

--- a/chef/cookbooks/bcpc/templates/default/powerdns/zone.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/zone.erb
@@ -1,13 +1,22 @@
 $ORIGIN <%= node['bcpc']['cloud']['domain'] %>.
 $TTL 3600
 
-@  IN SOA ns1.<%= node['bcpc']['cloud']['domain'] %>. <%= @admin_email %>. <%= @serial_number %> 3559 600 86400 3600
-@  IN NS ns1.<%= node['bcpc']['cloud']['domain'] %>.
+@ IN SOA ns1.<%= node['bcpc']['cloud']['domain'] %>. <%= @email %>. (
+    <%= @serial %> ; serial
+    3559 ; refresh
+    600 ; retry
+    86400 ; expire
+    3600 ; minimum
+)
+
+@ IN NS ns1.<%= node['bcpc']['cloud']['domain'] %>.
 
 <% @networks.each do |network| %>
-<% network['cidrs'].each do |cidr| %>
-<% cidr.each_host do |ip| %>
-<%= network['name'] %>-<%= ip.octets.join('-') %> IN A <%= ip %>
-<% end %>
-<% end %>
+  <% %w[fixed float].each do |type| %>
+    <% network.fetch(type, []).each do |subnet| %>
+      <% subnet['cidr'].each_host do |ip| %>
+<%= subnet['dns']['hostname_prefix'] %>-<%= ip.octets.join('-') %> IN A <%= ip %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/chef/cookbooks/bcpc/templates/default/powerdns/zone.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/zone.erb
@@ -14,7 +14,7 @@ $TTL 3600
 <% @networks.each do |network| %>
   <% %w[fixed float].each do |type| %>
     <% network.fetch(type, []).each do |subnet| %>
-      <% subnet['cidr'].each_host do |ip| %>
+      <% subnet['allocation'].each_host do |ip| %>
 <%= subnet['dns']['hostname_prefix'] %>-<%= ip.octets.join('-') %> IN A <%= ip %>
       <% end %>
     <% end %>


### PR DESCRIPTION
  - dns zone creation/fill
    - create zone for cloud domain
    - populate zone with ip information from fixed networks defined in neutron

  - designate
    - removed from runlist
    - very poor performance when importing >1k recordset zone file

  - ansible
    - register-compute-nodes task
      - updated selector to use '==' vs. 'contains' for exact matching

  - keystone
    - update admin email attribute to use domain variable

  - neutron
    - added support for floating ips
    - refactored 'networks' strucuture to support mutliple fixed/float subnets
      per network

  - unbound
    - updated cloud_domain forward-zone to point to powerdns over designate

  - powerdns
    - operating as master