### PR TITLE
Some upstream `chef-bcpc` cleanup

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -53,9 +53,9 @@ chef_databags:
         osd:
           key: AQBNiBlb4tnNMxAAJRMAVzczIADaHD7CDEw9Hg==
         rgw:
-          key: AQBNiBlb4tnNMxAAJRMAVzczIADaHD7CDEw9Hg==
+          key: AQBLfRtdWPC3FhAA8uMHA69x7dbKIMuYsMHHXw==
         rbd:
-          key: AQBNiBlb4tnNMxAAJRMAVzczIADaHD7CDEw9Hg==
+          key: AQBQfRtdEhH7BRAAmCVkTxnTqdm/k4dadzK7lA==
       client:
         admin:
           key: AQBMiBlbzzxcBhAAd2HrPAGJoMHhCH6pF3aNkA==
@@ -64,7 +64,7 @@ chef_databags:
         glance:
           key: AQDKpyJbV9CYIRAA6aDb1mQb/Q+0hLmezA5iOQ==
         nova:
-          key: AQDKpyJbV9CYIRAA6aDb1mQb/Q+0hLmezA5iOQ==
+          key: AQBRfRtdLrfAFhAA48geldH/5rBKiBg/5mkoXQ==
     etcd:
       ssl:
         ca:
@@ -79,11 +79,11 @@ chef_databags:
       creds:
         db:
           username: pdns
-          password: DUBSOwwBeqPj
+          password: s0fB4IV1cJGoVJcq0M6j
         webserver:
-          password: DUBSOwwBeqPj
+          password: c9KBy2dnry6KHxqKrjOx
         api:
-          key: DUBSOwwBeqPj
+          key: aFlXzmZKhmGIUzINRKpW
     keystone:
       db:
         username: keystone
@@ -100,23 +100,23 @@ chef_databags:
           password: 3Dhip8IKy_95O9LwOkpa
         os:
           username: glance
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: imQo35BowPbPx46OkYdR
     cinder:
       creds:
         db:
           username: cinder
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: R8H8IhmTOZr2yMCFYc7G
         os:
           username: cinder
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: EElHi6Zmasnx0MWno92N
     heat:
       creds:
         db:
           username: heat
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: dRnysxpuoQxINtSJASKw
         os:
           username: heat
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: qEEIxT47kXzYJaxEnQJw
     horizon:
       secret: XWmecfpS5wS7SMqi4un3
     libvirt:
@@ -125,18 +125,18 @@ chef_databags:
       creds:
         db:
           username: neutron
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: vobFVWV6ncl00RYHEUM3
         os:
           username: neutron
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: hIoEog8jsvVmFkfLn0Dj
     nova:
       creds:
         db:
           username: nova
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: j16SvTX95cqg5XjPxTLI
         os:
           username: nova
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: qHa04uIc1NnkBL9x3YZR
       ssh:
         crt: c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUhBRjhJYVJiRCtpT0tQR0ZQclpHcGQvSnQ1MEh0SWwyZzRPbGZTcWF5dHAK
         key: LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUFNd0FBQUF0emMyZ3RaVwpReU5UVXhPUUFBQUNCd0JmQ0drV3cvb2ppanhoVDYyUnFYZnliZWRCN1NKZG9PRHBYMHFtc3JhUUFBQUlnbGRDV2pKWFFsCm93QUFBQXR6YzJndFpXUXlOVFV4T1FBQUFDQndCZkNHa1d3L29qaWp4aFQ2MlJxWGZ5YmVkQjdTSmRvT0RwWDBxbXNyYVEKQUFBRUJBYmNzRnVIRkpDKzk5c25xZXhSbTRrSWMzRy93K2M3Y1RGZ3FHaURoeVNIQUY4SWFSYkQraU9LUEdGUHJaR3BkLwpKdDUwSHRJbDJnNE9sZlNxYXl0cEFBQUFBQUVDQXdRRgotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K  # noqa 204
