### PR TITLE
version updates and custom role removal

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -89,24 +89,24 @@ assets_files:
     filename: CentOS-7-x86_64-GenericCloud-1808.qcow2.xz
 
   - name: etcd
-    url: https://github.com/coreos/etcd/releases/download/v3.3.7/etcd-v3.3.7-linux-amd64.tar.gz
-    checksum: sha256:251605c618e789fe58e3b0c792ebf9304148d20de7840d475e840d6578e9093c
-    filename: etcd-v3.3.7-linux-amd64.tar.gz
+    url: https://github.com/etcd-io/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz
+    checksum: sha256:7b95bdc6dfd1d805f650ea8f886fdae6e7322f886a8e9d1b0d14603767d053b1
+    filename: etcd-v3.3.9-linux-amd64.tar.gz
 
   - name: calicoctl
-    url: https://github.com/projectcalico/calicoctl/releases/download/v3.2.0/calicoctl-linux-amd64
-    checksum: sha256:b0045e3f235d42618c3f4f6ec3e58715980995e2fab2424b39787cd72986a11d
+    url: https://github.com/projectcalico/calicoctl/releases/download/v3.2.3/calicoctl-linux-amd64
+    checksum: sha256:3396ee93361726eede85e3f86b256c80bf8d9d95e6ec37b6573fb44e7bf64e2f
     filename: calicoctl
 
   - name: consul
-    url: https://releases.hashicorp.com/consul/1.1.0/consul_1.1.0_linux_amd64.zip
-    checksum: sha256:09c40c8b5be868003810064916d8460bff334ccfb59a5046390224b27e052c45
-    filename: consul_1.1.0_linux_amd64.zip
+    url: https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip
+    checksum: sha256:f97996296ef3905c38c504b35035fb731d3cfd9cad129c9523402a4229c709c5
+    filename: consul_1.2.3_linux_amd64.zip
 
   - name: chef_client
-    url: https://packages.chef.io/files/stable/chef/14.1.1/ubuntu/18.04/chef_14.1.1-1_amd64.deb
-    checksum: sha256:1a3569b1ab39bc79f439b9c0d2b9d9b507748bdfcafe4fc22fe5402584d500ac
-    filename: chef_14.1.1-1_amd64.deb
+    url: https://packages.chef.io/files/current/chef/14.6.13/ubuntu/18.04/chef_14.6.13-1_amd64.deb
+    checksum: sha256:d5e460938a1817de1e223348e234e9b34542c235a71132a9c1dc353c67c8f593
+    filename: chef_14.6.13-1_amd64.deb
 
   - name: chef_server
     url: https://packages.chef.io/files/stable/chef-server/12.17.33/ubuntu/16.04/chef-server-core_12.17.33-1_amd64.deb

--- a/ansible/playbooks/roles/chef-node/tasks/setup.yml
+++ b/ansible/playbooks/roles/chef-node/tasks/setup.yml
@@ -13,12 +13,12 @@
 
 - name: upload chef-client
   copy:
-    src: "{{ assets_download_dir }}/chef_14.1.1-1_amd64.deb"
-    dest: "/var/tmp/chef_14.1.1-1_amd64.deb"
+    src: "{{ assets_download_dir }}/chef_14.6.13-1_amd64.deb"
+    dest: "/var/tmp/chef_14.6.13-1_amd64.deb"
 
 - name: install chef-client
   apt:
-    deb: "/var/tmp/chef_14.1.1-1_amd64.deb"
+    deb: "/var/tmp/chef_14.6.13-1_amd64.deb"
 
 - name: create /etc/chef directory
   file:

--- a/ansible/playbooks/roles/chef-workstation/tasks/setup.yml
+++ b/ansible/playbooks/roles/chef-workstation/tasks/setup.yml
@@ -1,11 +1,11 @@
 - name: upload chef-client
   copy:
-    src: "{{ assets_download_dir }}/chef_14.1.1-1_amd64.deb"
-    dest: "/tmp/chef_14.1.1-1_amd64.deb"
+    src: "{{ assets_download_dir }}/chef_14.6.13-1_amd64.deb"
+    dest: "/tmp/chef_14.6.13-1_amd64.deb"
 
 - name: install chef-client
   apt:
-    deb: "/tmp/chef_14.1.1-1_amd64.deb"
+    deb: "/tmp/chef_14.6.13-1_amd64.deb"
 
 - name: create .chef directory
   become: false

--- a/ansible/playbooks/roles/file-server/tasks/setup.yml
+++ b/ansible/playbooks/roles/file-server/tasks/setup.yml
@@ -11,8 +11,5 @@
     dest: "/var/bcpc/file-server/"
   with_items:
     - "{{ assets_download_dir }}/calicoctl"
-    - "{{ assets_download_dir }}/chef_14.1.1-1_amd64.deb"
-    - "{{ assets_download_dir }}/cirros-0.4.0-x86_64-disk.img"
-    - "{{ assets_download_dir }}/etcd-v3.3.7-linux-amd64.tar.gz"
-    - "{{ assets_download_dir }}/chef-server-core_12.17.33-1_amd64.deb"
-    - "{{ assets_download_dir }}/consul_1.1.0_linux_amd64.zip"
+    - "{{ assets_download_dir }}/etcd-v3.3.9-linux-amd64.tar.gz"
+    - "{{ assets_download_dir }}/consul_1.2.3_linux_amd64.zip"

