### PR TITLE
various automation and virtual updates

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -14,14 +14,12 @@ operator_group: operators
 
 # username and password used to access bare metal machines
 #
-initial_ssh_user: vagrant
-initial_ssh_pass: vagrant
+initial_ssh_user: ubuntu
+initial_ssh_pass: 53cr37
 
 ansible_python_interpreter: /usr/bin/env python3
 ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 ansible_user: "{{ operator_username }}"
-ansible_ssh_private_key_file: "{{ inventory_dir }}/playbooks/roles/localhost/files/id_ed25519"
-ssh_generate_private_key: true
 
 file_server_assets:
   - cirros
@@ -34,7 +32,7 @@ file_server_assets:
 chef_environment: virtual
 
 chef_server_host: "{{ groups['bootstraps'][0] }}"
-chef_server_ip: "{{ hostvars[chef_server_host].primary_ip  | default(ansible_host) | ipaddr('address') }}"
+chef_server_ip: "{{ hostvars[chef_server_host].primary_ip  | default(hostvars[chef_server_host].ansible_host) | ipaddr('address') }}"
 chef_server_fqdn: "{{ chef_server_host }}.{{ cloud_domain }}"
 chef_server_url: "https://{{ chef_server_host }}.{{ cloud_domain }}/organizations/{{ chef_org_short_name }}"
 

--- a/ansible/group_vars/cloud
+++ b/ansible/group_vars/cloud
@@ -1,0 +1,7 @@
+# -*- mode: yaml -*-
+# vi: set ft=yaml :
+
+virtual_dir: "{{ root_dir }}/virtual"
+ssh_dir: "{{ virtual_dir }}/files/ssh/"
+ansible_ssh_private_key_file: "{{ ssh_dir }}/id_ed25519"
+operator_authorized_key: "{{ lookup('file', ansible_ssh_private_key_file + '.pub')}}"

--- a/ansible/playbooks/roles/common/tasks/main.yml
+++ b/ansible/playbooks/roles/common/tasks/main.yml
@@ -3,6 +3,7 @@
   vars:
     ansible_ssh_user: "{{ initial_ssh_user }}"
     ansible_ssh_pass: "{{ initial_ssh_pass }}"
+    ansible_sudo_pass: "{{ initial_ssh_pass }}"
   tags: [never,operator]
 
 - import_tasks: chef-client.yml

--- a/ansible/playbooks/roles/common/tasks/operator.yml
+++ b/ansible/playbooks/roles/common/tasks/operator.yml
@@ -1,14 +1,4 @@
 ---
-- name: generate operations ssh key
-  when: ssh_generate_private_key
-  become: false
-  run_once: true
-  command: |
-    ssh-keygen -t ed25519 -f "{{ ansible_ssh_private_key_file }}" -C '' -N ''
-  args:
-    creates: "{{ ansible_ssh_private_key_file }}"
-  delegate_to: localhost
-
 - name: "create the cloud operator group"
   group:
     name: "{{ operator_group }}"
@@ -34,7 +24,7 @@
 - name: "populate cloud operator authorized key file"
   authorized_key:
     user: "{{ operator_username }}"
-    key: "{{ lookup('file', ansible_ssh_private_key_file + '.pub') }}"
+    key: "{{ operator_authorized_key }}"
 
 - name: "install operators group sudoers file"
   template:

--- a/chef/cookbooks/bcpc/attributes/networking.rb
+++ b/chef/cookbooks/bcpc/attributes/networking.rb
@@ -5,48 +5,35 @@
 default['bcpc']['networking']['networks']['primary']['cidr'] = '10.121.84.0/22'
 default['bcpc']['networking']['networks']['primary']['interface'] = 'eth1'
 
-default['bcpc']['networking']['networks']['storage']['cidr'] = '10.121.88.0/22'
-default['bcpc']['networking']['networks']['storage']['interface'] = 'eth2'
-
-# vlan and mtu examples
-# default['bcpc']['networking']['networks']['storage']['vlan'] = 1337
-# default['bcpc']['networking']['networks']['storage']['mtu'] = 9000
-
 default['bcpc']['networking']['racks'] = [
   {
     'id' => 1,
-    'pod' => 'a',
     'bgp' => {
       'tor_as' => 4_200_858_701,
       'node_as' => 4_200_858_701,
     },
     'networks' => {
       'primary' => { 'cidr' => '10.121.84.0/28', 'gateway' => '10.121.84.1' },
-      'storage' => { 'cidr' => '10.121.88.0/28', 'gateway' => '10.121.88.1' },
     },
   },
   {
     'id' => 2,
-    'pod' => 'a',
     'bgp' => {
       'tor_as' => 4_200_858_702,
       'node_as' => 4_200_858_702,
     },
     'networks' => {
       'primary' => { 'cidr' => '10.121.85.0/28', 'gateway' => '10.121.85.1' },
-      'storage' => { 'cidr' => '10.121.89.0/28', 'gateway' => '10.121.89.1' },
     },
   },
   {
     'id' => 3,
-    'pod' => 'a',
     'bgp' => {
       'tor_as' => 4_200_858_703,
       'node_as' => 4_200_858_703,
     },
     'networks' => {
       'primary' => { 'cidr' => '10.121.86.0/28', 'gateway' => '10.121.86.1' },
-      'storage' => { 'cidr' => '10.121.90.0/28', 'gateway' => '10.121.90.1' },
     },
   },
 ]

