### PR TITLE
remove unneeded dns extension driver that breaks floats

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/neutron/neutron.ml2_conf.ini.erb
+++ b/chef/cookbooks/bcpc/templates/default/neutron/neutron.ml2_conf.ini.erb
@@ -18,8 +18,3 @@ tenant_network_types = local
 # to be loaded from the neutron.ml2.mechanism_drivers namespace.
 #
 mechanism_drivers = calico
-
-# (ListOpt) Ordered list of extension driver entrypoints
-# to be loaded from the neutron.ml2.extension_drivers namespace.
-#
-# extension_drivers = dns


### PR DESCRIPTION
Removing the above fixes the following error:

2019-05-23 15:22:18.507 860995 ERROR neutron.api.v2.resource     return f(*dup_args, **dup_kwargs)
2019-05-23 15:22:18.507 860995 ERROR neutron.api.v2.resource   File "/usr/lib/python2.7/dist-packages/neutron/db/l3_db.py", line 1406, in create_floatingip
2019-05-23 15:22:18.507 860995 ERROR neutron.api.v2.resource     return self._create_floatingip(context, floatingip, initial_status)
2019-05-23 15:22:18.507 860995 ERROR neutron.api.v2.resource   File "/usr/lib/python2.7/dist-packages/neutron/db/l3_db.py", line 1373, in _create_floatingip
2019-05-23 15:22:18.507 860995 ERROR neutron.api.v2.resource     dns_data = self._process_dns_floatingip_create_precommit(
2019-05-23 15:22:18.507 860995 ERROR neutron.api.v2.resource AttributeError: 'CalicoPlugin' object has no attribute '_process_dns_floatingip_create_precommit'
2019-05-23 15:22:18.507 860995 ERROR neutron.api.v2.resource