### PR TITLE
ensure local zones are resolved by powerdns

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/unbound/server.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/unbound/server.conf.erb
@@ -2,10 +2,20 @@ server:
 <% @server.each do |k, v| %>
   <%= k %>: <%= v %>
 <% end %>
+<% @local_zones.each do |zone, nameservers| %>
+  local-zone: <%= zone %> transparent
+<% end %>
 <% @forward.each do |domain, nameservers| %>
   <% nameservers.each do |ns| %>
   forward-zone:
     name: <%= domain %>
+    forward-addr: <%= ns %>
+  <% end %>
+<% end %>
+<% @local_zones.each do |zone, nameservers| %>
+  <% nameservers.each do |ns| %>
+  forward-zone:
+    name: <%= zone %>
     forward-addr: <%= ns %>
   <% end %>
 <% end %>


### PR DESCRIPTION
before:

root@r1n1:~# host 10.1.1.1
Host 1.1.1.10.in-addr.arpa. not found: 3(NXDOMAIN)

after:

root@r1n1:~# host 10.1.1.1
1.1.1.10.in-addr.arpa domain name pointer ext1-float-10-1-1-1.bcpc.example.com.