### PR TITLE
remove extra commas from usernames

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -104,10 +104,10 @@ chef_databags:
     cinder:
       creds:
         db:
-          username: cinder,
+          username: cinder
           password: 3Dhip8IKy_95O9LwOkpa
         os:
-          username: cinder,
+          username: cinder
           password: 3Dhip8IKy_95O9LwOkpa
     horizon:
       secret: XWmecfpS5wS7SMqi4un3
@@ -119,7 +119,7 @@ chef_databags:
           username: neutron
           password: 3Dhip8IKy_95O9LwOkpa
         os:
-          username: neutron,
+          username: neutron
           password: 3Dhip8IKy_95O9LwOkpa
     nova:
       creds:


### PR DESCRIPTION
This fixes the usernames with cinder, and neutron, below:

```
root@r1n1:~# openstack user list
+----------------------------------+-----------+
| ID                               | Name      |
+----------------------------------+-----------+
| 2500ff03456d458b8e5f0008e86dfafe | neutron,  |
| 2f3188c2ca244c17ace4973d8a669b7c | cinder,   |
| 30692440f98c4c22b2726252431b39fb | nova      |
| 94d8b07fe2c2492cba93d4a70c0effab | admin     |
| a2fb6fb343114883be9ee6bbf535a6fa | placement |
| b02669ed6f9142508f98446195aa6358 | glance    |
+----------------------------------+-----------+
```