### PR TITLE
generate libvirt host uuid

### DIFF
--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -75,8 +75,8 @@ cookbook_file '/var/lib/nova/.ssh/config' do
   group 'nova'
 end
 
-host_uuid = ""
-ruby_block "generate host uuid" do
+host_uuid = ''
+ruby_block 'generate host uuid' do
   block do
     Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
     cmd = "uuidgen --md5 --name #{node['fqdn']} --namespace @dns"

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -75,9 +75,22 @@ cookbook_file '/var/lib/nova/.ssh/config' do
   group 'nova'
 end
 
+host_uuid = ""
+ruby_block "generate host uuid" do
+  block do
+    Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
+    cmd = "uuidgen --md5 --name #{node['fqdn']} --namespace @dns"
+    cmd = shell_out(cmd)
+    host_uuid = cmd.stdout.chomp()
+  end
+end
+
 # configure libvirt
 template '/etc/libvirt/libvirtd.conf' do
   source 'libvirt/libvirtd.conf.erb'
+  variables(
+    host_uuid: lazy { host_uuid }
+  )
   notifies :restart, 'service[libvirtd]', :immediately
 end
 

--- a/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
@@ -55,7 +55,7 @@ unix_sock_rw_perms = "0770"
 # In case 'dmidecode' does not provide a valid UUID and none is
 # provided here, a temporary UUID will be generated.
 #
-# The UUID provided by 'dmidecode' is similar across multiple systems. In such
-# cases, virtual machine migrations between those systems will fail because
-# they will be considered the same host
+# The UUID provided by 'dmidecode' is identical across multiple systems.
+# In such cases, virtual machine migrations between those systems will fail
+# because they will be considered the same host
 host_uuid = "<%= @host_uuid %>"

--- a/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
@@ -46,3 +46,11 @@ unix_sock_group = "libvirt"
 # If not using PolicyKit and setting group ownership for access
 # control then you may want to relax this to:
 unix_sock_rw_perms = "0770"
+
+# UUID of the host:
+# Provide the UUID of the host here in case the command
+# 'dmidecode -s system-uuid' does not provide a valid uuid. In case
+# 'dmidecode' does not provide a valid UUID and none is provided here, a
+# temporary UUID will be generated.
+# Keep the format of the example UUID below.
+host_uuid = "<%= @host_uuid %>"

--- a/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
@@ -48,8 +48,14 @@ unix_sock_group = "libvirt"
 unix_sock_rw_perms = "0770"
 
 # UUID of the host:
-# Provide the UUID of the host here in case the command
-# 'dmidecode -s system-uuid' does not provide a valid uuid. In case
-# 'dmidecode' does not provide a valid UUID and none is provided here, a
-# temporary UUID will be generated.
+#
+# Provide the UUID of the host here in case of the following:
+#
+# The command 'dmidecode -s system-uuid' does not provide a valid uuid.
+# In case 'dmidecode' does not provide a valid UUID and none is
+# provided here, a temporary UUID will be generated.
+#
+# The UUID provided by 'dmidecode' is similar across multiple systems. In such
+# cases, virtual machine migrations will fail because those systems will be
+# considered the same host
 host_uuid = "<%= @host_uuid %>"

--- a/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
@@ -56,6 +56,6 @@ unix_sock_rw_perms = "0770"
 # provided here, a temporary UUID will be generated.
 #
 # The UUID provided by 'dmidecode' is similar across multiple systems. In such
-# cases, virtual machine migrations will fail because those systems will be
-# considered the same host
+# cases, virtual machine migrations between those systems will fail because
+# they will be considered the same host
 host_uuid = "<%= @host_uuid %>"

--- a/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/libvirt/libvirtd.conf.erb
@@ -52,5 +52,4 @@ unix_sock_rw_perms = "0770"
 # 'dmidecode -s system-uuid' does not provide a valid uuid. In case
 # 'dmidecode' does not provide a valid UUID and none is provided here, a
 # temporary UUID will be generated.
-# Keep the format of the example UUID below.
 host_uuid = "<%= @host_uuid %>"


### PR DESCRIPTION
  - this update will produce a unique, deterministic uuid for each host
    based on the node's fqdn and use that for libvirts system uuid vs.
    relying on the one provided by the system hardware
