### PR TITLE
refactored register-compute-nodes make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ all : \
 	run-chef-client \
 	add-cloud-images \
 	register-compute-nodes \
+	enable-compute-service \
 	configure-host-aggregates
 
 create: create-virtual-network create-virtual-hosts
@@ -123,6 +124,12 @@ add-cloud-images:
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/site.yml \
 		-t add-cloud-images --limit headnodes
+
+enable-compute-service:
+
+	ansible-playbook -v \
+		-i ${inventory} ${playbooks}/site.yml \
+		-t enable-compute-service --limit headnodes
 
 register-compute-nodes:
 

--- a/ansible/playbooks/roles/common/tasks/configure-networking.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-networking.yml
@@ -20,6 +20,7 @@
           and ansible_system_vendor == 'QEMU'}}
 
 - import_tasks: configure-etc-hosts.yml
+  tags: [configure-etc-hosts]
 - import_tasks: configure-root-user-ssh.yml
 - import_tasks: configure-systemd-resolved.yml
 - import_tasks: configure-local-proxy.yml

--- a/ansible/playbooks/roles/headnode/tasks/enable-compute-service.yml
+++ b/ansible/playbooks/roles/headnode/tasks/enable-compute-service.yml
@@ -1,0 +1,20 @@
+- name: enable compute service
+  changed_when: false
+  shell: |
+    set -o pipefail
+    set -xe
+    # get the status of all nova-compute servies in json format
+    services=$(openstack compute service list \
+      --service nova-compute -c Host -c Status -f json)
+
+    # filter status results for only hosts that have disabled services
+    disabled=$(echo ${services} | \
+      jq -r '.[] | select(.Status == "disabled") .Host')
+
+    # enable nova-compute services on disabled hosts
+    echo "${disabled}" | \
+      xargs -n 1 -I % openstack compute service set --enable % nova-compute
+  args:
+    executable: /bin/bash
+  environment:
+    "{{ cloud_vars | osadmin() }}"

--- a/ansible/playbooks/roles/headnode/tasks/main.yml
+++ b/ansible/playbooks/roles/headnode/tasks/main.yml
@@ -3,6 +3,11 @@
   run_once: true
   tags: [never,register-compute-nodes]
 
+- import_tasks: enable-compute-service.yml
+  become: true
+  run_once: true
+  tags: [never,enable-compute-service]
+
 - import_tasks: cloud-images.yml
   become: true
   run_once: true

--- a/ansible/playbooks/roles/headnode/tasks/register-compute-nodes.yml
+++ b/ansible/playbooks/roles/headnode/tasks/register-compute-nodes.yml
@@ -1,24 +1,3 @@
 - name: nova-manage discover_hosts
   changed_when: false
   command: nova-manage cell_v2 discover_hosts --verbose
-
-- name: enable compute service
-  changed_when: false
-  shell: |
-    set -o pipefail
-    set -xe
-    # get the status of all nova-compute servies in json format
-    services=$(openstack compute service list \
-      --service nova-compute -c Host -c Status -f json)
-
-    # filter status results for only hosts that have disabled services
-    disabled=$(echo ${services} | \
-      jq -r '.[] | select(.Status == "disabled") .Host')
-
-    # enable nova-compute services on disabled hosts
-    echo "${disabled}" | \
-      xargs -n 1 -I % openstack compute service set --enable % nova-compute
-  args:
-    executable: /bin/bash
-  environment:
-    "{{ cloud_vars | osadmin() }}"


### PR DESCRIPTION
  - split register-compute-nodes make target into two separate tasks
    - register new compute nodes with nova
    - enable nova compute service on those new nodes

    these two tasks were originally executed in the same ansible task