### PR TITLE
fix dns domain on vms to match v7 behaviour

### DIFF
--- a/chef/cookbooks/bcpc/recipes/calico-work.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-work.rb
@@ -68,3 +68,11 @@ template '/etc/neutron/neutron.conf' do
   group 'neutron'
   notifies :restart, 'service[calico-dhcp-agent]', :immediately
 end
+
+template '/etc/neutron/plugins/ml2/ml2_ini.conf' do
+  source 'neutron/neutron.ml2_conf.ini.erb'
+  mode '644'
+  owner 'root'
+  group 'neutron'
+  notifies :restart, 'service[calico-dhcp-agent]', :immediately
+end

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -166,6 +166,7 @@ execute 'create neutron database' do
 
   notifies :delete, 'file[/tmp/neutron-db.sql]', :immediately
   notifies :create, 'template[/etc/neutron/neutron.conf]', :immediately
+  notifies :create, 'template[/etc/neutron/plugins/ml2/ml2_conf.ini]', :immediately
   notifies :run, 'execute[neutron-db-manage upgrade heads]', :immediately
 end
 
@@ -186,6 +187,11 @@ template '/etc/neutron/neutron.conf' do
     config: config,
     headnodes: headnodes(all: true)
   )
+  notifies :restart, 'service[neutron-server]', :immediately
+end
+
+template '/etc/neutron/plugins/ml2/ml2_conf.ini' do
+  source 'neutron/neutron.ml2_conf.ini.erb'
   notifies :restart, 'service[neutron-server]', :immediately
 end
 #

--- a/chef/cookbooks/bcpc/templates/default/calico/neutron.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/neutron.conf.erb
@@ -1,6 +1,7 @@
 [DEFAULT]
 core_plugin = calico
 state_path = /var/lib/neutron
+dns_domain = <%= node['bcpc']['cloud']['domain'] %>
 
 [calico]
 etcd_host = 127.0.0.1

--- a/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
@@ -8,6 +8,7 @@ state_path = /var/lib/neutron
 <% unless node['bcpc']['openstack']['services']['workers'].nil? %>
 api_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% end %>
+dns_domain = <%= node['bcpc']['cloud']['domain'] %>
 
 [calico]
 etcd_host = 127.0.0.1

--- a/chef/cookbooks/bcpc/templates/default/neutron/neutron.ml2_conf.ini.erb
+++ b/chef/cookbooks/bcpc/templates/default/neutron/neutron.ml2_conf.ini.erb
@@ -8,114 +8,20 @@
 # (ListOpt) List of network type driver entrypoints to be loaded from
 # the neutron.ml2.type_drivers namespace.
 #
-# type_drivers = local,flat,vlan,gre,vxlan
-# Example: type_drivers = flat,vlan,gre,vxlan
-
 type_drivers = local,flat
 
 # (ListOpt) Ordered list of network_types to allocate as tenant
 # networks. The default value 'local' is useful for single-box testing
 # but provides no connectivity between hosts.
 #
-# tenant_network_types = local
-# Example: tenant_network_types = vlan,gre,vxlan
-
-tenant_network_types = local,flat
+tenant_network_types = local
 
 # (ListOpt) Ordered list of networking mechanism driver entrypoints
 # to be loaded from the neutron.ml2.mechanism_drivers namespace.
-# mechanism_drivers =
-# Example: mechanism_drivers = openvswitch,mlnx
-# Example: mechanism_drivers = arista
-# Example: mechanism_drivers = cisco,logger
-# Example: mechanism_drivers = openvswitch,brocade
-# Example: mechanism_drivers = linuxbridge,brocade
-
+#
 mechanism_drivers = calico
 
 # (ListOpt) Ordered list of extension driver entrypoints
 # to be loaded from the neutron.ml2.extension_drivers namespace.
