### PR TITLE
wait for heat api before restarting apache for heat-api-cfn

### DIFF
--- a/chef/cookbooks/bcpc/recipes/heat.rb
+++ b/chef/cookbooks/bcpc/recipes/heat.rb
@@ -261,6 +261,12 @@ template '/etc/apache2/sites-available/heat-api.conf' do
   notifies :restart, 'service[heat-api-apache2]', :immediately
 end
 
+execute 'wait for heat api to become available' do
+  environment os_adminrc
+  retries 15
+  command 'openstack stack list'
+end
+
 # configure heat-api-cfn service
 template '/etc/apache2/sites-available/heat-api-cfn.conf' do
   source 'heat/heat-api-cfn.conf.erb'


### PR DESCRIPTION
Sometimes the heat-api service (apache) has not fully restarted when we try to restart the heat-api-cfn service (which is also apache). We wait for apache to be available before proceeding. This does not happen every time, but happens sporadically.