### PR TITLE
run horizon recipe before heat recipe

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -222,8 +222,8 @@ chef_roles:
       - recipe[bcpc::neutron-head]
       - recipe[bcpc::nova-head]
       - recipe[bcpc::cinder]
-      - recipe[bcpc::heat]
       - recipe[bcpc::horizon]
+      - recipe[bcpc::heat]
       - recipe[bcpc::os-quota]
       - recipe[bcpc::flavors]
 


### PR DESCRIPTION
As the heat recipe installs a heat dashboard in horizon, it requires horizon to be installed first. Switching the order of recipes fixes this.