@@ -144,7 +144,7 @@ chef_databags:
       creds:
         os:
           username: placement
-          password: 3Dhip8IKy_95O9LwOkpa
+          password: vB2h9aRbSzB8iqtrQsgt
     mysql:
       users:
         sst:

--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -10,9 +10,9 @@ end
 def setup_proxy(node)
   http_proxy  = ENV['http_proxy']  || ''
   https_proxy = ENV['https_proxy'] || ''
-  if http_proxy != ''
-    node.vm.provision 'shell', path: 'proxyconfig.sh', args: [http_proxy, https_proxy]
-  end
+  return unless http_proxy != ''
+  node.vm.provision 'shell', path: 'proxyconfig.sh',
+                             args: [http_proxy, https_proxy]
 end
 
 Vagrant.configure(2) do |config|
@@ -28,9 +28,12 @@ Vagrant.configure(2) do |config|
       node.vm.box_download_insecure = true
       cache_dir = local_cache(node.vm.box)
       node.vm.synced_folder cache_dir, '/var/cache/apt/archives', create: true
-      node.vm.network 'private_network', virtualbox__intnet: 'management1', auto_config: false
-      node.vm.network 'private_network', virtualbox__intnet: 'management2', auto_config: false
-      node.vm.network 'private_network', virtualbox__intnet: 'management3', auto_config: false
+      node.vm.network 'private_network', virtualbox__intnet: 'management1',
+                                         auto_config: false
+      node.vm.network 'private_network', virtualbox__intnet: 'management2',
+                                         auto_config: false
+      node.vm.network 'private_network', virtualbox__intnet: 'management3',
+                                         auto_config: false
       setup_proxy(node)
       node.vm.provision 'shell', path: 'provisioner.sh', args: 'network'
     end
@@ -48,11 +51,16 @@ Vagrant.configure(2) do |config|
         node.vm.box_download_insecure = true
         cache_dir = local_cache(node.vm.box)
         node.vm.synced_folder cache_dir, '/var/cache/apt/archives', create: true
-        node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_spine1", auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_spine2", auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_hv", auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "management#{i}", auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "storage#{i}", auto_config: false
+        node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_spine1",
+                                           auto_config: false
+        node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_spine2",
+                                           auto_config: false
+        node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_hv",
+                                           auto_config: false
+        node.vm.network 'private_network', virtualbox__intnet: "management#{i}",
+                                           auto_config: false
+        node.vm.network 'private_network', virtualbox__intnet: "storage#{i}",
+                                           auto_config: false
         setup_proxy(node)
         node.vm.provision 'shell', path: 'provisioner.sh', args: "tor#{i}"
         node.vm.hostname = "tor#{i}"
@@ -70,9 +78,12 @@ Vagrant.configure(2) do |config|
         cache_dir = local_cache(node.vm.box)
         node.vm.synced_folder cache_dir, '/var/cache/apt/archives', create: true
         node.vm.box_download_insecure = true
-        node.vm.network 'private_network', virtualbox__intnet: "tor1_spine#{i}", auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "tor2_spine#{i}", auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "tor3_spine#{i}", auto_config: false
+        node.vm.network 'private_network', virtualbox__intnet: "tor1_spine#{i}",
+                                           auto_config: false
+        node.vm.network 'private_network', virtualbox__intnet: "tor2_spine#{i}",
+                                           auto_config: false
+        node.vm.network 'private_network', virtualbox__intnet: "tor3_spine#{i}",
+                                           auto_config: false
         setup_proxy(node)
         node.vm.provision 'shell', path: 'provisioner.sh', args: "spine#{i}"
         node.vm.hostname = "spine#{i}"


### PR DESCRIPTION
These changes were tested with a full `upsteam` build. Obviously the latter's data bag overrides the upstream values but I did verify all the upstream ones are unique.