--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -7,4 +7,4 @@ default['bcpc']['calico']['repo']['url'] = 'http://ppa.launchpad.net/project-cal
 
 default['bcpc']['calico']['remote']['file'] = 'calicoctl'
 default['bcpc']['calico']['remote']['source'] = "#{default['bcpc']['file_server']['url']}/calicoctl"
-default['bcpc']['calico']['remote']['checksum'] = 'b0045e3f235d42618c3f4f6ec3e58715980995e2fab2424b39787cd72986a11d'
+default['bcpc']['calico']['remote']['checksum'] = '3396ee93361726eede85e3f86b256c80bf8d9d95e6ec37b6573fb44e7bf64e2f'

--- a/chef/cookbooks/bcpc/attributes/consul.rb
+++ b/chef/cookbooks/bcpc/attributes/consul.rb
@@ -3,8 +3,8 @@
 ###############################################################################
 
 default['bcpc']['consul']['remote_file'] = {
-  'file' => 'consul_1.1.0_linux_amd64.zip',
-  'checksum' => '09c40c8b5be868003810064916d8460bff334ccfb59a5046390224b27e052c45',
+  'file' => 'consul_1.2.3_linux_amd64.zip',
+  'checksum' => 'f97996296ef3905c38c504b35035fb731d3cfd9cad129c9523402a4229c709c5',
 }
 
 default['bcpc']['consul']['executable'] = '/usr/local/sbin/consul'

--- a/chef/cookbooks/bcpc/attributes/default.rb
+++ b/chef/cookbooks/bcpc/attributes/default.rb
@@ -184,9 +184,10 @@ default['bcpc']['memcached']['connections'] = 10240
 # etcd
 ###############################################################################
 
-default['bcpc']['etcd']['remote']['file'] = 'etcd-v3.3.7-linux-amd64.tar.gz'
-default['bcpc']['etcd']['remote']['source'] = "#{default['bcpc']['file_server']['url']}/etcd-v3.3.7-linux-amd64.tar.gz"
-default['bcpc']['etcd']['remote']['checksum'] = '251605c618e789fe58e3b0c792ebf9304148d20de7840d475e840d6578e9093c'
+etcd_file = 'etcd-v3.3.9-linux-amd64.tar.gz'
+default['bcpc']['etcd']['remote']['file'] = etcd_file
+default['bcpc']['etcd']['remote']['source'] = "#{default['bcpc']['file_server']['url']}/#{etcd_file}"
+default['bcpc']['etcd']['remote']['checksum'] = '7b95bdc6dfd1d805f650ea8f886fdae6e7322f886a8e9d1b0d14603767d053b1'
 
 ###############################################################################
 # virtualbox

--- a/chef/cookbooks/bcpc/attributes/keystone.rb
+++ b/chef/cookbooks/bcpc/attributes/keystone.rb
@@ -49,7 +49,7 @@ default['bcpc']['keystone']['notification_format'] = 'cadf'
 default['bcpc']['keystone']['identity']['domain_configurations_from_database'] = true
 
 default['bcpc']['keystone']['roles']['admin'] = 'admin'
-default['bcpc']['keystone']['roles']['member'] = '_member_'
+default['bcpc']['keystone']['roles']['member'] = 'member'
 
 default['bcpc']['keystone']['admin']['email'] = "admin@#{node['bcpc']['cloud']['domain']}"
 default['bcpc']['keystone']['admin']['username'] = 'admin'

--- a/chef/cookbooks/bcpc/recipes/keystone.rb
+++ b/chef/cookbooks/bcpc/recipes/keystone.rb
@@ -215,7 +215,7 @@ end
 execute 'add admin role to admin user in default domain' do
   environment os_adminrc
   command <<-EOH
-    openstack role add --domain default --user admin admin
+    openstack role add admin --domain default --user admin
   EOH
 
   not_if <<-DOC
@@ -225,18 +225,6 @@ execute 'add admin role to admin user in default domain' do
       --role admin \
       --domain default | grep admin
   DOC
-end
-
-execute 'create the default member role' do
-  environment os_adminrc
-
-  role = node['bcpc']['keystone']['roles']['member']
-
-  command <<-DOC
-    openstack role create #{role}
-  DOC
-
-  not_if "openstack role show #{role}"
 end
 
 execute 'create the service project' do
@@ -286,7 +274,7 @@ node['bcpc']['keystone']['domains'].each do |domain|
     environment os_adminrc
 
     command <<-EOH
-      openstack role add --domain #{domain_name} --user admin admin
+      openstack role add admin --domain #{domain_name} --user admin
     EOH
 
     not_if <<-DOC


### PR DESCRIPTION
  - version updates
    - etcd 3.3.7 -> 3.3.9
    - calicoctl 3.2.0 -> 3.2.3
    - consul 1.1.0 -> 1.2.3
    - chef-client 14.1.1 -> 14.5.33
  - removed creation of custom '\_member\_' role in favor of the default
    'member' role created by openstack