--- a/chef/cookbooks/bcpc/recipes/bird.rb
+++ b/chef/cookbooks/bcpc/recipes/bird.rb
@@ -31,18 +31,18 @@ service 'bird6' do
 end
 
 begin
-  pod = node_pod
+  rack = node_rack
   primary = node_interfaces(type: 'primary')
 
   template '/etc/bird/bird.conf' do
     source 'bird/bird.conf.erb'
 
     variables(
-      bgp: pod['bgp'],
+      bgp: rack['bgp'],
       is_worknode: worknode?,
       is_headnode: headnode?,
       iface: primary['dev'],
-      upstream_peer: pod['networks']['primary']['gateway']
+      upstream_peer: rack['networks']['primary']['gateway']
     )
 
     notifies :restart, 'service[bird]', :immediately

--- a/chef/cookbooks/bcpc/recipes/ceph-mon.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-mon.rb
@@ -93,12 +93,10 @@ template '/etc/ceph/ceph.conf' do
 
   networks = cloud_networks
   primary = networks['primary']
-  storage = networks['storage']
 
   variables(
     config: config,
     public_network: primary['cidr'],
-    cluster_network: storage['cidr'],
     headnodes: init_cloud? ? [node] : headnodes
   )
   notifies :restart, "service[ceph-mon@#{node['hostname']}]", :immediately

--- a/chef/cookbooks/bcpc/recipes/ceph-osd.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-osd.rb
@@ -25,12 +25,10 @@ template '/etc/ceph/ceph.conf' do
 
   networks = cloud_networks
   primary = networks['primary']
-  storage = networks['storage']
 
   variables(
     config: config,
     public_network: primary['cidr'],
-    cluster_network: storage['cidr'],
     headnodes: init_cloud? ? [node] : headnodes
   )
 end

--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -44,11 +44,19 @@ Vagrant.configure('2') do |config|
       gateway = node['networking']['gateway']
       primary = networks.find { |n| n['type'] == 'primary' }
 
-      # statically configure virtualbox NAT interface
-      subconfig.vm.provision 'shell' do |s|
-        s.path = 'provisioners/netcfg.sh'
-        s.args = "#{primary['ip']} #{gateway}"
+      # vm provisioners starts
+      # create default user
+      subconfig.vm.provision 'shell' do |shell|
+        shell.path = 'provisioners/create-default-user.sh'
+        shell.args = 'ubuntu 53cr37'
       end
+
+      # statically configure virtualbox NAT interface
+      subconfig.vm.provision 'shell' do |shell|
+        shell.path = 'provisioners/netcfg.sh'
+        shell.args = "#{primary['ip']} #{gateway}"
+      end
+      # vm provisioners ends
 
       # add swap space
       if hw_profile.key?('swap_gb')

--- a/virtual/provisioners/create-default-user.sh
+++ b/virtual/provisioners/create-default-user.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+user="${1}"
+
+if [ ! "$(getent passwd "${user}")" ]; then
+    password="${2}"
+    password_crypt=$(echo "${password}" | openssl passwd -1 -stdin)
+
+    useradd \
+      --create-home \
+      --password "${password_crypt}" \
+      --shell '/bin/bash' \
+      "${user}"
+
+    echo "${user} ALL=(ALL:ALL) ALL" > "/etc/sudoers.d/${user}"
+fi

--- a/virtual/topology/1h1w.yml
+++ b/virtual/topology/1h1w.yml
@@ -1,6 +1,5 @@
 nodes:
-  - host: r1an0
-    name: bootstrap
+  - host: r1n0
     group: bootstraps
     hardware_profile: bootstrap
     run_list:
@@ -12,7 +11,7 @@ nodes:
           network: management1
           ip: 10.121.84.2/28
 
-  - host: r1an1
+  - host: r1n1
     group: headnodes
     hardware_profile: headnode
     run_list:
@@ -23,10 +22,8 @@ nodes:
         - type: primary
           network: management1
           ip: 10.121.84.3/28
-        - type: storage
-          network: storage1
 
-  - host: r1an2
+  - host: r1n2
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -37,5 +34,3 @@ nodes:
         - type: primary
           network: management1
           ip: 10.121.84.4/28
-        - type: storage
-          network: storage1

--- a/virtual/topology/3h3w.yml
+++ b/virtual/topology/3h3w.yml
@@ -1,6 +1,5 @@
 nodes:
-  - host: r1an0
-    name: bootstrap
+  - host: r1n0
     group: bootstraps
     hardware_profile: bootstrap
     run_list:
