### PR TITLE
virtual: Fix multibox configuration node assignment

### DIFF
--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure(2) do |config|
     # Create 3 TORs
     (1..3).each do |i|
       config.vm.define "tor#{i}" do |node|
-        config.vm.provider 'virtualbox' do |vb|
+        node.vm.provider 'virtualbox' do |vb|
           vb.name = "tor#{i}"
           vb.memory = 512
         end
@@ -85,7 +85,7 @@ Vagrant.configure(2) do |config|
     # Create 2 spines
     (1..2).each do |i|
       config.vm.define "spine#{i}" do |node|
-        config.vm.provider 'virtualbox' do |vb|
+        node.vm.provider 'virtualbox' do |vb|
           vb.name = "spine#{i}"
           vb.memory = 512
         end


### PR DESCRIPTION
Name assignment was done accidentally with config global variable.
This caused failure during 'make create all' because all vms were
created with the name spine2.

Signed-off-by: Roy Shterman <roys@lightbitslabs.com>
Signed-off-by: Yogev Cohen <yogev@lightbitslabs.com>
