### PR TITLE
 nova-api-metadata can race w/systemd-resolved at boot & use wrong name servers

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -25,13 +25,13 @@ default['bcpc']['ceph']['pg_warn_max_obj_skew'] = 10
 default['bcpc']['ceph']['osd_niceness'] = -10
 default['bcpc']['ceph']['mon_niceness'] = -10
 
-# set tcmalloc max total thread cache
+# Set tcmalloc max total thread cache
 default['bcpc']['ceph']['tcmalloc_max_total_thread_cache_bytes'] = '128MB'
 
-# sets the max open fds at the OS level
+# Set the max open fds at the OS level
 default['bcpc']['ceph']['max_open_files'] = 2048
 
-# set tunables for ceph osd reovery
+# Set tunables for ceph osd reovery
 default['bcpc']['ceph']['paxos_propose_interval'] = 1
 default['bcpc']['ceph']['osd_recovery_max_active'] = 1
 default['bcpc']['ceph']['osd_recovery_threads'] = 2
@@ -45,7 +45,7 @@ default['bcpc']['ceph']['osd_scrub_max_interval'] = 604800
 default['bcpc']['ceph']['osd_scrub_sleep'] = 0.05
 default['bcpc']['ceph']['osd_memory_target'] = 9663676416
 
-# bluestore tunning
+# BlueStore tuning
 default['bcpc']['ceph']['bluestore_rocksdb_options'] = [
   'compression=kNoCompression',
   'max_write_buffer_number=4',

--- a/chef/cookbooks/bcpc/files/default/nova/custom.conf
+++ b/chef/cookbooks/bcpc/files/default/nova/custom.conf
@@ -1,0 +1,4 @@
+[Unit]
+After=
+After=postgresql.service mysql.service keystone.service rabbitmq-server.service ntp.service systemd-resolved.service
+Wants=systemd-resolved.service

--- a/chef/cookbooks/bcpc/recipes/ceph-mon.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-mon.rb
@@ -24,6 +24,7 @@ service "ceph-mon@#{node['hostname']}"
 
 template '/etc/ceph/ceph.client.admin.keyring' do
   source 'ceph/ceph.client.keyring.erb'
+  mode '0600'
   variables(
     username: 'admin',
     client: config['ceph']['client']['admin'],
@@ -133,6 +134,7 @@ begin
         # import the client.admin keyring first and move it to /etc/ceph
         #
         ceph auth import -i ${tmp_dir}/ceph.client.admin.keyring
+        chmod 0600 ${tmp_dir}/ceph.client.admin.keyring
         mv ${tmp_dir}/ceph.client.admin.keyring /etc/ceph
 
         for keyring in ${tmp_dir}/*.keyring; do

--- a/chef/cookbooks/bcpc/recipes/ceph-osd.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-osd.rb
@@ -40,6 +40,7 @@ end
 
 template '/etc/ceph/ceph.client.admin.keyring' do
   source 'ceph/ceph.client.keyring.erb'
+  mode '0600'
   variables(
     username: 'admin',
     client: config['ceph']['client']['admin'],

--- a/chef/cookbooks/bcpc/recipes/chrony.rb
+++ b/chef/cookbooks/bcpc/recipes/chrony.rb
@@ -14,18 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 package 'chrony'
 service 'chrony'
-
-template '/etc/chrony/chrony.conf' do
-  source 'chrony/chrony.conf.erb'
-  variables(
-    servers: node['bcpc']['ntp']['servers']
-  )
-  notifies :restart, 'service[chrony]', :immediately
-end
 
 execute 'reload systemd' do
   action :nothing
@@ -40,5 +31,12 @@ end
 cookbook_file '/etc/systemd/system/chrony.service.d/custom.conf' do
   source 'chrony/custom.conf'
   notifies :run, 'execute[reload systemd]', :immediately
+end
+
+template '/etc/chrony/chrony.conf' do
+  source 'chrony/chrony.conf.erb'
+  variables(
+    servers: node['bcpc']['ntp']['servers']
+  )
   notifies :restart, 'service[chrony]', :immediately
 end

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -154,6 +154,24 @@ bash 'remove default virsh net' do
   only_if 'virsh net-list | grep -i default'
 end
 
+execute 'reload systemd' do
+  action :nothing
+  command 'systemctl daemon-reload'
+end
+
+directory '/etc/systemd/system/nova-api-metadata.service.d' do
+  action :create
+end
+
+# Work-around so that nova-api-metadata waits for systemd-resolved to
+# become online. This is necessary because eventlet's underlying resolver
+# library defaults to a stub configuration that is incorrect at boot and
+# the daemon never sees the updated configuration.
+cookbook_file '/etc/systemd/system/nova-api-metadata.service.d/custom.conf' do
+  source 'nova/custom.conf'
+  notifies :run, 'execute[reload systemd]', :immediately
+end
+
 template '/etc/nova/nova.conf' do
   source 'nova/nova.conf.erb'
   variables(

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -97,6 +97,7 @@ end
 
 template '/etc/ceph/ceph.client.admin.keyring' do
   source 'ceph/ceph.client.keyring.erb'
+  mode '0600'
   variables(
     username: 'admin',
     client: config['ceph']['client']['admin'],


### PR DESCRIPTION
This also includes some other minor fixes. Tested on both `bve` and a metal environment.