### PR TITLE
refactored mysql and etcd service installation/configuration

### DIFF
--- a/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
@@ -51,5 +51,5 @@ end
 execute 'wait for etcd membership' do
   environment etcdctl_env
   retries 5
-  command "etcdctl member list"
+  command 'etcdctl member list'
 end

--- a/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
@@ -18,31 +18,38 @@
 include_recipe 'bcpc::etcd-packages'
 include_recipe 'bcpc::etcd-ssl'
 
+service 'etcd'
+
 headnodes = headnodes(all: true)
 
 etcd_endpoints = headnodes.collect do |headnode|
   "https://#{headnode['service_ip']}:2379"
 end
 
-systemd_unit 'etcd.service' do
-  action %i(create enable restart)
-  content <<-DOC.gsub(/^\s+/, '')
-    [Unit]
-    Description=etcd
-    Documentation=https://github.com/coreos/etcd
+template '/etc/systemd/system/etcd.service' do
+  source 'etcd-proxy/etcd.service.erb'
+  variables(
+    etcd_endpoints: etcd_endpoints
+  )
 
-    [Service]
-    Type=notify
-    Restart=always
-    RestartSec=5s
-    LimitNOFILE=40000
-    TimeoutStartSec=0
+  notifies :run, 'execute[enable etcd service]', :immediately
+  notifies :run, 'execute[reload systemd]', :immediately
+  notifies :restart, 'service[etcd]', :immediately
+end
 
-    ExecStart=/usr/local/bin/etcd gateway start \\
-      --endpoints=#{etcd_endpoints.join(',')} \\
-      --listen-addr=127.0.0.1:2379
+execute 'enable etcd service' do
+  action :nothing
+  command 'systemctl enable etcd.service'
+  not_if 'systemctl is-enabled etcd.service'
+end
 
-    [Install]
-    WantedBy=multi-user.target
-  DOC
+execute 'reload systemd' do
+  action :nothing
+  command 'systemctl daemon-reload'
+end
+
+execute 'wait for etcd membership' do
+  environment etcdctl_env
+  retries 5
+  command "etcdctl member list"
 end

--- a/chef/cookbooks/bcpc/templates/default/etcd-proxy/etcd.service.erb
+++ b/chef/cookbooks/bcpc/templates/default/etcd-proxy/etcd.service.erb
@@ -1,0 +1,17 @@
+[Unit]
+Description=etcd
+Documentation=https://github.com/coreos/etcd
+
+[Service]
+Type=notify
+Restart=always
+RestartSec=5s
+LimitNOFILE=40000
+TimeoutStartSec=0
+
+ExecStart=/usr/local/bin/etcd gateway start \
+  --endpoints=<%= @etcd_endpoints.join(',') %> \
+  --listen-addr=127.0.0.1:2379
+
+[Install]
+WantedBy=multi-user.target

--- a/chef/cookbooks/bcpc/templates/default/etcd/etcd.service.erb
+++ b/chef/cookbooks/bcpc/templates/default/etcd/etcd.service.erb
@@ -1,0 +1,33 @@
+[Unit]
+Description=etcd - highly-available key value store
+Documentation=https://github.com/coreos/etcd
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+Environment=data_dir=/var/lib/etcd
+ExecStartPre=/bin/mkdir -p ${data_dir}
+Restart=always
+RestartSec=5s
+LimitNOFILE=40000
+TimeoutStartSec=0
+
+ExecStart=/usr/local/bin/etcd \
+    --name=<%= node['fqdn'] %> \
+    --data-dir=${data_dir} \
+    --client-cert-auth \
+    --peer-auto-tls \
+    --trusted-ca-file=<%= node['bcpc']['etcd']['ca']['crt']['filepath'] %> \
+    --cert-file=<%= node['bcpc']['etcd']['server']['crt']['filepath'] %> \
+    --key-file=<%= node['bcpc']['etcd']['server']['key']['filepath'] %> \
+    --advertise-client-urls=https://<%= node['service_ip'] %>:2379 \
+    --listen-client-urls=https://<%= node['service_ip'] %>:2379,https://127.0.0.1:2379 \
+    --listen-peer-urls=https://<%= node['service_ip'] %>:2380 \
+    --initial-advertise-peer-urls=https://<%= node['service_ip'] %>:2380 \
+    --initial-cluster-token=<%= node['bcpc']['cloud']['region'] %>-etcd-cluster-01 \
+    --initial-cluster=<%= @initial_cluster %> \
+    --initial-cluster-state=<%= @initial_cluster_state %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- mysql
  - updated mysql recipe guard to use a state file vs. mysql query when running mysql-init-db.sql
- etcd
  - updated etcd recipe guard to use a state file when joining an existing etcd cluster
  - replaced 'systemd_unit' resource with traditional template and notifications
- etcd-proxy
  - replaced 'systemd_unit' resource with traditional template and notifications

