### PR TITLE
fix case when multiple forward addresses are in use

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/unbound/server.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/unbound/server.conf.erb
@@ -6,9 +6,9 @@ server:
   local-zone: <%= zone %> transparent
 <% end %>
 <% @forward.each do |domain, nameservers| %>
-  <% nameservers.each do |ns| %>
   forward-zone:
     name: <%= domain %>
+  <% nameservers.each do |ns| %>
     forward-addr: <%= ns %>
   <% end %>
 <% end %>


### PR DESCRIPTION
This avoids error messages such as the following:

May 06 23:51:00 r1n1 systemd[1]: Started Unbound DNS server.
May 06 23:51:00 r1n1 unbound[65991]: [65991:0] info: start of service (unbound 1.6.7).
May 06 23:51:00 r1n1 unbound[65991]: [65991:1] error: duplicate forward zone . ignored.