### PR TITLE
changed install path for ceph.bootstrap osd keyring

### DIFF
--- a/chef/cookbooks/bcpc/recipes/ceph-osd.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-osd.rb
@@ -29,7 +29,7 @@ template '/etc/ceph/ceph.conf' do
   )
 end
 
-template '/etc/ceph/ceph.bootstrap-osd.keyring' do
+template '/var/lib/ceph/bootstrap-osd/ceph.keyring' do
   source 'ceph/ceph.client.keyring.erb'
   variables(
     username: 'bootstrap-osd',


### PR DESCRIPTION
  - ceph-volume looks for ceph.boostrap's keyring file
    in /var/lib/ceph/boostrap-osd vs. /etc/ceph