### PR TITLE
adjusted etcd ssl cert permissions

### DIFF
--- a/chef/cookbooks/bcpc/attributes/etcd.rb
+++ b/chef/cookbooks/bcpc/attributes/etcd.rb
@@ -7,8 +7,9 @@ default['bcpc']['etcd']['remote']['file'] = etcd_file
 default['bcpc']['etcd']['remote']['source'] = "#{default['bcpc']['file_server']['url']}/#{etcd_file}"
 default['bcpc']['etcd']['remote']['checksum'] = '1620a59150ec0a0124a65540e23891243feb2d9a628092fb1edcc23974724a45'
 
-default['bcpc']['etcd']['ca']['crt']['filepath'] = '/etc/etcd/ssl/ca.pem'
-default['bcpc']['etcd']['client']['crt']['filepath'] = '/etc/etcd/ssl/client.pem'
-default['bcpc']['etcd']['client']['key']['filepath'] = '/etc/etcd/ssl/client-key.pem'
-default['bcpc']['etcd']['server']['crt']['filepath'] = '/etc/etcd/ssl/server.pem'
-default['bcpc']['etcd']['server']['key']['filepath'] = '/etc/etcd/ssl/server-key.pem'
+default['bcpc']['etcd']['ssl']['dir'] = '/etc/etcd/ssl'
+default['bcpc']['etcd']['ca']['crt']['filepath'] = "#{default['bcpc']['etcd']['ssl']['dir']}/ca.pem"
+default['bcpc']['etcd']['client']['crt']['filepath'] = "#{default['bcpc']['etcd']['ssl']['dir']}/client.pem"
+default['bcpc']['etcd']['client']['key']['filepath'] = "#{default['bcpc']['etcd']['ssl']['dir']}/client-key.pem"
+default['bcpc']['etcd']['server']['crt']['filepath'] = "#{default['bcpc']['etcd']['ssl']['dir']}/server.pem"
+default['bcpc']['etcd']['server']['key']['filepath'] = "#{default['bcpc']['etcd']['ssl']['dir']}/server-key.pem"

--- a/chef/cookbooks/bcpc/recipes/etcd-ssl.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd-ssl.rb
@@ -18,14 +18,24 @@
 region = node['bcpc']['cloud']['region']
 config = data_bag_item(region, 'config')
 
-directory '/etc/etcd/ssl' do
+group 'etcd' do
+  action :create
+end
+
+directory node['bcpc']['etcd']['ssl']['dir'] do
   action :create
   recursive true
+  mode '0750'
+  owner 'root'
+  group 'etcd'
 end
 
 # ca certificate
 file node['bcpc']['etcd']['ca']['crt']['filepath'] do
   content Base64.decode64(config['etcd']['ssl']['ca']['crt'])
+  mode '0640'
+  owner 'root'
+  group 'etcd'
 end
 
 # server and client key/certificate
@@ -33,6 +43,9 @@ end
   %w(crt key).each do |pem|
     file node['bcpc']['etcd'][type][pem]['filepath'] do
       content Base64.decode64(config['etcd']['ssl'][type][pem])
+      mode '0640'
+      owner 'root'
+      group 'etcd'
     end
   end
 end

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -138,6 +138,13 @@ end
 #
 # neutron package installation and service definition ends
 
+# add neutron to etcd so that it will be able to read the etcd ssl certs
+group 'etcd' do
+  action :modify
+  members 'neutron'
+  append true
+end
+
 # create/manage neutron database starts
 #
 file '/tmp/neutron-db.sql' do


### PR DESCRIPTION
  - etcd ssl certs are now owned by root:etcd with a mode of 0640
  - neutron has been added to the 'etcd' group to allow cert loading
