### PR TITLE
Work-around `calico-dhcp-agent` not restarting after seeing an exception.

### DIFF
--- a/chef/cookbooks/bcpc/files/default/calico/custom.conf
+++ b/chef/cookbooks/bcpc/files/default/calico/custom.conf
@@ -1,0 +1,6 @@
+[Service]
+KillMode=
+KillMode=control-group
+Restart=
+Restart=always
+RestartSec=3s

--- a/chef/cookbooks/bcpc/recipes/calico-work.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-work.rb
@@ -28,6 +28,22 @@ end
 
 service 'calico-dhcp-agent'
 
+execute 'reload systemd' do
+  action :nothing
+  command 'systemctl daemon-reload'
+end
+
+directory '/etc/systemd/system/calico-dhcp-agent.service.d' do
+  action :create
+end
+
+# Work-around so that calico-dhcp-agent is restarted if it exits with
+# an exception.
+cookbook_file '/etc/systemd/system/calico-dhcp-agent.service.d/custom.conf' do
+  source 'calico/custom.conf'
+  notifies :run, 'execute[reload systemd]', :immediately
+end
+
 # these neutron services are installed/enabled by calico packages
 # these services are superseded by nova-metadata-agent and calico-dhcp-agent
 # so we don't need them to be enabled/running


### PR DESCRIPTION
This `systemd` fragment causes `calico-dhcp-agent` to be restarted when it encounters an exception which we've seen when it gets an unexpected response from `etcd`. The root cause is still under investigation but the symptoms is that the service itself is still considered healthy enough to not require a restart - perhaps due to a zero exit status. This work-around cleans things up including the child `dnsmasq` process and then restarts the service.

This has been tested on our cluster of 110 hypervisors and examining the log shows the service successfully being restarted.