### PR TITLE
haproxy fixes

### DIFF
--- a/cookbooks/bcpc/recipes/haproxy-common.rb
+++ b/cookbooks/bcpc/recipes/haproxy-common.rb
@@ -35,6 +35,11 @@ end
 
 package "haproxy" do
     action :install
+    notifies :restart, 'service[rsyslog]', :immediately
+end
+
+service 'rsyslog' do
+    action :nothing
 end
 
 bash "enable-defaults-haproxy" do

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -51,6 +51,7 @@ listen keystone-api
   option httplog
   option httpchk GET /
   http-check expect status 300
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:5000 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -58,17 +59,20 @@ listen keystone-api
 frontend keystone-admin
   bind <%=node['bcpc']['management']['vip']%>:35357 <%= (node['bcpc']['protocol']['keystone'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   option httplog
+  option forwardfor
   default_backend keystone-admin-backend
 
 frontend keystone-admin-httponly
   bind <%=node['bcpc']['management']['vip']%>:35358
   option httplog
+  option forwardfor
   default_backend keystone-admin-backend
 
 backend keystone-admin-backend
   balance source
   option httpchk GET /
   http-check expect status 300
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:35357 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -79,6 +83,7 @@ listen glance-api
   option httplog
   option httpchk GET /
   http-check expect status 300
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:9292 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -89,6 +94,7 @@ listen glance-registry
   option httplog
   option httpchk GET /
   http-check expect status 401
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:9191 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -99,6 +105,7 @@ listen cinder-api
   option httplog
   option httpchk GET /
   http-check expect status 300
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8776 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -109,6 +116,7 @@ listen nova-api
   option httplog
   option httpchk GET /
   http-check expect status 200
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8774 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -120,6 +128,7 @@ listen neutron-api
   option httplog
   option httpchk GET /
   http-check expect status 200
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:9696 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -131,6 +140,7 @@ listen heat-api
   option httplog
   option httpchk GET /
   http-check expect status 300
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8004 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -141,6 +151,7 @@ listen heat-api-cfn
   option httplog
   option httpchk GET /
   http-check expect status 300
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8000 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -151,6 +162,7 @@ listen novnc
   option httplog
   option httpchk GET /vnc_auto.html
   http-check expect status 200
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:6080 check inter 5s rise 1 fall 1" %>
 <% end -%>
@@ -189,6 +201,7 @@ backend horizon-backend
   balance source
   option httpchk GET /
   http-check expect status 200
+  option forwardfor
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:9999 check inter 5s rise 1 fall 1" %>
 <% end -%>

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -48,7 +48,7 @@ listen mysql-galera
 listen keystone-api
   bind <%=node['bcpc']['management']['vip']%>:5000 <%= (node['bcpc']['protocol']['keystone'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source
-  option tcplog
+  option httplog
   option httpchk GET /
   http-check expect status 300
 <% @servers.each do |server| -%>
@@ -57,12 +57,12 @@ listen keystone-api
 
 frontend keystone-admin
   bind <%=node['bcpc']['management']['vip']%>:35357 <%= (node['bcpc']['protocol']['keystone'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
-  option tcplog
+  option httplog
   default_backend keystone-admin-backend
 
 frontend keystone-admin-httponly
   bind <%=node['bcpc']['management']['vip']%>:35358
-  option tcplog
+  option httplog
   default_backend keystone-admin-backend
 
 backend keystone-admin-backend
@@ -76,7 +76,7 @@ backend keystone-admin-backend
 listen glance-api
   bind <%=node['bcpc']['management']['vip']%>:9292 <%= (node['bcpc']['protocol']['glance'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source
-  option tcplog
+  option httplog
   option httpchk GET /
   http-check expect status 300
 <% @servers.each do |server| -%>
@@ -86,7 +86,7 @@ listen glance-api
 listen glance-registry
   bind <%=node['bcpc']['management']['vip']%>:9191 <%= (node['bcpc']['protocol']['glance'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source
-  option tcplog
+  option httplog
   option httpchk GET /
   http-check expect status 401
 <% @servers.each do |server| -%>
@@ -96,7 +96,7 @@ listen glance-registry
 listen cinder-api
   bind <%=node['bcpc']['management']['vip']%>:8776 <%= (node['bcpc']['protocol']['cinder'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source
-  option tcplog
+  option httplog
   option httpchk GET /
 <% if is_liberty? %>
   http-check expect status 200
@@ -110,7 +110,7 @@ listen cinder-api
 listen nova-api
   bind <%=node['bcpc']['management']['vip']%>:8774 <%= (node['bcpc']['protocol']['nova'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source
-  option tcplog
+  option httplog
   option httpchk GET /
   http-check expect status 200
 <% @servers.each do |server| -%>
@@ -121,7 +121,7 @@ listen nova-api
 listen neutron-api
   bind <%=node['bcpc']['management']['vip']%>:9696 <%= (node['bcpc']['protocol']['neutron'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source
-  option tcplog
+  option httplog
   option httpchk GET /
   http-check expect status 200
 <% @servers.each do |server| -%>
@@ -132,7 +132,7 @@ listen neutron-api
 listen heat-api
   bind <%=node['bcpc']['management']['vip']%>:8004 <%= (node['bcpc']['protocol']['heat'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source
-  option tcplog
+  option httplog
   option httpchk GET /
   http-check expect status 300
 <% @servers.each do |server| -%>
@@ -142,7 +142,7 @@ listen heat-api
 listen heat-api-cfn
   bind <%=node['bcpc']['management']['vip']%>:8000 <%= (node['bcpc']['protocol']['heat'] == 'https') ? "ssl crt /etc/haproxy/haproxy.pem" : "" %>
   balance source
-  option tcplog
+  option httplog
   option httpchk GET /
   http-check expect status 300
 <% @servers.each do |server| -%>
@@ -152,7 +152,7 @@ listen heat-api-cfn
 listen novnc
   bind <%=node['bcpc']['management']['vip']%>:6080 ssl crt /etc/haproxy/haproxy.pem
   balance source
-  option tcplog
+  option httplog
   option httpchk GET /vnc_auto.html
   http-check expect status 200
 <% @servers.each do |server| -%>
@@ -161,12 +161,12 @@ listen novnc
 
 frontend http
   bind <%=node['bcpc']['management']['vip']%>:80
-  option tcplog
+  option httplog
   default_backend http-backend
 
 frontend https
   bind <%=node['bcpc']['management']['vip']%>:443 ssl crt /etc/haproxy/haproxy.pem
-  option tcplog
+  option httplog
   stats enable
   stats uri /haproxy
   stats hide-version

--- a/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
+++ b/cookbooks/bcpc/templates/default/haproxy-head.cfg.erb
@@ -98,11 +98,7 @@ listen cinder-api
   balance source
   option httplog
   option httpchk GET /
-<% if is_liberty? %>
-  http-check expect status 200
-<% else %>
   http-check expect status 300
-<% end %>
 <% @servers.each do |server| -%>
   <%= "server #{server['hostname']} #{server['bcpc']['management']['ip']}:8776 check inter 5s rise 1 fall 1" %>
 <% end -%>


### PR DESCRIPTION
This commit changes from tcplog to httplog for more detailed logging in haproxy. This includes logging http response codes.

A liberty-specific section is removed.

Haproxy package installation now restarts rsyslog. This did not happen previously so logging may not occur until a node is rebooted or rsyslog restarted by other means.

The forwardfor option allows forwarding+logging the originating source IP address, rather forwarding the haproxy address.