### PR TITLE
ansible group_vars and pdns conf updates

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,7 +1,7 @@
 # -*- mode: yaml -*-
 # vi: set ft=yaml :
 
-root_dir: "{{ playbook_dir | dirname | dirname }}"
+root_dir: "{{ inventory_dir | dirname }}"
 
 # cloud domain name
 #
@@ -20,7 +20,7 @@ initial_ssh_pass: vagrant
 ansible_python_interpreter: /usr/bin/env python3
 ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 ansible_user: "{{ operator_username }}"
-ansible_ssh_private_key_file: "{{ playbook_dir }}/roles/localhost/files/id_ed25519"
+ansible_ssh_private_key_file: "{{ inventory_dir }}/playbooks/roles/localhost/files/id_ed25519"
 ssh_generate_private_key: true
 
 file_server_assets:

--- a/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
@@ -89,6 +89,6 @@ security-poll-suffix = <%= node['bcpc']['powerdns']['security_poll_suffix'] %>
 
 <% if node['bcpc']['powerdns']['also-notify']['enabled'] %>
 # also-notify   When notifying a domain, also notify these nameservers
-only-notify = ''
+only-notify =
 also-notify = <%= node['bcpc']['powerdns']['also-notify']['ips'].join(',') %>
 <% end %>


### PR DESCRIPTION
  - ansible group_vars
    - replaced playbook_dir ansible variable with inventory_dir
      - this is needed for adhoc ansible commands because the playbook_dir
        is not populated outside of ansible-playbook invocations which
        prevents critical path variables from being interpolated correctly

  - pdns conf
    - updated only-notify to empty assigment from ''.