### PR TITLE
added nova cpu_mode and cpu_model attribute defaults

### DIFF
--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -29,8 +29,8 @@ default['bcpc']['nova']['notifications']['driver'] = 'messagingv2'
 default['bcpc']['nova']['notifications']['notify_on_state_change'] = 'vm_and_task_state'
 
 # CPU passthrough/masking configurations
-default['bcpc']['nova']['cpu_config']['cpu_mode'] = nil
-default['bcpc']['nova']['cpu_config']['cpu_model'] = nil
+default['bcpc']['nova']['cpu_config']['cpu_mode'] = 'custom'
+default['bcpc']['nova']['cpu_config']['cpu_model'] = 'kvm64'
 
 # select from between this many equally optimal hosts when launching an instance
 default['bcpc']['nova']['scheduler_host_subset_size'] = 3

--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -30,7 +30,8 @@ default['bcpc']['nova']['notifications']['notify_on_state_change'] = 'vm_and_tas
 
 # CPU passthrough/masking configurations
 default['bcpc']['nova']['cpu_config']['cpu_mode'] = 'custom'
-default['bcpc']['nova']['cpu_config']['cpu_model'] = 'qemu64'
+default['bcpc']['nova']['cpu_config']['cpu_model'] = 'kvm64'
+default['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'] = []
 
 # select from between this many equally optimal hosts when launching an instance
 default['bcpc']['nova']['scheduler_host_subset_size'] = 3

--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -30,7 +30,7 @@ default['bcpc']['nova']['notifications']['notify_on_state_change'] = 'vm_and_tas
 
 # CPU passthrough/masking configurations
 default['bcpc']['nova']['cpu_config']['cpu_mode'] = 'custom'
-default['bcpc']['nova']['cpu_config']['cpu_model'] = 'kvm64'
+default['bcpc']['nova']['cpu_config']['cpu_model'] = 'qemu64'
 
 # select from between this many equally optimal hosts when launching an instance
 default['bcpc']['nova']['scheduler_host_subset_size'] = 3

--- a/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
@@ -14,10 +14,9 @@ rbd_user = <%= node['bcpc']['nova']['ceph']['user'] %>
 rbd_secret_uuid = <%= @config['libvirt']['secret'] %>
 disk_cachemodes = "network=writeback"
 hw_disk_discard = unmap
-<% if !node['bcpc']['nova']['cpu_config']['cpu_mode'].nil? %>
+<% unless node['bcpc']['nova']['cpu_config']['cpu_mode'].nil? %>
 cpu_mode = <%= node['bcpc']['nova']['cpu_config']['cpu_mode'] %>
 <% end -%>
-
-<% if !node['bcpc']['nova']['cpu_config']['cpu_model'].nil? %>
+<% unless node['bcpc']['nova']['cpu_config']['cpu_model'].nil? %>
 cpu_model = <%= node['bcpc']['nova']['cpu_config']['cpu_model'] %>
-<% end %>
+<% end -%>

--- a/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
@@ -20,3 +20,6 @@ cpu_mode = <%= node['bcpc']['nova']['cpu_config']['cpu_mode'] %>
 <% unless node['bcpc']['nova']['cpu_config']['cpu_model'].nil? %>
 cpu_model = <%= node['bcpc']['nova']['cpu_config']['cpu_model'] %>
 <% end -%>
+<% unless node['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'].empty? %>
+cpu_model_extra_flags = <%= node['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'].join(',') %>
+<% end -%>

--- a/chef/environments/virtual.json
+++ b/chef/environments/virtual.json
@@ -10,6 +10,13 @@
           "net.ifnames=0",
           "biosdevname=0"
         ]
+      },
+      "nova": {
+        "cpu_config": {
+          "cpu_mode": "custom",
+          "cpu_model": "qemu64",
+          "cpu_model_extra_flags": ["abm","lahf_lm","popcnt","sse4a"]
+        }
       }
     }
   }


### PR DESCRIPTION
  - nova
    - set cpu_mode and cpu_model to 'custom' and 'kvm64' respectively to
      properly setup the virtual cpu in virtualized environments