### PR TITLE
Add missing variables for adhoc ansible commands

### DIFF
--- a/virtual/files/ansible/vars/virtual.yml
+++ b/virtual/files/ansible/vars/virtual.yml
@@ -2,9 +2,11 @@
 # virtual environment settings
 ###############################################################################
 
+root_dir: "{{ inventory_dir | dirname }}"
 virtual_dir: "{{ root_dir }}/virtual"
 virtual_ssh_dir: "{{ virtual_dir }}/files/ssh"
 ansible_ssh_private_key_file: "{{ virtual_ssh_dir }}/id_ed25519"
+ansible_ssh_user: operations
 operator_authorized_key: >
   {{ lookup('file', ansible_ssh_private_key_file + '.pub') }}
 ansible_ssh_common_args: >


### PR DESCRIPTION
Some vars are missing which are needed when running adhoc playbooks
and ansible commands