-# extension_drivers =
-# Example: extension_drivers = anewextensiondriver
-
-# =========== items for MTU selection and advertisement =============
-# (IntOpt) Path MTU.  The maximum permissible size of an unfragmented
-# packet travelling from and to addresses where encapsulated Neutron
-# traffic is sent.  Drivers calculate maximum viable MTU for
-# validating tenant requests based on this value (typically,
-# path_mtu - max encap header size).  If <=0, the path MTU is
-# indeterminate and no calculation takes place.
-# path_mtu = 0
-
-# (IntOpt) Segment MTU.  The maximum permissible size of an
-# unfragmented packet travelling a L2 network segment.  If <=0,
-# the segment MTU is indeterminate and no calculation takes place.
-# segment_mtu = 0
-
-# (ListOpt) Physical network MTUs.  List of mappings of physical
-# network to MTU value.  The format of the mapping is
-# <physnet>:<mtu val>.  This mapping allows specifying a
-# physical network MTU value that differs from the default
-# segment_mtu value.
-# physical_network_mtus =
-# Example: physical_network_mtus = physnet1:1550, physnet2:1500
-# ======== end of items for MTU selection and advertisement =========
-
-[ml2_type_flat]
-# (ListOpt) List of physical_network names with which flat networks
-# can be created. Use * to allow flat networks with arbitrary
-# physical_network names.
 #
-# flat_networks =
-# Example:flat_networks = physnet1,physnet2
-# Example:flat_networks = *
-flat_networks = ext-net1
-
-[ml2_type_vlan]
-# (ListOpt) List of <physical_network>[:<vlan_min>:<vlan_max>] tuples
-# specifying physical_network names usable for VLAN provider and
-# tenant networks, as well as ranges of VLAN tags on each
-# physical_network available for allocation as tenant networks.
-#
-# network_vlan_ranges =
-# Example: network_vlan_ranges = physnet1:1000:2999,physnet2
-network_vlan_ranges = int-net1:1000:1400
-
-[ml2_type_gre]
-# (ListOpt) Comma-separated list of <tun_min>:<tun_max> tuples enumerating ranges of GRE tunnel IDs that are available for tenant network allocation
-tunnel_id_ranges = 1:10000
-
-[ml2_type_vxlan]
-# (ListOpt) Comma-separated list of <vni_min>:<vni_max> tuples enumerating
-# ranges of VXLAN VNI IDs that are available for tenant network allocation.
-#
-# vni_ranges =
-vni_ranges = 1:10000
-
-# (StrOpt) Multicast group for the VXLAN interface. When configured, will
-# enable sending all broadcast traffic to this multicast group. When left
-# unconfigured, will disable multicast VXLAN mode.
-#
-# vxlan_group =
-# Example: vxlan_group = 239.1.1.1
-vxlan_group = 239.1.1.1
-
-[securitygroup]
-firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
-
-# Controls if neutron security group is enabled or not.
-# It should be false when you use nova security group.
-enable_security_group = True
-
-# Use ipset to speed-up the iptables security groups. Enabling ipset support
-# requires that ipset is installed on L2 agent node.
-enable_ipset = True
-
-[linux_bridge]
-# cannot bind multiple networks to the same physical adapter
-physical_interface_mappings = int-net1:eth4,ext-net1:eth3
-
-[vxlan]
-enable_vxlan = True
-local_ip = <%= node['bcpc']['floating']['ip'] %>
-l2_population = True
+extension_drivers = dns

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -43,6 +43,7 @@ metadata_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% if not node['bcpc']['nova']['default_log_levels'].nil? %>
 default_log_levels = "<%= node['bcpc']['nova']['default_log_levels'] %>"
 <% end %>
+dhcp_domain = <%= node['bcpc']['cloud']['domain'] %>
 
 [api]
 auth_strategy = keystone


### PR DESCRIPTION
In v7, the dns domain defaults to the cluster domain name. e.g. ip-10.10.10.10.cluster.example.com
In v7, the dhcp dns search domain defaults to the cluster name. e.g. cluster.example.com
In v8, the dns domain defaults to novalocal. e.g. myhostname.novalocal
In v8, the dhcp dns search domain defaults to openstacklocal. This causes
delays in DNS lookups to external servers as the wrong domain is used.

This commit fixes the behaviour to match the v7 behaviour for both dhcp dns
search domain and dns domain.

Coupled with a suitable cloud-init fragment for setting the hostname, this
commit allows the external vm dns entry to match the internal vm fqdn.