### PR TITLE
Remove restart of nova-compute

### DIFF
--- a/cookbooks/bcpc/recipes/nova-work.rb
+++ b/cookbooks/bcpc/recipes/nova-work.rb
@@ -27,7 +27,6 @@ end
 
 package "nova-compute-#{node['bcpc']['virt_type']}" do
   action :install
-  notifies :restart, 'service[nova-compute]', :immediately
 end
 
 nova_services = %w(nova-api nova-compute nova-novncproxy)


### PR DESCRIPTION
The latest nova-compute-qemu package removes the circular dependency, causing nova-compute not install. remove nova-compute restart which anyway will get installed later.