### PR TITLE
Add base_url to fix a pagination bug

### DIFF
--- a/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -36,6 +36,8 @@ glance_api_version=2
 # Volume driver settings for RBD
 enabled_backends=<%= node['bcpc']['ceph']['enabled_pools'].map {|type| type.upcase}.join(",") %>
 
+osapi_volume_base_URL=<%=node['bcpc']['protocol']['cinder']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8776
+
 [oslo_messaging_rabbit]
 # Rabbit message queue settings
 #rabbit_host=<%=node['bcpc']['management']['vip']%>

--- a/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -17,6 +17,7 @@ auth_strategy=keystone
 api_paste_config=/etc/nova/api-paste.ini
 osapi_compute_listen=<%= node['bcpc']['management']['ip'] %>
 osapi_compute_workers=<%=node['bcpc']['nova']['workers']%>
+osapi_compute_link_prefix=<%=node['bcpc']['protocol']['nova']%>://openstack.<%=node['bcpc']['cluster_domain']%>:8774
 <% if node['bcpc']['enabled']['neutron'] %>
 metadata_listen=127.0.0.1
 <% else %>


### PR DESCRIPTION
The pagination uses url which is due to an issue populates http:// this config parameter forces using the correct protocol

**Describe your changes**
Add a config parameter in nova.conf/cinder.conf to specify the correct return url for the next page

**Testing performed**
Tested before and after change and made sure all the commands and API requests are working

