### PR TITLE
calico 3.6

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -160,8 +160,8 @@ assets_files:
     filename: etcd-v3.3.10-linux-amd64.tar.gz
 
   - name: calicoctl
-    url: https://github.com/projectcalico/calicoctl/releases/download/v3.4.0/calicoctl-linux-amd64
-    checksum: sha256:7017efab112a75ff7123ca0db62a52940e68bd6f1f2fe41ef08fe12dd4c89ca5
+    url: https://github.com/projectcalico/calicoctl/releases/download/v3.6.0/calicoctl-linux-amd64
+    checksum: sha256:b17659ca43f8812c6bea3fe30135c1d44857a756b13ed49c83895e74e2761359
     filename: calicoctl
 
   - name: consul

--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -3,11 +3,9 @@
 ###############################################################################
 
 # calico apt repository
-default['bcpc']['calico']['repo']['url'] = 'http://ppa.launchpad.net/project-calico/calico-3.4/ubuntu'
+default['bcpc']['calico']['repo']['url'] = 'http://ppa.launchpad.net/project-calico/calico-3.6/ubuntu'
 
 # calicoctl
 default['bcpc']['calico']['calicoctl']['remote']['file'] = 'calicoctl'
 default['bcpc']['calico']['calicoctl']['remote']['source'] = "#{default['bcpc']['file_server']['url']}/calicoctl"
-default['bcpc']['calico']['calicoctl']['remote']['checksum'] = '7017efab112a75ff7123ca0db62a52940e68bd6f1f2fe41ef08fe12dd4c89ca5'
-
-# calico-felix
+default['bcpc']['calico']['calicoctl']['remote']['checksum'] = 'b17659ca43f8812c6bea3fe30135c1d44857a756b13ed49c83895e74e2761359'

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -345,9 +345,11 @@ bash 'update admin default security group' do
       if ! openstack security group rule list ${sec_id} \
             --protocol icmp \
             --long -c Ethertype -f value | grep -q ${ethertype}; then
+
         openstack security group rule create ${sec_id} \
           --protocol icmp \
           --ethertype ${ethertype}
+
       fi
 
       # allow ssh, http and https

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -339,7 +339,7 @@ bash 'update admin default security group' do
 
     sec_groups=$(openstack security group list --project ${id} -f json)
     sec_id=$(echo ${sec_groups} | \
-      jq -r --arg id "${id}" '.[] | select(.Name == "Default") .ID')
+      jq -r --arg id "${id}" '.[] | select(.Name == "default") .ID')
 
     # allow icmp
     if ! openstack security group rule list ${sec_id} | grep -q icmp; then

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -338,8 +338,7 @@ bash 'update admin default security group' do
     id=$(openstack project show ${admin_project} -f value -c id)
 
     sec_groups=$(openstack security group list --project ${id} -f json)
-    sec_id=$(echo ${sec_groups} | \
-      jq -r --arg id "${id}" '.[] | select(.Name == "default") .ID')
+    sec_id=$(echo ${sec_groups} | jq -r '.[] | select(.Name == "default") .ID')
 
     # allow icmp
     if ! openstack security group rule list ${sec_id} | grep -q icmp; then

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -337,9 +337,9 @@ bash 'update admin default security group' do
     admin_project=#{node['bcpc']['openstack']['admin']['project']}
     id=$(openstack project show ${admin_project} -f value -c id)
 
-    sec_groups=$(openstack security group list -f json)
+    sec_groups=$(openstack security group list --project ${id} -f json)
     sec_id=$(echo ${sec_groups} | \
-      jq -r --arg id "${id}" '.[] | select(.Project == $id) .ID')
+      jq -r --arg id "${id}" '.[] | select(.Name == "Default") .ID')
 
     # allow icmp
     if ! openstack security group rule list ${sec_id} | grep -q icmp; then

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -329,26 +329,30 @@ node['bcpc']['neutron']['networks'].each do |network|
 end
 # create networks ends
 
-bash 'update cloud/admin default security group to allow ping and ssh' do
+bash 'update admin default security group' do
   environment os_adminrc
 
   code <<-DOC
     # the default security group for the cloud has no project id
-    cloud_project_id=''
     admin_project=#{node['bcpc']['openstack']['admin']['project']}
-    admin_project_id=$(openstack project show ${admin_project} -f value -c id)
+    id=$(openstack project show ${admin_project} -f value -c id)
 
-    for id in ${cloud_project_id} ${admin_project_id}; do
-      sec_groups=$(openstack security group list -f json)
-      group_id=$(echo ${sec_groups} | jq -r --arg id "${id}" '.[] | select(.Project == $id) .ID')
+    sec_groups=$(openstack security group list -f json)
+    sec_id=$(echo ${sec_groups} | \
+      jq -r --arg id "${id}" '.[] | select(.Project == $id) .ID')
 
-      if ! openstack security group rule list $group_id | grep icmp; then
-        openstack security group rule create --protocol icmp $group_id
-      fi
+    # allow icmp
+    if ! openstack security group rule list ${sec_id} | grep -q icmp; then
+      openstack security group rule create ${sec_id} --protocol icmp
+    fi
 
-      if ! openstack security group rule list --protocol tcp $group_id | grep '22:22'; then
-        openstack security group rule create $group_id \
-          --protocol tcp --dst-port 22:22 --remote-ip 0.0.0.0/0
+    # allow ssh, http and https
+    for port_range in 22:22 80:80 443:443; do
+      if ! openstack security group rule list ${sec_id} --protocol tcp \
+            -c "Port Range" -f value | grep -q "${port_range}"; then
+
+        openstack security group rule create ${sec_id} \
+          --protocol tcp --dst-port ${port_range} --remote-ip 0.0.0.0/0
       fi
     done
   DOC


### PR DESCRIPTION
  - updated calico to 3.6
  - updated calicoctl to 3.6
  - updated admin default security group to include ssh, http and https