### PR TITLE
Use 201812.27.0 as the default box version to avoid `vagrant ssh` issues

### DIFF
--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_box = 'bento/ubuntu-18.04'
+base_box_version = '201812.27.0'
+
 require 'yaml'
 
 def mount_apt_cache(config)
@@ -54,7 +57,8 @@ vb_folder = vb_folder.match(/^Default machine folder:\s+(.+)$/)[1]
 
 Vagrant.configure('2') do |config|
   config.ssh.forward_x11 = true
-  config.vm.box = 'bento/ubuntu-18.04'
+  config.vm.box = base_box
+  config.vm.box_version = base_box_version
   config.vm.box_download_insecure = true
   mount_apt_cache(config)
 

--- a/virtual/Vagrantfile.libvirt
+++ b/virtual/Vagrantfile.libvirt
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_box = 'bento/ubuntu-18.04'
+base_box_version = '201812.27.0'
+
 require 'yaml'
 
 def load_topology
@@ -57,7 +60,8 @@ hardware = load_hardware
 
 Vagrant.configure('2') do |config|
   config.ssh.forward_x11 = true
-  config.vm.box = 'bento/ubuntu-18.04'
+  config.vm.box = base_box
+  config.vm.box_version = base_box_version
   config.vm.box_download_insecure = true
 
   config.vm.provider :libvirt do |lv|
@@ -129,7 +133,8 @@ Vagrant.configure('2') do |config|
 
           drive_letters.each do |l|
             device = "sd#{l}"
-            lv.storage :file, size: "#{size_gb}G", device: device.to_s, bus: 'sata'
+            lv.storage :file, size: "#{size_gb}G", device: device.to_s,
+                                                   bus: 'sata'
           end
         end
       end

--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 base_box = 'bento/ubuntu-18.04'
+base_box_version = '201812.27.0'
 
 def mount_apt_cache(config)
   user_data_path = Vagrant.user_data_path.to_s
@@ -42,6 +43,7 @@ Vagrant.configure(2) do |config|
       end
       node.vm.hostname = 'network'
       node.vm.box = base_box
+      config.vm.box_version = base_box_version
       node.vm.box_download_insecure = true
       mount_apt_cache(node)
       node.vm.network 'private_network', virtualbox__intnet: 'management1',
@@ -64,6 +66,7 @@ Vagrant.configure(2) do |config|
           vb.memory = 512
         end
         node.vm.box = base_box
+        config.vm.box_version = base_box_version
         node.vm.box_download_insecure = true
         mount_apt_cache(node)
         node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_spine1",
@@ -90,6 +93,7 @@ Vagrant.configure(2) do |config|
           vb.memory = 512
         end
         node.vm.box = base_box
+        config.vm.box_version = base_box_version
         node.vm.box_download_insecure = true
         mount_apt_cache(node)
         node.vm.network 'private_network', virtualbox__intnet: "tor1_spine#{i}",

--- a/virtual/network/Vagrantfile.libvirt
+++ b/virtual/network/Vagrantfile.libvirt
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+base_box = 'bento/ubuntu-18.04'
+base_box_version = '201812.27.0'
 
 def setup_proxy(node)
   http_proxy = ENV['http_proxy'] || ''
@@ -44,7 +46,8 @@ end
 network = load_network
 
 Vagrant.configure(2) do |config|
-  config.vm.box = 'bento/ubuntu-18.04'
+  config.vm.box = base_box
+  config.vm.box_version = base_box_version
   config.vm.box_download_insecure = true
 
   config.vm.provider :libvirt do |lv|


### PR DESCRIPTION
The default bento/ubuntu-18.04 image appears to suffer from an issue where `vagrant ssh` no longer works when connecting to VMs. The earlier 201812.27.0 doesn't seem to suffer from this issue and since the libssl installation issue we originally ran into that caused the bento image to be rebuilt (https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1832919, https://github.com/chef/bento/issues/1201) is no longer an issue with the older image, we should temporarily switch to that to avoid the `vagrant ssh` issue.