### PR TITLE
Work-around `chronyd` being unable to sync at boot before network is online.

### DIFF
--- a/chef/cookbooks/bcpc/files/default/chrony/custom.conf
+++ b/chef/cookbooks/bcpc/files/default/chrony/custom.conf
@@ -1,0 +1,4 @@
+[Unit]
+After=
+After=network.target network-online.target
+Wants=network-online.target

--- a/chef/cookbooks/bcpc/recipes/chrony.rb
+++ b/chef/cookbooks/bcpc/recipes/chrony.rb
@@ -26,3 +26,19 @@ template '/etc/chrony/chrony.conf' do
   )
   notifies :restart, 'service[chrony]', :immediately
 end
+
+execute 'reload systemd' do
+  action :nothing
+  command 'systemctl daemon-reload'
+end
+
+directory '/etc/systemd/system/chrony.service.d' do
+  action :create
+end
+
+# Work-around so that Chrony daemon waits for network to become online.
+cookbook_file '/etc/systemd/system/chrony.service.d/custom.conf' do
+  source 'chrony/custom.conf'
+  notifies :run, 'execute[reload systemd]', :immediately
+  notifies :restart, 'service[chrony]', :immediately
+end


### PR DESCRIPTION
Performed repeated tests in both a virtual and a real cluster's machine to verify that `chronyd` was able to sync at boot with the work-around applied.

(I consider this a work-around rather than a true fix given the commentary in https://bugs.launchpad.net/ubuntu/+source/chrony/+bug/1746458 and the subsequent rollback of the same sort of change.)