### PR TITLE
A quick 1-line patch to support disabling multipathing for NVME devices

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -18,6 +18,7 @@ chef_environment:
         cmdline_linux:
           - net.ifnames=0
           - biosdevname=0
+          - nvme_core.multipath=0
       nova:
         cpu_config:
           cpu_mode: custom


### PR DESCRIPTION
Small, 1-line fix to address re-enumerating NVME storage devices, which breaks Ceph OSDs when underlying block devices fail or are replaced. 