### PR TITLE
Set default project for admin user in default domain

### DIFF
--- a/chef/cookbooks/bcpc/recipes/keystone.rb
+++ b/chef/cookbooks/bcpc/recipes/keystone.rb
@@ -241,6 +241,19 @@ execute 'add admin role to admin user in default domain' do
   DOC
 end
 
+execute 'set default project for admin user in default domain' do
+  environment os_adminrc
+  command <<-EOH
+    openstack user set --domain default --project admin admin
+  EOH
+
+  not_if <<-DOC
+    default_project_id=$(openstack project show -c id -f value admin)
+    openstack user show -c default_project_id --domain default admin | \
+      grep ${default_project_id}
+  DOC
+end
+
 execute 'create the service project' do
   environment os_adminrc
 


### PR DESCRIPTION
The OpenStack builder for Packer apparently expects the default 'admin' user to have the 'admin' project explicitly assigned to it. Without that being done, errors of the following form appear:

Build 'openstack' errored: Error initializing compute client: No suitable endpoint could be found in the service catalog. Build 'openstack' errored: Error initializing compute client: No suitable endpoint could be found in the service catalog.