### PR TITLE
Allow setting of RBD's default feature set; turn off problematic values.

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -39,3 +39,8 @@ default['bcpc']['ceph']['osd_recovery_op_priority'] = 1
 default['bcpc']['ceph']['osd_max_backfills'] = 1
 default['bcpc']['ceph']['osd_op_threads'] = 2
 default['bcpc']['ceph']['osd_mon_report_interval_min'] = 5
+
+# Set RBD default feature set to only include layering and
+# deep-flatten. Other values (in particular, exclusive-lock) may prevent
+# instances from being able to access their root file system after a crash.
+default['bcpc']['ceph']['rbd_default_features'] = 33

--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -7,6 +7,7 @@ auth client required = cephx
 mon initial members = <%= @headnodes.map{ |n| n['hostname'] }.join(',') %>
 mon host = <%= @headnodes.map{ |n| n['service_ip'] }.join(',') %>
 max open files = <%= node['bcpc']['ceph']['max_open_files'] %>
+rbd default features = <%= node['bcpc']['ceph']['rbd_default_features'] %>
 
 [osd]
 osd scrub load threshold = <%= node['bcpc']['ceph']['osd_scrub_load_threshold'] %>


### PR DESCRIPTION
Tested this on a 3h3w configuration by both crashing an instance and forcibly halting a hypervisor running an instance. In both cases, the instance was able to successfully boot again. Prior to the change, the instance was unable to boot, apparently because it wasn't able to access its root file system.