### PR TITLE
be more specific about libvirt builds

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-networking.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-networking.yml
@@ -135,7 +135,7 @@
     src: netplan/libvirt.yaml.j2
     dest: "/etc/netplan/libvirt.yaml"
   register: netplan
-  when: ansible_virtualization_type == 'kvm' or ansible_system_vendor == 'QEMU'
+  when: ansible_virtualization_type == 'kvm' and ansible_virtualization_role == 'guest' and ansible_system_vendor == 'QEMU'
 
 - name: netplan transit interfaces
   template:

--- a/ansible/playbooks/roles/common/tasks/configure-networking.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-networking.yml
@@ -7,6 +7,11 @@
     transit_interfaces: >
       {{ interfaces['transit'] | transit_interfaces(ansible_facts) }}
 
+- name: define libvirt_kvm_guest var
+  set_fact:
+    libvirt_kvm_guest: >
+      {{ ansible_virtualization_type == 'kvm' and ansible_virtualization_role == 'guest' and ansible_system_vendor == 'QEMU' }}
+
 - name: set hostname
   hostname:
     name: "{{ inventory_hostname }}"
@@ -135,7 +140,7 @@
     src: netplan/libvirt.yaml.j2
     dest: "/etc/netplan/libvirt.yaml"
   register: netplan
-  when: ansible_virtualization_type == 'kvm' and ansible_virtualization_role == 'guest' and ansible_system_vendor == 'QEMU'
+  when: libvirt_kvm_guest
 
 - name: netplan transit interfaces
   template:

--- a/ansible/playbooks/roles/common/templates/ssh/sshd_config.j2
+++ b/ansible/playbooks/roles/common/templates/ssh/sshd_config.j2
@@ -19,7 +19,7 @@ Protocol 2
 Port 22
 {% if ansible_virtualization_type == 'virtualbox' %}
 ListenAddress {{ virtualbox['nat_ip'] }}
-{% elif ansible_virtualization_type == 'kvm' or ansible_system_vendor == 'QEMU' %}
+{% elif ansible_virtualization_type == 'kvm' and ansible_virtualization_role == 'guest' and ansible_system_vendor == 'QEMU' %}
 ListenAddress {{ ansible_eth0.ipv4.address }}
 {% endif %}
 ListenAddress {{ interfaces['service']['ip'] }}

--- a/ansible/playbooks/roles/common/templates/ssh/sshd_config.j2
+++ b/ansible/playbooks/roles/common/templates/ssh/sshd_config.j2
@@ -19,7 +19,7 @@ Protocol 2
 Port 22
 {% if ansible_virtualization_type == 'virtualbox' %}
 ListenAddress {{ virtualbox['nat_ip'] }}
-{% elif ansible_virtualization_type == 'kvm' and ansible_virtualization_role == 'guest' and ansible_system_vendor == 'QEMU' %}
+{% elif libvirt_kvm_guest %}
 ListenAddress {{ ansible_eth0.ipv4.address }}
 {% endif %}
 ListenAddress {{ interfaces['service']['ip'] }}


### PR DESCRIPTION
`ansible_virtualization_type` can be 'kvm' on physical hardware, whereas we only want this to match when running under QEMU and when the machine is VM (i.e. a kvm guest).