### PR TITLE
fix horizon setting that causes manage.py/heat-dashboard failure

### DIFF
--- a/chef/cookbooks/bcpc/recipes/heat.rb
+++ b/chef/cookbooks/bcpc/recipes/heat.rb
@@ -201,11 +201,6 @@ template '/etc/haproxy/haproxy.d/heat.cfg' do
   notifies :restart, 'service[haproxy-heat]', :immediately
 end
 
-link '/usr/share/openstack-dashboard/themes' do
-  # https://bugs.launchpad.net/ubuntu/+source/heat-dashboard/+bug/1848495
-  to '/usr/share/openstack-dashboard/openstack_dashboard/themes'
-end
-
 # heat packages installation and service definitions
 heat_packages = %w(heat-api heat-api-cfn heat-engine python-heat-dashboard)
 package heat_packages

--- a/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
+++ b/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
@@ -20,7 +20,7 @@ LOGIN_REDIRECT_URL = WEBROOT
 
 DEFAULT_THEME = 'default'
 AVAILABLE_THEMES = [
-  ('default', 'Default', '../themes/default'),
+  ('default', 'Default', 'themes/default'),
 ]
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
Per https://bugs.launchpad.net/ubuntu/+source/heat-dashboard/+bug/1848495