### PR TITLE
add openstack flavor toggle

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -28,6 +28,8 @@ chef_environment:
             - popcnt
             - sse4a
       ntp: "{{ ntp }}"
+      openstack-flavors:
+        enabled: true
       proxy: "{{ proxy }}"
 
 ###############################################################################

--- a/chef/cookbooks/bcpc/attributes/flavors.rb
+++ b/chef/cookbooks/bcpc/attributes/flavors.rb
@@ -1,0 +1,48 @@
+###############################################################################
+# openstack flavors
+###############################################################################
+
+default['bcpc']['openstack-flavors']['enabled'] = false
+
+default['bcpc']['openstack-flavors']['flavors']['generic1.tiny']['vcpus'] = 1
+default['bcpc']['openstack-flavors']['flavors']['generic1.tiny']['ram'] = 512
+default['bcpc']['openstack-flavors']['flavors']['generic1.tiny']['disk'] = 1
+
+default['bcpc']['openstack-flavors']['flavors']['generic1.small']['vcpus'] = 1
+default['bcpc']['openstack-flavors']['flavors']['generic1.small']['ram'] = 2048
+default['bcpc']['openstack-flavors']['flavors']['generic1.small']['disk'] = 20
+
+default['bcpc']['openstack-flavors']['flavors']['generic1.medium']['vcpus'] = 2
+default['bcpc']['openstack-flavors']['flavors']['generic1.medium']['ram'] = 4096
+default['bcpc']['openstack-flavors']['flavors']['generic1.medium']['disk'] = 40
+
+default['bcpc']['openstack-flavors']['flavors']['generic1.large']['vcpus'] = 4
+default['bcpc']['openstack-flavors']['flavors']['generic1.large']['ram'] = 8192
+default['bcpc']['openstack-flavors']['flavors']['generic1.large']['disk'] = 40
+
+default['bcpc']['openstack-flavors']['flavors']['generic1.xlarge']['vcpus'] = 8
+default['bcpc']['openstack-flavors']['flavors']['generic1.xlarge']['ram'] = 16384
+default['bcpc']['openstack-flavors']['flavors']['generic1.xlarge']['disk'] = 40
+
+default['bcpc']['openstack-flavors']['flavors']['generic1.2xlarge']['vcpus'] = 16
+default['bcpc']['openstack-flavors']['flavors']['generic1.2xlarge']['ram'] = 32768
+default['bcpc']['openstack-flavors']['flavors']['generic1.2xlarge']['disk'] = 40
+
+default['bcpc']['openstack-flavors']['flavors']['generic2.small']['vcpus'] = 1
+default['bcpc']['openstack-flavors']['flavors']['generic2.small']['ram'] = 6144
+default['bcpc']['openstack-flavors']['flavors']['generic2.small']['disk'] = 50
+
+default['bcpc']['openstack-flavors']['flavors']['generic2.medium']['vcpus'] = 2
+default['bcpc']['openstack-flavors']['flavors']['generic2.medium']['ram'] = 12288
+default['bcpc']['openstack-flavors']['flavors']['generic2.medium']['disk'] = 100
+
+default['bcpc']['openstack-flavors']['flavors']['generic2.large']['vcpus'] = 4
+default['bcpc']['openstack-flavors']['flavors']['generic2.large']['ram'] = 24576
+default['bcpc']['openstack-flavors']['flavors']['generic2.large']['disk'] = 100
+
+default['bcpc']['openstack-flavors']['flavors']['generic2.xlarge']['vcpus'] = 8
+default['bcpc']['openstack-flavors']['flavors']['generic2.xlarge']['ram'] = 49152
+default['bcpc']['openstack-flavors']['flavors']['generic2.xlarge']['disk'] = 100
+default['bcpc']['openstack-flavors']['flavors']['generic2.2xlarge']['vcpus'] = 16
+default['bcpc']['openstack-flavors']['flavors']['generic2.2xlarge']['ram'] = 98304
+default['bcpc']['openstack-flavors']['flavors']['generic2.2xlarge']['disk'] = 100

--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -82,51 +82,6 @@ default['bcpc']['nova']['scheduler_default_filters'] = %w(
   ServerGroupAffinityFilter
 )
 
