### PR TITLE
Added some memory tuning to attempt to alleviate memory pressure issues

### DIFF
--- a/cookbooks/bcpc/templates/default/rabbitmq.config.erb
+++ b/cookbooks/bcpc/templates/default/rabbitmq.config.erb
@@ -4,8 +4,20 @@
 %
 %###############################################
 
-[
-  {kernel,   [{inet_dist_use_interface, {<%=node['bcpc']['management']['ip'].gsub('.',',')%>}}]},
-  {rabbitmq_management, [{listener, [{port, 55672}, {ip, "<%=node['bcpc']['management']['ip']%>"}]}, {redirect_old_port, false}]},
-  {rabbit, [{loopback_users, []}, {heartbeat, <%=node['bcpc']['rabbitmq']['heartbeat']%>}, {cluster_partition_handling, pause_minority}, {tcp_listeners, [{"<%=node['bcpc']['management']['ip']%>", 5672}]}]}
-].
+[{
+  kernel,[
+    { inet_dist_use_interface, { <%=node['bcpc']['management']['ip'].gsub('.',',')%>} }
+  ]}, {
+  rabbitmq_management, [
+    { listener, [{ port, 55672 }, { ip, "<%=node['bcpc']['management']['ip']%>" }] },
+    { redirect_old_port, false }
+  ]}, {
+  rabbit, [
+   { loopback_users, [] },
+   { heartbeat, <%=node['bcpc']['rabbitmq']['heartbeat']%> },
+   { cluster_partition_handling, pause_minority },
+   { vm_memory_high_watermark, 0.5},
+   { vm_memory_high_watermark_paging_ratio, 0.75},
+   { tcp_listeners, [{ "<%=node['bcpc']['management']['ip']%>", 5672 }] }
+  ]
+}].


### PR DESCRIPTION
Gently easing up the memory watermark to 50% of host RAM, and to start swapping when 75% of that 50% has been reached. This will attempt to address rabbitmq from spiraling off and consuming excessive amounts of memory when the queue gets a burst of messages. Also reformatted the ERB output for easier readability. 