### PR TITLE
Introduce DynamicJSON metadata-related attributes to Nova.

### DIFF
--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -138,3 +138,8 @@ default['bcpc']['nova']['quota']['global']['floating-ips'] = -1
 default['bcpc']['nova']['quota']['project']['admin']['cores'] = -1
 default['bcpc']['nova']['quota']['project']['admin']['ram'] = -1
 default['bcpc']['nova']['quota']['project']['admin']['floating-ips'] = -1
+
+# metadata API
+#
+default['bcpc']['nova']['vendordata']['name'] = nil
+default['bcpc']['nova']['vendordata']['port'] = 8444

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -43,6 +43,10 @@ default_log_levels = "<%= node['bcpc']['nova']['default_log_levels'] %>"
 [api]
 auth_strategy = keystone
 
+<% if not node['bcpc']['nova']['vendordata']['name'].nil? %>
+vendordata_dynamic_targets = <%= node['bcpc']['nova']['vendordata']['name'] %>@https://<%= "#{@node['bcpc']['cloud']['fqdn']}" %>:<%= node['bcpc']['nova']['vendordata']['port'] %>
+vendordata_providers = DynamicJSON,StaticJSON
+<% end -%>
 
 [keystone_authtoken]
 auth_uri = <%= "https://#{@node['bcpc']['cloud']['fqdn']}:5000/" %>


### PR DESCRIPTION
This introduced two attributes to allow an external metadata service to be enabled for Nova using the DynamicJSON mechanism. The resulting data is available via `http://169.254.169.254/openstack/2016-10-06/vendor_data2.json`.