-# flavors
-#
-default['bcpc']['nova']['flavors']['generic1.tiny']['vcpus'] = 1
-default['bcpc']['nova']['flavors']['generic1.tiny']['ram'] = 512
-default['bcpc']['nova']['flavors']['generic1.tiny']['disk'] = 1
-
-default['bcpc']['nova']['flavors']['generic1.small']['vcpus'] = 1
-default['bcpc']['nova']['flavors']['generic1.small']['ram'] = 2048
-default['bcpc']['nova']['flavors']['generic1.small']['disk'] = 20
-
-default['bcpc']['nova']['flavors']['generic1.medium']['vcpus'] = 2
-default['bcpc']['nova']['flavors']['generic1.medium']['ram'] = 4096
-default['bcpc']['nova']['flavors']['generic1.medium']['disk'] = 40
-
-default['bcpc']['nova']['flavors']['generic1.large']['vcpus'] = 4
-default['bcpc']['nova']['flavors']['generic1.large']['ram'] = 8192
-default['bcpc']['nova']['flavors']['generic1.large']['disk'] = 40
-
-default['bcpc']['nova']['flavors']['generic1.xlarge']['vcpus'] = 8
-default['bcpc']['nova']['flavors']['generic1.xlarge']['ram'] = 16384
-default['bcpc']['nova']['flavors']['generic1.xlarge']['disk'] = 40
-
-default['bcpc']['nova']['flavors']['generic1.2xlarge']['vcpus'] = 16
-default['bcpc']['nova']['flavors']['generic1.2xlarge']['ram'] = 32768
-default['bcpc']['nova']['flavors']['generic1.2xlarge']['disk'] = 40
-
-default['bcpc']['nova']['flavors']['generic2.small']['vcpus'] = 1
-default['bcpc']['nova']['flavors']['generic2.small']['ram'] = 6144
-default['bcpc']['nova']['flavors']['generic2.small']['disk'] = 50
-
-default['bcpc']['nova']['flavors']['generic2.medium']['vcpus'] = 2
-default['bcpc']['nova']['flavors']['generic2.medium']['ram'] = 12288
-default['bcpc']['nova']['flavors']['generic2.medium']['disk'] = 100
-
-default['bcpc']['nova']['flavors']['generic2.large']['vcpus'] = 4
-default['bcpc']['nova']['flavors']['generic2.large']['ram'] = 24576
-default['bcpc']['nova']['flavors']['generic2.large']['disk'] = 100
-
-default['bcpc']['nova']['flavors']['generic2.xlarge']['vcpus'] = 8
-default['bcpc']['nova']['flavors']['generic2.xlarge']['ram'] = 49152
-default['bcpc']['nova']['flavors']['generic2.xlarge']['disk'] = 100
-default['bcpc']['nova']['flavors']['generic2.2xlarge']['vcpus'] = 16
-default['bcpc']['nova']['flavors']['generic2.2xlarge']['ram'] = 98304
-default['bcpc']['nova']['flavors']['generic2.2xlarge']['disk'] = 100
-
 # default quota
 #
 default['bcpc']['nova']['quota']['default']['ram'] = -1

--- a/chef/cookbooks/bcpc/recipes/flavors.rb
+++ b/chef/cookbooks/bcpc/recipes/flavors.rb
@@ -14,7 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
+return unless node['bcpc']['openstack-flavors']['enabled']
 
 execute 'wait for flavors' do
   environment os_adminrc
@@ -22,7 +23,7 @@ execute 'wait for flavors' do
   command 'openstack flavor list'
 end
 
-node['bcpc']['nova']['flavors'].each do |flavor, spec|
+node['bcpc']['openstack-flavors']['flavors'].each do |flavor, spec|
   execute "create #{flavor} flavor" do
     environment os_adminrc
     command <<-DOC

--- a/chef/cookbooks/bcpc/recipes/flavors.rb
+++ b/chef/cookbooks/bcpc/recipes/flavors.rb
@@ -1,7 +1,7 @@
 # Cookbook Name:: bcpc
 # Recipe:: flavors
 #
-# Copyright 2018, Bloomberg Finance L.P.
+# Copyright 2019, Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
  - openstack flavors are now disabled by default in
    attributes/flavors.rb
  - flavors can be enabled by overriding default['bcpc']['openstack-flavors']['enabled']