### PR TITLE
updated calico-dhcp-agent service drop-in

### DIFF
--- a/chef/cookbooks/bcpc/files/default/calico/custom.conf
+++ b/chef/cookbooks/bcpc/files/default/calico/custom.conf
@@ -1,6 +1,4 @@
 [Service]
-KillMode=
 KillMode=control-group
-Restart=
 Restart=always
 RestartSec=3s


### PR DESCRIPTION
removed empty keys (killmode,restart) which where causing parse errors.
