### PR TITLE
keystone, horizon and cinder updates

### DIFF
--- a/chef/cookbooks/bcpc/files/default/keystone/cloud_admin.json
+++ b/chef/cookbooks/bcpc/files/default/keystone/cloud_admin.json
@@ -1,0 +1,3 @@
+{
+	"cloud_admin": "role:admin and (is_admin_project:True or domain_id:default)"
+}

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -236,9 +236,16 @@ template '/etc/cinder/cinder.conf' do
     headnodes: headnodes(all: true)
   )
 
-  notifies :restart, 'service[cinder-api]', :immediately
-  notifies :restart, 'service[cinder-volume]', :immediately
-  notifies :restart, 'service[cinder-scheduler]', :immediately
+  # the cinder services here are being stopped/started vs. restarted
+  # is because on some systems, the package installation and configuration
+  # happens so fast that it causes systemd to complain about the service
+  # restarting too fast.
+  notifies :stop, 'service[cinder-api]', :immediately
+  notifies :stop, 'service[cinder-volume]', :immediately
+  notifies :stop, 'service[cinder-scheduler]', :immediately
+  notifies :start, 'service[cinder-api]', :immediately
+  notifies :start, 'service[cinder-volume]', :immediately
+  notifies :start, 'service[cinder-scheduler]', :immediately
 end
 # configure cinder service ends
 

--- a/chef/cookbooks/bcpc/recipes/keystone.rb
+++ b/chef/cookbooks/bcpc/recipes/keystone.rb
@@ -158,6 +158,16 @@ remote_file '/etc/keystone/policy.json' do
   source 'file:///usr/share/keystone/policy.v3cloudsample.json'
 end
 
+# create policy.d dir for policy overrides
+directory '/etc/keystone/policy.d' do
+  action :create
+end
+
+# install override for cloud_admin definition
+cookbook_file '/etc/keystone/policy.d/cloud_admin.json' do
+  source 'keystone/cloud_admin.json'
+end
+
 # configure keystone service starts
 template '/etc/keystone/keystone.conf' do
   source 'keystone/keystone.conf.erb'

--- a/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
+++ b/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
@@ -5,11 +5,13 @@ from django.utils.translation import ugettext_lazy as _
 from horizon.utils import secret_key
 from openstack_dashboard.settings import HORIZON_CONFIG
 
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 SITE_BRANDING = "<%= node['bcpc']['cloud']['region'] %>"
 SECRET_KEY = '<%= @config['horizon']['secret'] %>'
+COMPRESS_ENABLED = True
+COMPRESS_OFFLINE = True
 
 WEBROOT = '/horizon'
 LOGIN_URL = WEBROOT + '/auth/login/'
@@ -18,7 +20,8 @@ LOGIN_REDIRECT_URL = WEBROOT
 
 DEFAULT_THEME = 'default'
 AVAILABLE_THEMES = [
-  ('default', 'Default', 'themes/default')
+  ('default', 'Default', '../themes/default'),
+#  ('material', 'Material', '../themes/material')
 ]
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
@@ -27,13 +30,6 @@ SESSION_COOKIE_SECURE = True
 SHOW_KEYSTONE_V2_RC = False
 HORIZON_IMAGES_UPLOAD_MODE = 'off'
 TIME_ZONE = "UTC"
-
-OPENSTACK_API_VERSIONS = {
-  "identity": 3,
-  "image": 2,
-  "volume": 3,
-  "compute": 2,
-}
 
 <% if @domains.any? %>
 OPENSTACK_KEYSTONE_MULTIDOMAIN_SUPPORT = True
@@ -52,6 +48,7 @@ OPENSTACK_KEYSTONE_URL = "https://%s:5000/<%= node['bcpc']['catalog']['identity'
 
 OPENSTACK_NEUTRON_NETWORK = {
   'enable_router': True,
+  'enable_quotas': True,
   'enable_fip_topology_check': True,
   'supported_provider_types': ['local']
 }
@@ -62,15 +59,4 @@ CACHES = {
     'BACKEND' : 'django.core.cache.backends.memcached.MemcachedCache',
     'LOCATION' : [<%= @headnodes.map{|n| "'#{n['ipaddress']}:11211'"}.join(',') %>]
   }
-}
-
-ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
-POLICY_FILES_PATH = os.path.join(ROOT_PATH, "conf")
-
-POLICY_FILES = {
-  'identity': 'keystone_policy.json',
-  'compute': 'nova_policy.json',
-  'volume': 'cinder_policy.json',
-  'image': 'glance_policy.json',
-  'network': 'neutron_policy.json',
 }

--- a/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
@@ -67,6 +67,9 @@ driver =
 [policy]
 driver = <%= node['bcpc']['keystone']['drivers']['policy'] %>
 
+[oslo_policy]
+policy_dirs = policy.d
+
 [token]
 provider = fernet
 


### PR DESCRIPTION
  - keystone
    - added policy.d directory creation
    - added cloud_admin policy override file
  - horizon
    - updated config to support neutron quotas
    - removed policy file configuration
  - cinder
    - updated cinder services to stop/start after configuration updates