### PR TITLE
powerdns webserver listening on the local interface only

### DIFF
--- a/chef/cookbooks/bcpc/attributes/powerdns.rb
+++ b/chef/cookbooks/bcpc/attributes/powerdns.rb
@@ -15,6 +15,7 @@ default['bcpc']['powerdns']['axfr']['ips'] = []
 default['bcpc']['powerdns']['receiver_threads'] = 3
 
 # webserver
+default['bcpc']['powerdns']['webserver']['address'] = '127.0.0.1'
 default['bcpc']['powerdns']['webserver']['port'] = 8081
 
 # name servers

--- a/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
@@ -64,7 +64,7 @@ webserver = yes
 
 # webserver-address    Address webserver to listen on
 #
-webserver-address = <%= node['service_ip'] %>
+webserver-address = <%= node['bcpc']['powerdns']['webserver']['address'] %>
 
 # webserver-port    Port of webserver to listen on
 #


### PR DESCRIPTION
`webserver-allow-from` defaults to 127.0.0.1 so this is currently the only
address worth listening on. Added a variable to allow this be configurable in
the future.