### PR TITLE
Change ceph parameter mon_osd_down_out_subtree_limit from rack to host

### DIFF
--- a/cookbooks/bcpc/attributes/ceph.rb
+++ b/cookbooks/bcpc/attributes/ceph.rb
@@ -88,3 +88,4 @@ default['bcpc']['ceph']['osd_recovery_op_priority'] = 1
 default['bcpc']['ceph']['osd_max_backfills'] = 1
 default['bcpc']['ceph']['osd_op_threads'] = 2
 default['bcpc']['ceph']['osd_mon_report_interval_min'] = 5
+default['bcpc']['ceph']['mon_osd_down_out_subtree_limit'] = "host"

--- a/cookbooks/bcpc/templates/default/ceph.conf.erb
+++ b/cookbooks/bcpc/templates/default/ceph.conf.erb
@@ -17,6 +17,7 @@
     mon pg warn max object skew = <%= @node['bcpc']['ceph']['pg_warn_max_obj_skew'] %>
     max open files = <%= @node['bcpc']['ceph']['max_open_files'] %>
     paxos propose interval = <%= @node['bcpc']['ceph']['paxos_propose_interval'] %>
+    mon osd down out subtree limit = <%= @node['bcpc']['ceph']['mon_osd_down_out_subtree_limit'] %>
 
 [mon]
     keyring = /var/lib/ceph/mon/$cluster-$id/keyring


### PR DESCRIPTION
Change ceph mon parameter
'mon osd down out subtree limit' FROM rack TO host to prevent OSDs from being marked out when a host fails

The parameter 'mon osd down out subtree limit' defined by ceph is as follows

"The smallest CRUSH unit type that Ceph will not automatically mark out. For instance, if set to host and if all OSDs of a host are down, Ceph will not automatically mark out these OSDs."
