### PR TITLE
Update etcd version to 3.3.10

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -87,9 +87,9 @@ assets_files:
     filename: CentOS-7-x86_64-GenericCloud-1808.qcow2.xz
 
   - name: etcd
-    url: https://github.com/etcd-io/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz
-    checksum: sha256:7b95bdc6dfd1d805f650ea8f886fdae6e7322f886a8e9d1b0d14603767d053b1
-    filename: etcd-v3.3.9-linux-amd64.tar.gz
+    url: https://github.com/etcd-io/etcd/releases/download/v3.3.10/etcd-v3.3.10-linux-amd64.tar.gz
+    checksum: sha256:1620a59150ec0a0124a65540e23891243feb2d9a628092fb1edcc23974724a45
+    filename: etcd-v3.3.10-linux-amd64.tar.gz
 
   - name: calicoctl
     url: https://github.com/projectcalico/calicoctl/releases/download/v3.4.0/calicoctl-linux-amd64

--- a/ansible/playbooks/roles/file-server/tasks/setup.yml
+++ b/ansible/playbooks/roles/file-server/tasks/setup.yml
@@ -11,6 +11,6 @@
     dest: "/var/bcpc/file-server/"
   with_items:
     - "{{ assets_download_dir }}/calicoctl"
-    - "{{ assets_download_dir }}/etcd-v3.3.9-linux-amd64.tar.gz"
+    - "{{ assets_download_dir }}/etcd-v3.3.10-linux-amd64.tar.gz"
     - "{{ assets_download_dir }}/consul_1.2.3_linux_amd64.zip"
     - "{{ assets_download_dir }}/cirros-0.4.0-x86_64-disk.img"

--- a/chef/cookbooks/bcpc/attributes/default.rb
+++ b/chef/cookbooks/bcpc/attributes/default.rb
@@ -190,10 +190,10 @@ default['bcpc']['memcached']['connections'] = 10240
 # etcd
 ###############################################################################
 
-etcd_file = 'etcd-v3.3.9-linux-amd64.tar.gz'
+etcd_file = 'etcd-v3.3.10-linux-amd64.tar.gz'
 default['bcpc']['etcd']['remote']['file'] = etcd_file
 default['bcpc']['etcd']['remote']['source'] = "#{default['bcpc']['file_server']['url']}/#{etcd_file}"
-default['bcpc']['etcd']['remote']['checksum'] = '7b95bdc6dfd1d805f650ea8f886fdae6e7322f886a8e9d1b0d14603767d053b1'
+default['bcpc']['etcd']['remote']['checksum'] = '1620a59150ec0a0124a65540e23891243feb2d9a628092fb1edcc23974724a45'
 
 ###############################################################################
 # virtualbox


### PR DESCRIPTION
This upgrades the version of etcd from 3.3.9 to 3.3.10.

I tested this with a virtual 3h3w configuration using bird-leafy-spine, starting multiple VMs on hypervisors on different racks and verified that I was able to send traffic between the two VMs.