### PR TITLE
cinder automation and ansible conf fixes

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -5,3 +5,6 @@ stderr_callback=debug
 [colors]
 # dark blue is quite unreadable on a black background
 verbose = cyan
+
+[inventory]
+enable_plugins = yaml

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -126,8 +126,17 @@ package 'cinder-volume'
 service 'cinder-api' do
   service_name 'apache2'
 end
-service 'cinder-volume'
-service 'cinder-scheduler'
+
+service 'cinder-volume' do
+  retries 10
+  retry_delay 5
+end
+
+service 'cinder-scheduler' do
+  retries 10
+  retry_delay 5
+end
+
 service 'haproxy-cinder' do
   service_name 'haproxy'
 end
@@ -248,16 +257,9 @@ template '/etc/cinder/cinder.conf' do
     headnodes: headnodes(all: true)
   )
 
-  # the cinder services here are being stopped/started vs. restarted
-  # is because on some systems, the package installation and configuration
-  # happens so fast that it causes systemd to complain about the service
-  # restarting too fast.
-  notifies :stop, 'service[cinder-api]', :immediately
-  notifies :stop, 'service[cinder-volume]', :immediately
-  notifies :stop, 'service[cinder-scheduler]', :immediately
-  notifies :start, 'service[cinder-api]', :immediately
-  notifies :start, 'service[cinder-volume]', :immediately
-  notifies :start, 'service[cinder-scheduler]', :immediately
+  notifies :restart, 'service[cinder-api]', :immediately
+  notifies :restart, 'service[cinder-volume]', :immediately
+  notifies :restart, 'service[cinder-scheduler]', :immediately
 end
 # configure cinder service ends
 

--- a/virtual/files/ansible/vars/virtual.yml
+++ b/virtual/files/ansible/vars/virtual.yml
@@ -7,3 +7,7 @@ virtual_ssh_dir: "{{ virtual_dir }}/files/ssh"
 ansible_ssh_private_key_file: "{{ virtual_ssh_dir }}/id_ed25519"
 operator_authorized_key: >
   {{ lookup('file', ansible_ssh_private_key_file + '.pub') }}
+ansible_ssh_common_args: >
+  -o StrictHostKeyChecking=no
+  -o UserKnownHostsFile=/dev/null
+  -o 'IdentitiesOnly yes'


### PR DESCRIPTION
  - cinder
    - updated cinder volume and scheduler service to retry restarts
  - ansible
    - added config option to ansible.cfg to only enable the yaml
      inventory plugin to remove warning about inventory.yml errors