### PR TITLE
Pin rally version to avoid using cutting edge releases that may break

### DIFF
--- a/chef/cookbooks/bcpc/attributes/rally.rb
+++ b/chef/cookbooks/bcpc/attributes/rally.rb
@@ -3,8 +3,8 @@
 ###############################################################################
 
 default['bcpc']['rally']['enabled'] = true
-default['bcpc']['rally']['version'] = '1.5.0'
-default['bcpc']['rally']['rally_version'] = '1.6.0'
+default['bcpc']['rally']['rally_openstack']['version'] = '1.5.0'
+default['bcpc']['rally']['rally']['version'] = '1.6.0'
 default['bcpc']['rally']['ssl_verify'] = false
 default['bcpc']['rally']['conf_dir'] = '/etc/rally'
 default['bcpc']['rally']['home_dir'] = '/var/lib/rally'

--- a/chef/cookbooks/bcpc/attributes/rally.rb
+++ b/chef/cookbooks/bcpc/attributes/rally.rb
@@ -4,6 +4,7 @@
 
 default['bcpc']['rally']['enabled'] = true
 default['bcpc']['rally']['version'] = '1.5.0'
+default['bcpc']['rally']['rally_version'] = '1.6.0'
 default['bcpc']['rally']['ssl_verify'] = false
 default['bcpc']['rally']['conf_dir'] = '/etc/rally'
 default['bcpc']['rally']['home_dir'] = '/var/lib/rally'

--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -21,6 +21,7 @@ conf_dir = node['bcpc']['rally']['conf_dir']
 home_dir = node['bcpc']['rally']['home_dir']
 venv_dir = node['bcpc']['rally']['venv_dir']
 version = node['bcpc']['rally']['version']
+rally_version = node['bcpc']['rally']['rally_version']
 database_dir = node['bcpc']['rally']['database_dir']
 
 # pip uses the HOME env to figure out the users home directory. chef
@@ -80,7 +81,7 @@ execute 'install rally in virtualenv' do
     virtualenv --no-download #{venv_dir}
     . #{venv_dir}/bin/activate
     pip install --upgrade pbr
-    pip install --upgrade rally-openstack==#{version}
+    pip install --upgrade rally-openstack==#{version} rally==#{rally_version}
   EOH
   not_if "rally --version | grep rally-openstack | grep #{version}"
 end

--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -20,8 +20,8 @@ return unless node['bcpc']['rally']['enabled']
 conf_dir = node['bcpc']['rally']['conf_dir']
 home_dir = node['bcpc']['rally']['home_dir']
 venv_dir = node['bcpc']['rally']['venv_dir']
-version = node['bcpc']['rally']['version']
-rally_version = node['bcpc']['rally']['rally_version']
+rally_version = node['bcpc']['rally']['rally']['version']
+rally_openstack_version = node['bcpc']['rally']['rally_openstack']['version']
 database_dir = node['bcpc']['rally']['database_dir']
 
 # pip uses the HOME env to figure out the users home directory. chef
@@ -81,9 +81,9 @@ execute 'install rally in virtualenv' do
     virtualenv --no-download #{venv_dir}
     . #{venv_dir}/bin/activate
     pip install --upgrade pbr
-    pip install --upgrade rally-openstack==#{version} rally==#{rally_version}
+    pip install --upgrade rally-openstack==#{rally_openstack_version} rally==#{rally_version}
   EOH
-  not_if "rally --version | grep rally-openstack | grep #{version}"
+  not_if "rally --version | grep rally-openstack | grep #{rally_openstack_version}"
 end
 
 directory conf_dir do


### PR DESCRIPTION
Pin rally version to avoid compatibilities

```
$ rally --debug db ensure
2019-09-24 20:53:57.090 33900 RALLYDEBUG rally.api [-] INFO logs from urllib3 and requests module are hide.
2019-09-24 20:53:57.091 33900 RALLYDEBUG rally.api [-] urllib3 insecure warnings are hidden.
2019-09-24 20:53:57.092 33900 RALLYDEBUG rally.api [-] ERROR log from boto module is hide.
Ensuring database exists: sqlite:////var/lib/rally/db/rally.sqlite
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils [-] Unexpected exception in CLI: TypeError: stamp() got an unexpected keyword argument 'revision'
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils Traceback (most recent call last):
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils   File "/usr/local/lib/rally/local/lib/python2.7/site-packages/rally/cli/cliutils.py", line 674, in run
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils     ret = fn(*fn_args, **fn_kwargs)
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils   File "/usr/local/lib/rally/local/lib/python2.7/site-packages/rally/cli/commands/db.py", line 55, in ensure
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils     db.schema.schema_create()
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils   File "/usr/local/lib/rally/local/lib/python2.7/site-packages/rally/common/db/schema.py", line 139, in schema_create
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils     schema_stamp("head", config=config)
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils   File "/usr/local/lib/rally/local/lib/python2.7/site-packages/rally/common/db/schema.py", line 152, in schema_stamp
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils     return alembic.command.stamp(config, revision=revision)
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils TypeError: stamp() got an unexpected keyword argument 'revision'
2019-09-24 20:53:57.105 33900 ERROR rally.cli.cliutils
```

Tested on BVE