@@ -12,7 +11,7 @@ nodes:
           network: management1
           ip: 10.121.84.2/28
 
-  - host: r1an1
+  - host: r1n1
     group: headnodes
     hardware_profile: headnode
     run_list:
@@ -23,10 +22,8 @@ nodes:
         - type: primary
           network: management1
           ip: 10.121.84.3/28
-        - type: storage
-          network: storage1
 
-  - host: r2an1
+  - host: r2n1
     group: headnodes
     hardware_profile: headnode
     run_list:
@@ -37,10 +34,8 @@ nodes:
         - type: primary
           network: management2
           ip: 10.121.85.3/28
-        - type: storage
-          network: storage2
 
-  - host: r3an1
+  - host: r3n1
     group: headnodes
     hardware_profile: headnode
     run_list:
@@ -51,10 +46,8 @@ nodes:
         - type: primary
           network: management3
           ip: 10.121.86.3/28
-        - type: storage
-          network: storage3
 
-  - host: r1an2
+  - host: r1n2
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -65,10 +58,8 @@ nodes:
         - type: primary
           network: management1
           ip: 10.121.84.4/28
-        - type: storage
-          network: storage1
 
-  - host: r2an2
+  - host: r2n2
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -79,10 +70,8 @@ nodes:
         - type: primary
           network: management2
           ip: 10.121.85.4/28
-        - type: storage
-          network: storage2
 
-  - host: r3an2
+  - host: r3n2
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -93,5 +82,3 @@ nodes:
         - type: primary
           network: management3
           ip: 10.121.86.4/28
-        - type: storage
-          network: storage3

--- a/virtual/topology/3h6w.yml
+++ b/virtual/topology/3h6w.yml
@@ -1,6 +1,5 @@
 nodes:
-  - host: r1an0
-    name: bootstrap
+  - host: r1n0
     group: bootstraps
     hardware_profile: bootstrap
     run_list:
@@ -12,7 +11,7 @@ nodes:
           network: management1
           ip: 10.121.84.2/28
 
-  - host: r1an1
+  - host: r1n1
     group: headnodes
     hardware_profile: headnode
     run_list:
@@ -23,10 +22,8 @@ nodes:
         - type: primary
           network: management1
           ip: 10.121.84.3/28
-        - type: storage
-          network: storage1
 
-  - host: r2an1
+  - host: r2n1
     group: headnodes
     hardware_profile: headnode
     run_list:
@@ -37,10 +34,8 @@ nodes:
         - type: primary
           network: management2
           ip: 10.121.85.3/28
-        - type: storage
-          network: storage2
 
-  - host: r3an1
+  - host: r3n1
     group: headnodes
     hardware_profile: headnode
     run_list:
@@ -51,10 +46,8 @@ nodes:
         - type: primary
           network: management3
           ip: 10.121.86.3/28
-        - type: storage
-          network: storage3
 
-  - host: r1an2
+  - host: r1n2
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -65,10 +58,8 @@ nodes:
         - type: primary
           network: management1
           ip: 10.121.84.4/28
-        - type: storage
-          network: storage1
 
-  - host: r1an3
+  - host: r1n3
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -79,10 +70,8 @@ nodes:
         - type: primary
           network: management1
           ip: 10.121.84.5/28
-        - type: storage
-          network: storage1
 
-  - host: r2an2
+  - host: r2n2
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -93,10 +82,8 @@ nodes:
         - type: primary
           network: management2
           ip: 10.121.85.4/28
-        - type: storage
-          network: storage2
 
-  - host: r2an3
+  - host: r2n3
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -107,10 +94,8 @@ nodes:
         - type: primary
           network: management2
           ip: 10.121.85.5/28
-        - type: storage
-          network: storage2
 
-  - host: r3an2
+  - host: r3n2
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -121,10 +106,8 @@ nodes:
         - type: primary
           network: management3
           ip: 10.121.86.4/28
-        - type: storage
-          network: storage3
 
-  - host: r3an3
+  - host: r3n3
     group: worknodes
     hardware_profile: worknode
     run_list:
@@ -135,5 +118,3 @@ nodes:
         - type: primary
           network: management3
           ip: 10.121.86.5/28
-        - type: storage
-          network: storage3


### PR DESCRIPTION
  - ansible
    - private key generation has been removed. this is now in the virtual
      build process
    - initial_ssh_user and initial_ssh_pass updated to reflect default user
      created during the virtual build process
    - chef_server_ip variable corrected to use proper default when primary
      ip is not available
    - ansible_sudo_pass added to allow default user to become sudo
  - chef
    - removed the concept of pods from networking code
    - removed remaining references to the storage interface
  - vagrant
    - added 'create-default-user' provisioner
    - updated create-virtual-environment to generate the operators ssh keypair
      which will be used later during the automation process
  - virtualbox
    - topology file
    - remove custom 'bootstrap' name. vm name will now match the hostname
    - updated all hostnames to remove the pod id