### PR TITLE
disable and stop glance-registry

### DIFF
--- a/chef/cookbooks/bcpc/recipes/glance.rb
+++ b/chef/cookbooks/bcpc/recipes/glance.rb
@@ -230,6 +230,10 @@ end
 #
 # install and configure components ends
 
+service 'glance-registry' do
+  action [:disable, :stop]
+end
+
 execute 'wait for glance to come online' do
   environment os_adminrc
   retries 15


### PR DESCRIPTION
glance registry is no longer used so does not need to be running