### PR TITLE
Expose Unbound's `unblock-lan-zones` option to the configuration.

### DIFF
--- a/chef/cookbooks/bcpc/attributes/unbound.rb
+++ b/chef/cookbooks/bcpc/attributes/unbound.rb
@@ -12,14 +12,15 @@ default['bcpc']['unbound']['server']['access-control'] = '0.0.0.0/0 allow'
 default['bcpc']['unbound']['server']['chroot'] = '""'
 default['bcpc']['unbound']['server']['directory'] = '/etc/unbound'
 default['bcpc']['unbound']['server']['do-ip4'] = 'yes'
-default['bcpc']['unbound']['server']['do-udp'] = 'yes'
 default['bcpc']['unbound']['server']['do-tcp'] = 'yes'
+default['bcpc']['unbound']['server']['do-udp'] = 'yes'
 default['bcpc']['unbound']['server']['domain-insecure'] = '*'
 default['bcpc']['unbound']['server']['interface'] = vip
 default['bcpc']['unbound']['server']['logfile'] = '""'
 default['bcpc']['unbound']['server']['num-threads'] = 2
 default['bcpc']['unbound']['server']['pidfile'] = '/var/run/unbound.pid'
 default['bcpc']['unbound']['server']['port'] = 53
+default['bcpc']['unbound']['server']['unblock-lan-zones'] = 'no'
 default['bcpc']['unbound']['server']['use-syslog'] = 'yes'
 default['bcpc']['unbound']['server']['verbosity'] = 1
 


### PR DESCRIPTION
Tested setting this to `yes` in a `bve` test environment.