### PR TITLE
keystone and neutron updates

### DIFF
--- a/chef/cookbooks/bcpc/attributes/neutron.rb
+++ b/chef/cookbooks/bcpc/attributes/neutron.rb
@@ -4,8 +4,12 @@
 default['bcpc']['neutron']['debug'] = false
 default['bcpc']['neutron']['db']['dbname'] = 'neutron'
 
+# neutron network nameservers
+# this list is used during the neutron subnet creation process to set the
+# dns-namserver for the instances
+default['bcpc']['neutron']['network']['nameservers'] = [node['bcpc']['cloud']['vip']]
+
 # networks
-#
 default['bcpc']['neutron']['networks'] = [
   {
     'name' => 'ext1',

--- a/chef/cookbooks/bcpc/recipes/calico-work.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-work.rb
@@ -56,11 +56,6 @@ template '/etc/neutron/neutron.conf' do
   mode '644'
   owner 'root'
   group 'neutron'
-
-  variables(
-    vip: node['bcpc']['cloud']['vip']
-  )
-
   notifies :restart, 'service[calico-dhcp-agent]', :immediately
 end
 

--- a/chef/cookbooks/bcpc/recipes/keystone.rb
+++ b/chef/cookbooks/bcpc/recipes/keystone.rb
@@ -284,6 +284,14 @@ node['bcpc']['keystone']['domains'].each do |domain|
     not_if "openstack domain show #{domain_name}"
   end
 
+  # run mapping_populate to improve future ldap queries
+  execute 'keystone-manage mapping_populate' do
+    environment os_adminrc
+    command <<-DOC
+      keystone-manage mapping_populate --domain #{domain_name}
+    DOC
+  end
+
   execute "add admin role to admin user in the #{domain_name} domain" do
     environment os_adminrc
 

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -224,9 +224,18 @@ node['bcpc']['neutron']['networks'].each do |network|
     execute "create the #{fixed_network} network #{subnet_name} subnet" do
       environment os_adminrc
 
+      # convert nameservers list into repeated --dns-nameserver arguments
+      nameservers = node['bcpc']['neutron']['network']['nameservers']
+      nameservers = nameservers.map do |n|
+        "--dns-nameserver #{n}"
+      end
+      nameservers = nameservers.join(' ')
+
       command <<-DOC
         openstack subnet create #{subnet_name} \
-          --network #{fixed_network} --subnet-range #{cidr}
+          #{nameservers} \
+          --network #{fixed_network} \
+          --subnet-range #{cidr}
       DOC
 
       not_if <<-DOC

--- a/chef/cookbooks/bcpc/templates/default/calico/neutron.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/neutron.conf.erb
@@ -1,7 +1,5 @@
 [DEFAULT]
 core_plugin = calico
-dns_domain = <%= node['bcpc']['cloud']['domain'] %>
-dnsmasq_dns_servers = <%= @vip %>
 state_path = /var/lib/neutron
 
 [calico]


### PR DESCRIPTION
  - keystone
    - now executing keystone-manage mapping_populate after domain creation
      to help improve future ldap queries
  - neutron
    - removed unused dns related options from configuration
      - dns_domain
      - dnsmasq_dns_servers
    - updated fixed subnet creation to include the --dns_nameserver option
      which will configure instances to have those dns nameservers listed in
      their resolv.conf