### PR TITLE
mysqlchk xinetd fix and primary network cidr update

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -5,9 +5,6 @@
 default['bcpc']['ceph']['repo']['enabled'] = false
 default['bcpc']['ceph']['repo']['url'] = ''
 
-# aggregate cidr for ceph mon hosts
-default['bcpc']['ceph']['mon']['public_network'] = '10.121.84.0/22'
-
 default['bcpc']['ceph']['pg_num'] = 64
 default['bcpc']['ceph']['pgp_num'] = 64
 default['bcpc']['ceph']['osds'] = %w(sdb sdc sdd sde)

--- a/chef/cookbooks/bcpc/attributes/networking.rb
+++ b/chef/cookbooks/bcpc/attributes/networking.rb
@@ -4,6 +4,7 @@
 
 # network interface nodes will use to communicate on the primary network
 default['bcpc']['networking']['networks']['primary']['interface'] = 'eth1'
+default['bcpc']['networking']['networks']['primary']['aggregate-cidr'] = '10.121.84.0/22'
 
 default['bcpc']['networking']['racks'] = [
   {

--- a/chef/cookbooks/bcpc/files/default/consul/mysql-check
+++ b/chef/cookbooks/bcpc/files/default/consul/mysql-check
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -I -q ${HOSTNAME}:3307 2>/dev/null | grep 'HTTP/1.1 200'
+curl -I -q 127.0.0.1:3307 2>/dev/null | grep 'HTTP/1.1 200'

--- a/chef/cookbooks/bcpc/libraries/utils.rb
+++ b/chef/cookbooks/bcpc/libraries/utils.rb
@@ -130,6 +130,10 @@ def local_host_aggregate
   "#{zone_prefix}-#{node_map['rack_id']}"
 end
 
+def primary_network_aggregate_cidr
+  node['bcpc']['networking']['networks']['primary']['aggregate-cidr']
+end
+
 def node_network_map
   # try to get node information via the node hostname
   match = node['hostname'].match(/^.*r(\d+)n(\d+).*$/i)

--- a/chef/cookbooks/bcpc/recipes/ceph-mon.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-mon.rb
@@ -94,7 +94,7 @@ template '/etc/ceph/ceph.conf' do
   variables(
     config: config,
     headnodes: init_cloud? ? [node] : headnodes,
-    public_network: node['bcpc']['ceph']['mon']['public_network']
+    public_network: primary_network_aggregate_cidr
   )
   notifies :restart, "service[ceph-mon@#{node['hostname']}]", :immediately
 end

--- a/chef/cookbooks/bcpc/recipes/ceph-osd.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-osd.rb
@@ -26,7 +26,7 @@ template '/etc/ceph/ceph.conf' do
   variables(
     config: config,
     headnodes: init_cloud? ? [node] : headnodes,
-    public_network: node['bcpc']['ceph']['mon']['public_network']
+    public_network: primary_network_aggregate_cidr
   )
 end
 

--- a/chef/cookbooks/bcpc/recipes/mysql.rb
+++ b/chef/cookbooks/bcpc/recipes/mysql.rb
@@ -100,15 +100,12 @@ end
 
 template '/etc/xinetd.d/mysqlchk' do
   source 'mysql/xinetd-mysqlchk.erb'
-  mode '440'
-  networks = node['bcpc']['networking']['networks']
-  primary = networks['primary']
+  mode '640'
   variables(
     user: {
       'username' => 'check',
       'password' => config['mysql']['users']['check']['password'],
-    },
-    only_from: primary['cidr']
+    }
   )
   notifies :restart, 'service[xinetd]', :immediately
 end

--- a/chef/cookbooks/bcpc/recipes/rabbitmq.rb
+++ b/chef/cookbooks/bcpc/recipes/rabbitmq.rb
@@ -151,13 +151,10 @@ end
 
 template '/etc/xinetd.d/amqpchk' do
   source 'rabbitmq/xinetd-amqpchk.erb'
-  mode '440'
-
-  networks = node['bcpc']['networking']['networks']
-  primary = networks['primary']
+  mode '640'
 
   variables(
-    only_from: primary['cidr']
+    only_from: primary_network_aggregate_cidr
   )
 
   notifies :restart, 'service[xinetd]', :immediately

--- a/chef/cookbooks/bcpc/templates/default/mysql/xinetd-mysqlchk.erb
+++ b/chef/cookbooks/bcpc/templates/default/mysql/xinetd-mysqlchk.erb
@@ -6,18 +6,17 @@
 # description: mysqlchk
 service mysqlchk
 {
-# this is a config for xinetd, place it in /etc/xinetd.d/
-  disable = no
+  # this is a config for xinetd, place it in /etc/xinetd.d/
+  disable         = no
   flags           = REUSE
   socket_type     = stream
-  bind            = <%= node['ipaddress'] %>
+  bind            = 127.0.0.1
   port            = 3307
   wait            = no
   user            = nobody
   server          = /usr/bin/clustercheck
   server_args     = <%= @user['username'] %> <%= @user['password'] %> 1
   log_on_failure  += USERID
-  only_from       = <%= @only_from %>
   # recommended to put the IPs that need
   # to connect exclusively (security purposes)
   per_source      = UNLIMITED


### PR DESCRIPTION
  - primary network cidr
    - added method to return the primary network aggregate cidr
  - mysqlchk
    - updated xinetd service to bind to localhost vs. primary ip
  - consul mysql health check
    - updated curl localhost vs. primary ip
  - ceph
    - updated to use primary network aggregate cidr method for
      public_network ceph.conf param
  - rabbitmq
    - updated xinetd service to bind to localhost vs. primary ip