### PR TITLE
Address some issues with AS #s in larger configuration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ export playbooks = ansible/playbooks
 export ANSIBLE_CONFIG = ansible/ansible.cfg
 
 headnodes = $$(ansible headnodes -i ${inventory} --list | tail -n +2 | wc -l)
-storagenodes = $$(ansible storagenodes -i ${inventory} --list | tail -n +2 | wc -l)
+storagenodes = \
+        $$(ansible storagenodes -i ${inventory} --list | tail -n +2 | wc -l)
 
 all : \
 	download-assets \
@@ -23,7 +24,7 @@ all : \
 
 create: create-virtual-network create-virtual-hosts
 
-destroy: destroy-virtual-network destroy-virtual-hosts
+destroy: destroy-virtual-hosts destroy-virtual-network
 
 create-virtual-hosts :
 

--- a/chef/cookbooks/bcpc/attributes/networking.rb
+++ b/chef/cookbooks/bcpc/attributes/networking.rb
@@ -6,7 +6,8 @@
 default['bcpc']['networking']['networks']['primary']['interface'] = 'eth1'
 default['bcpc']['networking']['networks']['primary']['aggregate-cidr'] = '10.65.0.0/24'
 
-# TODO(justinjpacheco): This rack information should be cleaned up, perhaps made Ceph specific?
+# TODO(justinjpacheco): This rack information should be cleaned up,
+# perhaps made Ceph specific?
 default['bcpc']['networking']['racks'] = [
   {
     'id' => 1,
@@ -21,7 +22,7 @@ default['bcpc']['networking']['racks'] = [
   {
     'id' => 2,
     'bgp' => {
-      'tor_as' => 4_200_858_702,
+      'tor_as' => 4_200_858_703,
       'node_as' => 4_200_858_801,
     },
     'networks' => {
@@ -31,7 +32,7 @@ default['bcpc']['networking']['racks'] = [
   {
     'id' => 3,
     'bgp' => {
-      'tor_as' => 4_200_858_703,
+      'tor_as' => 4_200_858_705,
       'node_as' => 4_200_858_801,
     },
     'networks' => {

--- a/virtual/network/bird/spine1.conf
+++ b/virtual/network/bird/spine1.conf
@@ -16,13 +16,12 @@ prefix set hypervisors_nets;
 {
         hypervisors_nets = [
             192.168.0.0/24+,
-            # loopback network
-            10.65.0.0/24{32,32},
-            # tenant networks
+            # Tenant networks
             10.1.0.0/16{32,32},
-            # Management networks
+            # Loopback networks
+            10.65.0.0/24{32,32},
+            # Transit networks
             10.121.84.0/22+,
-            # Storage networks
             10.121.88.0/22+
         ];
         if net ~ hypervisors_nets then accept;
@@ -63,23 +62,23 @@ protocol direct {
         interface "eth1", "eth2";
 }
 
-protocol bgp tor1_spine1 {
+protocol bgp 'spine1:tor1' {
         local as 4200858601;
-        neighbor 172.16.0.0 as 4200858702;
+        neighbor 172.16.0.0 as 4200858701;
         export all;
         import filter hypervisors;
 }
 
-protocol bgp tor2_spine1 {
+protocol bgp 'spine1:tor2' {
         local as 4200858601;
-        neighbor 172.16.0.4 as 4200858704;
+        neighbor 172.16.0.4 as 4200858703;
         export all;
         import filter hypervisors;
 }
 
-protocol bgp tor3_spine1 {
+protocol bgp 'spine1:tor3' {
         local as 4200858601;
-        neighbor 172.16.0.8 as 4200858706;
+        neighbor 172.16.0.8 as 4200858705;
         export all;
         import filter hypervisors;
 }

--- a/virtual/network/bird/spine2.conf
+++ b/virtual/network/bird/spine2.conf
@@ -16,13 +16,12 @@ prefix set hypervisors_nets;
 {
         hypervisors_nets = [
             192.168.0.0/24+,
-            # loopback network
-            10.65.0.0/24{32,32},
-            # tenant networks
+            # Tenant networks
             10.1.0.0/16{32,32},
-            # Management networks
+            # Loopback networks
+            10.65.0.0/24{32,32},
+            # Transit networks
             10.121.84.0/22+,
-            # Storage networks
             10.121.88.0/22+
         ];
         if net ~ hypervisors_nets then accept;
@@ -63,23 +62,23 @@ protocol direct {
         interface "eth1", "eth2";
 }
 
-protocol bgp tor1_spine2 {
+protocol bgp 'spine2:tor1' {
         local as 4200858601;
         neighbor 172.16.0.2 as 4200858701;
         export all;
         import filter hypervisors;
 }
 
-protocol bgp tor2_spine2 {
+protocol bgp 'spine2:tor2' {
         local as 4200858601;
-        neighbor 172.16.0.6 as 4200858702;
+        neighbor 172.16.0.6 as 4200858703;
         export all;
         import filter hypervisors;
 }
 
-protocol bgp tor3_spine2 {
+protocol bgp 'spine2:tor3' {
         local as 4200858601;
-        neighbor 172.16.0.10 as 4200858703;
+        neighbor 172.16.0.10 as 4200858705;
         export all;
         import filter hypervisors;
 }

--- a/virtual/network/bird/tor1.conf
+++ b/virtual/network/bird/tor1.conf
@@ -16,13 +16,12 @@ prefix set hypervisors_nets;
 {
         hypervisors_nets = [
             192.168.0.0/26,
-            # loopback network
-            10.65.0.0/24{32,32},
-            # tenant networks
+            # Tenant networks
             10.1.0.0/16{32,32},
-            # Management networks
+            # Loopback networks
+            10.65.0.0/24{32,32},
+            # Transit networks
             10.121.84.0/22+,
-            # Storage networks
             10.121.88.0/22+
         ];
         if net ~ hypervisors_nets then accept;
@@ -36,9 +35,8 @@ prefix set mynetworks_nets;
         mynetworks_nets = [
             172.16.0.0/26+,
             192.168.0.0/24+,
-            # Management networks
+            # Transit networks
             10.121.84.0/22+,
-            # Storage networks
             10.121.88.0/22+
         ];
         if net ~ mynetworks_nets then accept;
@@ -68,38 +66,44 @@ protocol direct {
         interface "eth3", "eth4", "eth5";
 }
 
-protocol bgp tor1_spine1 {
-        local as 4200858702;
+protocol bgp 'spine1:tor1' {
+        local as 4200858701;
         neighbor 172.16.0.1 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
 }
 
-protocol bgp tor1_spine2 {
-        local as 4200858702;
+protocol bgp 'spine2:tor1' {
+        local as 4200858701;
         neighbor 172.16.0.3 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
 }
 
-# node000 is the bootstrap node.
-protocol bgp tor1_node000 {
-        local as 4200858702;
-        neighbor 10.121.84.2 as 4200858701;
+protocol bgp 'tor1:r1n0' {
+        local as 4200858701;
+        neighbor 10.121.84.2 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
 }
 
-protocol bgp tor1_node001 {
-        local as 4200858702;
-        neighbor 10.121.84.3 as 4200858701;
+protocol bgp 'tor1:r1n1' {
+        local as 4200858701;
+        neighbor 10.121.84.3 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
 }
 
-protocol bgp tor1_node002 {
-        local as 4200858702;
-        neighbor 10.121.84.4 as 4200858701;
+protocol bgp 'tor1:r1n2' {
+        local as 4200858701;
+        neighbor 10.121.84.4 as 4200858801;
+        export filter mynetworks;
+        import filter hypervisors;
+}
+
+protocol bgp 'tor1:r1n3' {
+        local as 4200858701;
+        neighbor 10.121.84.5 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
 }

--- a/virtual/network/bird/tor2.conf
+++ b/virtual/network/bird/tor2.conf
@@ -16,13 +16,12 @@ prefix set hypervisors_nets;
 {
         hypervisors_nets = [
             192.168.0.64/26,
-            # loopback network
-            10.65.0.0/24{32,32},
-            # tenant networks
+            # Tenant networks
             10.1.0.0/16{32,32},
-            # Management networks
+            # Loopback networks
+            10.65.0.0/24{32,32},
+            # Transit networks
             10.121.84.0/22+,
-            # Storage networks
             10.121.88.0/22+
         ];
         if net ~ hypervisors_nets then accept;
@@ -36,9 +35,8 @@ prefix set mynetworks_nets;
         mynetworks_nets = [
             172.16.0.0/26+,
             192.168.0.0/24+,
-            # Management networks
+            # Transit networks
             10.121.84.0/22+,
-            # Storage networks
             10.121.88.0/22+
         ];
         if net ~ mynetworks_nets then accept;
@@ -68,31 +66,37 @@ protocol direct {
         interface "eth3", "eth4", "eth5";
 }
 
-protocol bgp tor2_spine1 {
-        local as 4200858704;
+protocol bgp 'spine1:tor2' {
+        local as 4200858703;
         neighbor 172.16.0.5 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
 }
 
-protocol bgp tor2_spine2 {
-        local as 4200858704;
+protocol bgp 'spine2:tor2' {
+        local as 4200858703;
         neighbor 172.16.0.7 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
 }
 
-# node000 is the bootstrap node.
-protocol bgp tor2_node025 {
-        local as 4200858704;
-        neighbor 10.121.85.3 as 4200858703;
+protocol bgp 'tor2:r2n1' {
+        local as 4200858703;
+        neighbor 10.121.85.3 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
 }
 
-protocol bgp tor2_node026 {
-        local as 4200858704;
-        neighbor 10.121.85.4 as 4200858703;
+protocol bgp 'tor2:r2n2' {
+        local as 4200858703;
+        neighbor 10.121.85.4 as 4200858801;
+        export filter mynetworks;
+        import filter hypervisors;
+}
+
+protocol bgp 'tor2:r3n3' {
+        local as 4200858703;
+        neighbor 10.121.85.5 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
 }

--- a/virtual/network/bird/tor3.conf
+++ b/virtual/network/bird/tor3.conf
@@ -16,13 +16,12 @@ prefix set hypervisors_nets;
 {
         hypervisors_nets = [
             192.168.0.128/26,
-            # loopback network
-            10.65.0.0/24{32,32},
-            # tenant networks
+            # Tenant networks
             10.1.0.0/16{32,32},
-            # Management networks
+            # Loopback networks
+            10.65.0.0/24{32,32},
+            # Transit networks
             10.121.84.0/22+,
-            # Storage networks
             10.121.88.0/22+
         ];
         if net ~ hypervisors_nets then accept;
@@ -36,9 +35,8 @@ prefix set mynetworks_nets;
         mynetworks_nets = [
             172.16.0.0/26+,
             192.168.0.0/24+,
-            # Management networks
+            # Transit networks
             10.121.84.0/22+,
-            # Storage networks
             10.121.88.0/22+
         ];
         if net ~ mynetworks_nets then accept;
@@ -68,31 +66,37 @@ protocol direct {
         interface "eth3", "eth4", "eth5";
 }
 
-protocol bgp tor3_spine1 {
-        local as 4200858706;
+protocol bgp 'spine1:tor3' {
+        local as 4200858705;
         neighbor 172.16.0.9 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
 }
 
-protocol bgp tor3_spine2 {
-        local as 4200858706;
+protocol bgp 'spine2:tor3' {
+        local as 4200858705;
         neighbor 172.16.0.11 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
 }
 
-# node000 is the bootstrap node.
-protocol bgp tor3_node050 {
-        local as 4200858706;
-        neighbor 10.121.86.3 as 4200858705;
+protocol bgp 'tor3:r3n1' {
+        local as 4200858705;
+        neighbor 10.121.86.3 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
 }
 
-protocol bgp tor3_node051 {
-        local as 4200858706;
-        neighbor 10.121.86.4 as 4200858705;
+protocol bgp 'tor3:r3n2' {
+        local as 4200858705;
+        neighbor 10.121.86.4 as 4200858801;
+        export filter mynetworks;
+        import filter hypervisors;
+}
+
+protocol bgp 'tor3:r3n3' {
+        local as 4200858705;
+        neighbor 10.121.86.5 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
 }

--- a/virtual/topology/1h1w.yml
+++ b/virtual/topology/1h1w.yml
@@ -4,7 +4,7 @@ nodes:
     hardware_profile: bootstrap
     host_vars:
       bgp:
-        asn: 4200858701
+        asn: 4200858801
       interfaces:
         service:
           ip: 10.65.0.1
@@ -13,7 +13,7 @@ nodes:
             mac: '08:00:27:00:00:10'
             neighbor:
               ip: 10.121.84.1
-              asn: 4200858702
+              asn: 4200858701
               name: management1
           - ip: 10.121.88.2/28
             mac: '08:00:27:00:00:11'
@@ -29,7 +29,7 @@ nodes:
     hardware_profile: headnode
     host_vars:
       bgp:
-        asn: 4200858701
+        asn: 4200858801
       interfaces:
         service:
           ip: 10.65.0.2
@@ -38,7 +38,7 @@ nodes:
             mac: '08:00:27:00:00:12'
             neighbor:
               ip: 10.121.84.1
-              asn: 4200858702
+              asn: 4200858701
               name: management1
           - ip: 10.121.88.3/28
             mac: '08:00:27:00:00:13'
@@ -54,7 +54,7 @@ nodes:
     hardware_profile: worknode
     host_vars:
       bgp:
-        asn: 4200858701
+        asn: 4200858801
       interfaces:
         service:
           ip: 10.65.0.3
@@ -63,7 +63,7 @@ nodes:
             mac: '08:00:27:00:00:14'
             neighbor:
               ip: 10.121.84.1
-              asn: 4200858702
+              asn: 4200858701
               name: management1
           - ip: 10.121.88.4/28
             mac: '08:00:27:00:00:15'

--- a/virtual/topology/3h3w.yml
+++ b/virtual/topology/3h3w.yml
@@ -83,7 +83,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.26
+          ip: 10.65.0.16
         transit:
           - ip: 10.121.85.3/28
             mac: '08:00:27:00:00:20'
@@ -108,7 +108,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.27
+          ip: 10.65.0.17
         transit:
           - ip: 10.121.85.4/28
             mac: '08:00:27:00:00:22'
@@ -134,7 +134,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.51
+          ip: 10.65.0.32
         transit:
           - ip: 10.121.86.3/28
             mac: '08:00:27:00:00:30'
@@ -159,7 +159,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.52
+          ip: 10.65.0.33
         transit:
           - ip: 10.121.86.4/28
             mac: '08:00:27:00:00:32'

--- a/virtual/topology/3h3w.yml
+++ b/virtual/topology/3h3w.yml
@@ -4,7 +4,7 @@ nodes:
     hardware_profile: bootstrap
     host_vars:
       bgp:
-        asn: 4200858701
+        asn: 4200858801
       interfaces:
         service:
           ip: 10.65.0.1
@@ -13,7 +13,7 @@ nodes:
             mac: '08:00:27:00:00:10'
             neighbor:
               ip: 10.121.84.1
-              asn: 4200858702
+              asn: 4200858701
               name: management1
           - ip: 10.121.88.2/28
             mac: '08:00:27:00:00:11'
@@ -29,7 +29,7 @@ nodes:
     hardware_profile: headnode
     host_vars:
       bgp:
-        asn: 4200858701
+        asn: 4200858801
       interfaces:
         service:
           ip: 10.65.0.2
@@ -38,7 +38,7 @@ nodes:
             mac: '08:00:27:00:00:12'
             neighbor:
               ip: 10.121.84.1
-              asn: 4200858702
+              asn: 4200858701
               name: management1
           - ip: 10.121.88.3/28
             mac: '08:00:27:00:00:13'
@@ -54,7 +54,7 @@ nodes:
     hardware_profile: worknode
     host_vars:
       bgp:
-        asn: 4200858701
+        asn: 4200858801
       interfaces:
         service:
           ip: 10.65.0.3
@@ -63,7 +63,7 @@ nodes:
             mac: '08:00:27:00:00:14'
             neighbor:
               ip: 10.121.84.1
-              asn: 4200858702
+              asn: 4200858701
               name: management1
           - ip: 10.121.88.4/28
             mac: '08:00:27:00:00:15'
@@ -80,16 +80,16 @@ nodes:
     hardware_profile: headnode
     host_vars:
       bgp:
-        asn: 4200858703
+        asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.4
+          ip: 10.65.0.26
         transit:
           - ip: 10.121.85.3/28
             mac: '08:00:27:00:00:20'
             neighbor:
               ip: 10.121.85.1
-              asn: 4200858704
+              asn: 4200858703
               name: management2
           - ip: 10.121.89.3/28
             mac: '08:00:27:00:00:21'
@@ -105,16 +105,16 @@ nodes:
     hardware_profile: worknode
     host_vars:
       bgp:
-        asn: 4200858703
+        asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.5
+          ip: 10.65.0.27
         transit:
           - ip: 10.121.85.4/28
             mac: '08:00:27:00:00:22'
             neighbor:
               ip: 10.121.85.1
-              asn: 4200858704
+              asn: 4200858703
               name: management2
           - ip: 10.121.89.4/28
             mac: '08:00:27:00:00:23'
@@ -131,16 +131,16 @@ nodes:
     hardware_profile: headnode
     host_vars:
       bgp:
-        asn: 4200858705
+        asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.6
+          ip: 10.65.0.51
         transit:
           - ip: 10.121.86.3/28
             mac: '08:00:27:00:00:30'
             neighbor:
               ip: 10.121.86.1
-              asn: 4200858706
+              asn: 4200858705
               name: management3
           - ip: 10.121.90.3/28
             mac: '08:00:27:00:00:31'
@@ -156,16 +156,16 @@ nodes:
     hardware_profile: worknode
     host_vars:
       bgp:
-        asn: 4200858705
+        asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.7
+          ip: 10.65.0.52
         transit:
           - ip: 10.121.86.4/28
             mac: '08:00:27:00:00:32'
             neighbor:
               ip: 10.121.86.1
-              asn: 4200858706
+              asn: 4200858705
               name: management3
           - ip: 10.121.90.4/28
             mac: '08:00:27:00:00:33'

--- a/virtual/topology/3h6w.yml
+++ b/virtual/topology/3h6w.yml
@@ -2,125 +2,255 @@ nodes:
   - host: r1n0
     group: bootstraps
     hardware_profile: bootstrap
-    run_list:
-      - role[bootstrap]
-    networking:
-      gateway: 10.121.84.1
-      networks:
-        - type: primary
-          network: management1
-          ip: 10.121.84.2/28
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.1
+        transit:
+          - ip: 10.121.84.2/28
+            mac: '08:00:27:00:00:10'
+            neighbor:
+              ip: 10.121.84.1
+              asn: 4200858701
+              name: management1
+          - ip: 10.121.88.2/28
+            mac: '08:00:27:00:00:11'
+            neighbor:
+              ip: 10.121.88.1
+              asn: 4200858702
+              name: management4
+      run_list:
+        - role[bootstrap]
 
   - host: r1n1
     group: headnodes
     hardware_profile: headnode
-    run_list:
-      - role[headnode]
-    networking:
-      gateway: 10.121.84.1
-      networks:
-        - type: primary
-          network: management1
-          ip: 10.121.84.3/28
-
-  - host: r2n1
-    group: headnodes
-    hardware_profile: headnode
-    run_list:
-      - role[headnode]
-    networking:
-      gateway: 10.121.85.1
-      networks:
-        - type: primary
-          network: management2
-          ip: 10.121.85.3/28
-
-  - host: r3n1
-    group: headnodes
-    hardware_profile: headnode
-    run_list:
-      - role[headnode]
-    networking:
-      gateway: 10.121.86.1
-      networks:
-        - type: primary
-          network: management3
-          ip: 10.121.86.3/28
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.2
+        transit:
+          - ip: 10.121.84.3/28
+            mac: '08:00:27:00:00:12'
+            neighbor:
+              ip: 10.121.84.1
+              asn: 4200858701
+              name: management1
+          - ip: 10.121.88.3/28
+            mac: '08:00:27:00:00:13'
+            neighbor:
+              ip: 10.121.88.1
+              asn: 4200858702
+              name: management4
+      run_list:
+        - role[headnode]
 
   - host: r1n2
     group: worknodes
     hardware_profile: worknode
-    run_list:
-      - role[worknode]
-      - role[storagenode]
-    networking:
-      gateway: 10.121.84.1
-      networks:
-        - type: primary
-          network: management1
-          ip: 10.121.84.4/28
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.3
+        transit:
+          - ip: 10.121.84.4/28
+            mac: '08:00:27:00:00:14'
+            neighbor:
+              ip: 10.121.84.1
+              asn: 4200858701
+              name: management1
+          - ip: 10.121.88.4/28
+            mac: '08:00:27:00:00:15'
+            neighbor:
+              ip: 10.121.88.1
+              asn: 4200858702
+              name: management4
+      run_list:
+        - role[worknode]
+        - role[storagenode]
 
   - host: r1n3
     group: worknodes
     hardware_profile: worknode
-    run_list:
-      - role[worknode]
-      - role[storagenode]
-    networking:
-      gateway: 10.121.84.1
-      networks:
-        - type: primary
-          network: management1
-          ip: 10.121.84.5/28
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.4
+        transit:
+          - ip: 10.121.84.5/28
+            mac: '08:00:27:00:00:16'
+            neighbor:
+              ip: 10.121.84.1
+              asn: 4200858701
+              name: management1
+          - ip: 10.121.88.5/28
+            mac: '08:00:27:00:00:17'
+            neighbor:
+              ip: 10.121.88.1
+              asn: 4200858702
+              name: management4
+      run_list:
+        - role[worknode]
+        - role[storagenode]
+
+  - host: r2n1
+    group: headnodes
+    hardware_profile: headnode
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.26
+        transit:
+          - ip: 10.121.85.3/28
+            mac: '08:00:27:00:00:20'
+            neighbor:
+              ip: 10.121.85.1
+              asn: 4200858703
+              name: management2
+          - ip: 10.121.89.3/28
+            mac: '08:00:27:00:00:21'
+            neighbor:
+              ip: 10.121.89.1
+              asn: 4200858704
+              name: management5
+      run_list:
+        - role[headnode]
 
   - host: r2n2
     group: worknodes
     hardware_profile: worknode
-    run_list:
-      - role[worknode]
-      - role[storagenode]
-    networking:
-      gateway: 10.121.85.1
-      networks:
-        - type: primary
-          network: management2
-          ip: 10.121.85.4/28
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.27
+        transit:
+          - ip: 10.121.85.4/28
+            mac: '08:00:27:00:00:22'
+            neighbor:
+              ip: 10.121.85.1
+              asn: 4200858703
+              name: management2
+          - ip: 10.121.89.4/28
+            mac: '08:00:27:00:00:23'
+            neighbor:
+              ip: 10.121.89.1
+              asn: 4200858704
+              name: management5
+      run_list:
+        - role[worknode]
+        - role[storagenode]
 
   - host: r2n3
     group: worknodes
     hardware_profile: worknode
-    run_list:
-      - role[worknode]
-      - role[storagenode]
-    networking:
-      gateway: 10.121.85.1
-      networks:
-        - type: primary
-          network: management2
-          ip: 10.121.85.5/28
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.28
+        transit:
+          - ip: 10.121.85.5/28
+            mac: '08:00:27:00:00:24'
+            neighbor:
+              ip: 10.121.85.1
+              asn: 4200858703
+              name: management2
+          - ip: 10.121.89.5/28
+            mac: '08:00:27:00:00:25'
+            neighbor:
+              ip: 10.121.89.1
+              asn: 4200858704
+              name: management5
+      run_list:
+        - role[worknode]
+        - role[storagenode]
+
+  - host: r3n1
+    group: headnodes
+    hardware_profile: headnode
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.51
+        transit:
+          - ip: 10.121.86.3/28
+            mac: '08:00:27:00:00:30'
+            neighbor:
+              ip: 10.121.86.1
+              asn: 4200858705
+              name: management3
+          - ip: 10.121.90.3/28
+            mac: '08:00:27:00:00:31'
+            neighbor:
+              ip: 10.121.90.1
+              asn: 4200858706
+              name: management6
+      run_list:
+        - role[headnode]
 
   - host: r3n2
     group: worknodes
     hardware_profile: worknode
-    run_list:
-      - role[worknode]
-      - role[storagenode]
-    networking:
-      gateway: 10.121.86.1
-      networks:
-        - type: primary
-          network: management3
-          ip: 10.121.86.4/28
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.52
+        transit:
+          - ip: 10.121.86.4/28
+            mac: '08:00:27:00:00:32'
+            neighbor:
+              ip: 10.121.86.1
+              asn: 4200858705
+              name: management3
+          - ip: 10.121.90.4/28
+            mac: '08:00:27:00:00:33'
+            neighbor:
+              ip: 10.121.90.1
+              asn: 4200858706
+              name: management6
+      run_list:
+        - role[worknode]
+        - role[storagenode]
 
   - host: r3n3
     group: worknodes
     hardware_profile: worknode
-    run_list:
-      - role[worknode]
-      - role[storagenode]
-    networking:
-      gateway: 10.121.86.1
-      networks:
-        - type: primary
-          network: management3
-          ip: 10.121.86.5/28
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.53
+        transit:
+          - ip: 10.121.86.5/28
+            mac: '08:00:27:00:00:34'
+            neighbor:
+              ip: 10.121.86.1
+              asn: 4200858705
+              name: management3
+          - ip: 10.121.90.5/28
+            mac: '08:00:27:00:00:35'
+            neighbor:
+              ip: 10.121.90.1
+              asn: 4200858706
+              name: management6
+      run_list:
+        - role[worknode]
+        - role[storagenode]

--- a/virtual/topology/3h6w.yml
+++ b/virtual/topology/3h6w.yml
@@ -109,7 +109,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.26
+          ip: 10.65.0.16
         transit:
           - ip: 10.121.85.3/28
             mac: '08:00:27:00:00:20'
@@ -134,7 +134,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.27
+          ip: 10.65.0.17
         transit:
           - ip: 10.121.85.4/28
             mac: '08:00:27:00:00:22'
@@ -160,7 +160,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.28
+          ip: 10.65.0.18
         transit:
           - ip: 10.121.85.5/28
             mac: '08:00:27:00:00:24'
@@ -186,7 +186,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.51
+          ip: 10.65.0.32
         transit:
           - ip: 10.121.86.3/28
             mac: '08:00:27:00:00:30'
@@ -211,7 +211,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.52
+          ip: 10.65.0.33
         transit:
           - ip: 10.121.86.4/28
             mac: '08:00:27:00:00:32'
@@ -237,7 +237,7 @@ nodes:
         asn: 4200858801
       interfaces:
         service:
-          ip: 10.65.0.53
+          ip: 10.65.0.34
         transit:
           - ip: 10.121.86.5/28
             mac: '08:00:27:00:00:34'


### PR DESCRIPTION
This PR addresses a few issues with AS #s in the `3h3w` and `3h6w` configuration. In addition, it also aligns the virtual build with the recent metal deployments. In particular, the following AS # deployment is proposed:

AS #                    Node Type
====                   ========
4200858601       Spine routers
420085870?       TOR routers (allocated in sequential pairs per virtual rack)
4200858801       Infrastructure nodes

So in a `3h3w` configuration, there are the following assignments:

AS #                    Nodename
====                   ========
4200858601       spine1, spine2
4200858701        tor1
4200858703        tor2
4200858705        tor3
4200858801        r1n0, r1n1, r1n2, r2n1, r2n2, r2n3, r3n1, r3n2, r3n3

The not yet allocated AS #s 4200858702, 4200858704, and 4200858706 are for the second TOR in each virtual rack (ECMP).

This was tested by creating both a `3h3w` and `3h6w` configurations and starting multiple instances, all of which were logged into via SSH.