### PR TITLE
Update Calico version to 3.4

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -92,8 +92,8 @@ assets_files:
     filename: etcd-v3.3.9-linux-amd64.tar.gz
 
   - name: calicoctl
-    url: https://github.com/projectcalico/calicoctl/releases/download/v3.2.3/calicoctl-linux-amd64
-    checksum: sha256:3396ee93361726eede85e3f86b256c80bf8d9d95e6ec37b6573fb44e7bf64e2f
+    url: https://github.com/projectcalico/calicoctl/releases/download/v3.4.0/calicoctl-linux-amd64
+    checksum: sha256:7017efab112a75ff7123ca0db62a52940e68bd6f1f2fe41ef08fe12dd4c89ca5
     filename: calicoctl
 
   - name: consul

--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -2,7 +2,7 @@
 # calico/calicoctl
 ###############################################################################
 
-default['bcpc']['calico']['repo']['url'] = 'http://ppa.launchpad.net/project-calico/calico-3.2/ubuntu'
+default['bcpc']['calico']['repo']['url'] = 'http://ppa.launchpad.net/project-calico/calico-3.4/ubuntu'
 default['bcpc']['calico']['remote']['file'] = 'calicoctl'
 default['bcpc']['calico']['remote']['source'] = "#{default['bcpc']['file_server']['url']}/calicoctl"
-default['bcpc']['calico']['remote']['checksum'] = '3396ee93361726eede85e3f86b256c80bf8d9d95e6ec37b6573fb44e7bf64e2f'
+default['bcpc']['calico']['remote']['checksum'] = '7017efab112a75ff7123ca0db62a52940e68bd6f1f2fe41ef08fe12dd4c89ca5'


### PR DESCRIPTION
This upgrades the version of Calico from 3.2.4 to 3.4.0.

I tested this with a virtual 3h3w configuration using bird-leafy-spine, starting multiple VMs on hypervisors on different racks and verified that I was able to send traffic between the two VMs. If there is additional testing recommended, I'd appreciate getting some ideas.