### PR TITLE
enable heat by default

### DIFF
--- a/chef/cookbooks/bcpc/attributes/heat.rb
+++ b/chef/cookbooks/bcpc/attributes/heat.rb
@@ -2,7 +2,7 @@
 # heat
 ###############################################################################
 
-default['bcpc']['heat']['enabled'] = false
+default['bcpc']['heat']['enabled'] = true
 
 # database
 default['bcpc']['heat']['db']['dbname'] = 'heat'


### PR DESCRIPTION
Specific installations can still disable the feature using the toggle. This way the code gets build coverage and is not as liable to suffer code rot.