### PR TITLE
reverting powerdns addtional float record generation

### DIFF
--- a/cookbooks/bcpc/recipes/powerdns.rb
+++ b/cookbooks/bcpc/recipes/powerdns.rb
@@ -118,14 +118,7 @@ if node['bcpc']['enabled']['dns'] then
   reverse_fixed_zone = node['bcpc']['fixed']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['fixed']['cidr']).first
   reverse_fixed_zones.push(reverse_fixed_zone)
 
-  reverse_float_zones = []
-  reverse_float_zone = calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])
-  reverse_float_zones.push(reverse_float_zone.first)
-
-  node['bcpc'].fetch('additional_floating',[]).each do |float|
-    reverse_float_zones.push(calc_reverse_dns_zone(float['cidr']).first)
-  end
-
+  reverse_float_zone = node['bcpc']['floating']['reverse_dns_zone'] || calc_reverse_dns_zone(node['bcpc']['floating']['cidr'])
   management_zone = calc_reverse_dns_zone(node['bcpc']['management']['cidr'])
 
   # Reverse fixed zone is assumed to be classful.
@@ -164,7 +157,7 @@ if node['bcpc']['enabled']['dns'] then
 
   }
 
-  reverse_float_zones.each do |zone|
+  reverse_float_zone.each do |zone|
     ruby_block "powerdns-table-domains-reverse-float-zone-#{zone}" do
       block do
         %x[ export MYSQL_PWD=#{get_config('mysql-root-password')};
@@ -312,23 +305,6 @@ if node['bcpc']['enabled']['dns'] then
   mgmt_octets = calc_octets_to_drop(node['bcpc']['management']['cidr'])
   float_octets = calc_octets_to_drop(node['bcpc']['floating']['cidr'])
 
-  float_cidrs = []
-  float_cidrs.push(
-    {
-      'subnet' => IPAddr.new(node['bcpc']['floating']['available_subnet']),
-      'octets' => calc_octets_to_drop(node['bcpc']['floating']['cidr'])
-    }
-  )
-
-  node['bcpc'].fetch('additional_floating',[]).each do |float|
-    float_cidrs.push(
-      {
-        'subnet' => IPAddr.new(float['cidr']),
-        'octets' => calc_octets_to_drop(float['cidr'])
-      }
-    )
-  end
-
   template float_records_file do
     source "powerdns_generate_float_records.sql.erb"
     owner "root"
@@ -339,13 +315,13 @@ if node['bcpc']['enabled']['dns'] then
       lazy {
         {
           :all_servers         => get_all_nodes,
-          :float_cidrs         => float_cidrs,
+          :float_cidr          => IPAddr.new(node['bcpc']['floating']['available_subnet']),
           :database_name       => node['bcpc']['dbname']['pdns'],
           :cluster_domain      => node['bcpc']['cluster_domain'],
           :management_vip      => node['bcpc']['management']['vip'],
           :monitoring_vip      => node['bcpc']['monitoring']['vip'],
           :reverse_fixed_zones => reverse_fixed_zones,
-          :reverse_float_zones => reverse_float_zones,
+          :reverse_float_zone  => reverse_float_zone,
           :management_zone     => management_zone,
           :mgmt_octets         => mgmt_octets,
           :float_octets        => float_octets

--- a/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
+++ b/cookbooks/bcpc/templates/default/powerdns_generate_float_records.sql.erb
@@ -9,7 +9,7 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
 -- MySQL does not allow deleting from a table and selecting from that same table in a subquery, so ids of old SOA records are written to a temporary table, records are deleted,
 -- then the temporary table is cleaned up
 CREATE TEMPORARY TABLE soa_records_to_delete_<%=get_config('powerdns-update-timestamp')%> (id int);
-<% [@cluster_domain, @reverse_float_zones, @reverse_fixed_zones, @management_zone].flatten.each do |zone| %>
+<% [@cluster_domain, @reverse_float_zone, @reverse_fixed_zones, @management_zone].flatten.each do |zone| %>
 
 -- delete malformed NS record where the content is the management VIP instead of cluster domain
 DELETE FROM <%= @database_name %>.records WHERE type='NS' and content='<%= @management_vip %>';
@@ -66,19 +66,15 @@ INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_re
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='kibana.<%=@cluster_domain%>', type='A', content='<%=@monitoring_vip%>', bcpc_record_type='STATIC';
 
 -- insert A and PTR records for every floating IP in this cluster's range
-<% @float_cidrs.each do |float| %>
-  <% float['subnet'].to_range.each do |ip| %>
-  <% s_hostname = "public-" + ip.to_s.gsub(".", "-") + "." + @cluster_domain %>
-  <% reverse_name = ip.reverse %>
-
+<% @float_cidr.to_range.each do |ip| %>
+<% s_hostname = "public-" + ip.to_s.gsub(".", "-") + "." + @cluster_domain %>
+<% reverse_name = ip.reverse %>
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
     ((SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), '<%=s_hostname%>', 'A', '<%=ip.to_s%>', 'STATIC')
     ON DUPLICATE KEY UPDATE domain_id=(SELECT id FROM domains WHERE name='<%=@cluster_domain%>'), name='<%=s_hostname%>', type='A', content='<%=ip.to_s%>', bcpc_record_type='STATIC';
 INSERT INTO <%=@database_name%>.records (domain_id, name, type, content, bcpc_record_type) VALUES
-    (get_ptr_domain('<%=reverse_name%>', <%= float['octets'] %>), '<%=reverse_name%>', 'PTR', '<%=s_hostname%>', 'STATIC')
-    ON DUPLICATE KEY UPDATE domain_id=get_ptr_domain('<%=reverse_name%>', <%= float['octets'] %>), name='<%=reverse_name%>', type='PTR', content='<%=s_hostname%>', bcpc_record_type='STATIC';
-
-  <% end %>
+    (get_ptr_domain('<%=reverse_name%>', <%= @float_octets %>), '<%=reverse_name%>', 'PTR', '<%=s_hostname%>', 'STATIC')
+    ON DUPLICATE KEY UPDATE domain_id=get_ptr_domain('<%=reverse_name%>', <%= @float_octets %>), name='<%=reverse_name%>', type='PTR', content='<%=s_hostname%>', bcpc_record_type='STATIC';
 <% end %>
 
 -- fixed IPs are inserted by another template (look at powerdns-nova recipe)


### PR DESCRIPTION
  - causes duplicate records to be inserted into database and doesn't
    generate the correct amount of reverse in.addr blocks