### PR TITLE
added support for separate hypervisor domain

### DIFF
--- a/ansible/playbooks/roles/chef-node/tasks/chef-node.yml
+++ b/ansible/playbooks/roles/chef-node/tasks/chef-node.yml
@@ -107,6 +107,7 @@
   command: knife node show "{{ node_fqdn }}" --long --format json
   register: node_details_raw
   delegate_to: "{{ chef_server_host }}"
+  no_log: true
 
 - name: define node_details
   set_fact:
@@ -116,12 +117,14 @@
         from_json |
         update_chef_node_host_vars(hostvars[inventory_hostname])
       }}
+  no_log: true
 
 - name: write node_details to file
   copy:
     content: "{{ node_details | to_nice_json }}"
     dest: "{{ node_fqdn }}.json"
   delegate_to: "{{ chef_server_host }}"
+  no_log: true
 
 - name: import node changes
   command: knife node from file "{{ node_fqdn }}.json"

--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -35,6 +35,7 @@ ansible_ssh_common_args: >
 
 cloud_ip: 10.65.0.254
 cloud_domain: bcpc.example.com
+cloud_hypervisor_domain: "{{ cloud_domain }}"
 cloud_fqdn: "openstack.{{ cloud_domain }}"
 cloud_region: "{{ chef_environment['name'] }}"
 

--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -35,7 +35,7 @@ ansible_ssh_common_args: >
 
 cloud_ip: 10.65.0.254
 cloud_domain: bcpc.example.com
-cloud_hypervisor_domain: "{{ cloud_domain }}"
+cloud_infrastructure_domain: "{{ cloud_domain }}"
 cloud_fqdn: "openstack.{{ cloud_domain }}"
 cloud_region: "{{ chef_environment['name'] }}"
 

--- a/ansible/playbooks/roles/common/defaults/main/chef_node.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef_node.yml
@@ -1,3 +1,3 @@
 node_hostname: "{{ inventory_hostname }}"
-node_fqdn: "{{ inventory_hostname }}.{{ cloud_domain }}"
-node_runlist: "{{ hostvars[inventory_hostname].run_list | join (',') }}"
+node_fqdn: "{{ node_hostname }}.{{ cloud_hypervisor_domain }}"
+node_runlist: "{{ hostvars[node_hostname].run_list | join (',') }}"

--- a/ansible/playbooks/roles/common/defaults/main/chef_node.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef_node.yml
@@ -1,3 +1,3 @@
 node_hostname: "{{ inventory_hostname }}"
-node_fqdn: "{{ node_hostname }}.{{ cloud_hypervisor_domain }}"
+node_fqdn: "{{ node_hostname }}.{{ cloud_infrastructure_domain }}"
 node_runlist: "{{ hostvars[node_hostname].run_list | join (',') }}"

--- a/ansible/playbooks/roles/common/defaults/main/chef_server.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef_server.yml
@@ -10,6 +10,6 @@ chef_org_long_name: Bloomberg Clustered Private Cloud
 chef_org_validator_pem: /etc/chef/validator.pem
 chef_server_host: "{{ groups['bootstraps'][0] }}"
 chef_server_ip: "{{ hostvars[chef_server_host][service][ip] | ipaddr('address') }}"
-chef_server_fqdn: "{{ chef_server_host }}.{{ cloud_hypervisor_domain }}"
+chef_server_fqdn: "{{ chef_server_host }}.{{ cloud_infrastructure_domain }}"
 chef_server_url: "https://{{ chef_server_fqdn }}/organizations/{{ chef_org_short_name }}"
 chef_server_package: "{{ 'chef_server' | find_asset(all_file_assets) }}"

--- a/ansible/playbooks/roles/common/defaults/main/chef_server.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef_server.yml
@@ -10,6 +10,6 @@ chef_org_long_name: Bloomberg Clustered Private Cloud
 chef_org_validator_pem: /etc/chef/validator.pem
 chef_server_host: "{{ groups['bootstraps'][0] }}"
 chef_server_ip: "{{ hostvars[chef_server_host][service][ip] | ipaddr('address') }}"
-chef_server_fqdn: "{{ chef_server_host }}.{{ cloud_domain }}"
+chef_server_fqdn: "{{ chef_server_host }}.{{ cloud_hypervisor_domain }}"
 chef_server_url: "https://{{ chef_server_fqdn }}/organizations/{{ chef_org_short_name }}"
 chef_server_package: "{{ 'chef_server' | find_asset(all_file_assets) }}"

--- a/ansible/playbooks/roles/common/templates/etc/hosts.j2
+++ b/ansible/playbooks/roles/common/templates/etc/hosts.j2
@@ -12,13 +12,13 @@ ff02::1	ip6-allnodes
 ff02::2	ip6-allrouters
 
 # This is the FQDN of the cloud
-{{ cloud_ip }} {{cloud_fqdn}}
+{{ cloud_ip }} {{ cloud_fqdn }}
 
 # The following are all the hosts in the ansible cloud group
 {% for host in groups['cloud'] %}
 {% if host == chef_server_host %}
-{{ hostvars[host]['interfaces']['service']['ip'] }}	{{ host }}.{{cloud_domain}}	{{ host }}	bootstrap
+{{ hostvars[host]['interfaces']['service']['ip'] }}	{{ host }}.{{ cloud_hypervisor_domain }}	{{ host }}	bootstrap
 {% else %}
-{{ hostvars[host]['interfaces']['service']['ip'] }}	{{ host }}.{{cloud_domain}}	{{ host }}
+{{ hostvars[host]['interfaces']['service']['ip'] }}	{{ host }}.{{ cloud_hypervisor_domain }}	{{ host }}
 {% endif %}
 {% endfor %}

--- a/ansible/playbooks/roles/common/templates/etc/hosts.j2
+++ b/ansible/playbooks/roles/common/templates/etc/hosts.j2
@@ -17,8 +17,8 @@ ff02::2	ip6-allrouters
 # The following are all the hosts in the ansible cloud group
 {% for host in groups['cloud'] %}
 {% if host == chef_server_host %}
-{{ hostvars[host]['interfaces']['service']['ip'] }}	{{ host }}.{{ cloud_hypervisor_domain }}	{{ host }}	bootstrap
+{{ hostvars[host]['interfaces']['service']['ip'] }}	{{ host }}.{{ cloud_infrastructure_domain }}	{{ host }}	bootstrap
 {% else %}
-{{ hostvars[host]['interfaces']['service']['ip'] }}	{{ host }}.{{ cloud_hypervisor_domain }}	{{ host }}
+{{ hostvars[host]['interfaces']['service']['ip'] }}	{{ host }}.{{ cloud_infrastructure_domain }}	{{ host }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
  - ansible
    - added default variable: cloud_hypervisor_domain
      - used in chef_node fqdn and /etc/hosts building
    - added no_log to some overly verbose ansible tasks