### PR TITLE
add defautl aggregate

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -210,7 +210,12 @@ virtualbox:
 # host aggregates
 ###############################################################################
 
-host_aggregates: []
+host_aggregates:
+  - name: nova
+    args:
+      - --property network=ext1
+    hosts:
+      - r1n2
 
 ###############################################################################
 # networking


### PR DESCRIPTION
**Describe your changes**
Improve out of box experience for default 1h1w topology by adding a default `aggregates` to ext. As with empty aggregates, no VMs can be created.

**Testing performed**
On builds after the change, able to create VMs via command line. ex: with the below command:
```
openstack server create --flavor generic1.tiny --image cirros --network ext1 test
```
