### PR TITLE
Update rally and rally-openstack version

### DIFF
--- a/chef/cookbooks/bcpc/attributes/rally.rb
+++ b/chef/cookbooks/bcpc/attributes/rally.rb
@@ -4,7 +4,7 @@
 
 default['bcpc']['rally']['enabled'] = true
 default['bcpc']['rally']['rally_openstack']['version'] = '1.6.0'
-default['bcpc']['rally']['rally']['version'] = '1.6.0'
+default['bcpc']['rally']['rally']['version'] = '2.1.0'
 default['bcpc']['rally']['ssl_verify'] = false
 default['bcpc']['rally']['conf_dir'] = '/etc/rally'
 default['bcpc']['rally']['home_dir'] = '/var/lib/rally'

--- a/chef/cookbooks/bcpc/attributes/rally.rb
+++ b/chef/cookbooks/bcpc/attributes/rally.rb
@@ -3,7 +3,7 @@
 ###############################################################################
 
 default['bcpc']['rally']['enabled'] = true
-default['bcpc']['rally']['rally_openstack']['version'] = '1.5.0'
+default['bcpc']['rally']['rally_openstack']['version'] = '1.6.0'
 default['bcpc']['rally']['rally']['version'] = '1.6.0'
 default['bcpc']['rally']['ssl_verify'] = false
 default['bcpc']['rally']['conf_dir'] = '/etc/rally'


### PR DESCRIPTION
Update rally and rally-openstack versions

**Describe your changes**
new rally-openstack version fixed some issues cinder clients.

**Testing performed**
Ran the rally tests and make sure the tests are running as expected and successful

**Additional context**
```
(venv) rally@r1n0:~/bb-rally/tasks$ rally --version
Rally version: 2.1.0

Installed Plugins:
        rally-openstack: 1.6.0
(venv) rally@r1n0:~/bb-rally/tasks$ rally task sla-check
+---------------------------------------------------------+-----+--------------+--------+--------------------------------------------------------+
| benchmark                                               | pos | criterion    | status | detail                                                 |
+---------------------------------------------------------+-----+--------------+--------+--------------------------------------------------------+
| Authenticate.keystone                                   | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_attach_volume                  | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_delete_snapshot                | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_delete_volume                  | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_delete_volume                  | 1   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_delete_volume                  | 2   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_extend_volume                  | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_list_snapshots                 | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_list_volume                    | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_list_volume                    | 1   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_and_upload_volume_to_image         | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_from_volume_and_delete_volume      | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| CinderVolumes.create_nested_snapshots_and_attach_volume | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| GlanceImages.create_and_delete_image                    | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| GlanceImages.create_and_list_image                      | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| GlanceImages.list_images                                | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| KeystoneBasic.add_and_remove_user_role                  | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| KeystoneBasic.create_add_and_list_user_roles            | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| KeystoneBasic.create_and_delete_role                    | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| KeystoneBasic.create_and_delete_service                 | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| KeystoneBasic.create_and_list_tenants                   | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| KeystoneBasic.create_update_and_delete_tenant           | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| KeystoneBasic.get_entities                              | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaKeypair.boot_and_delete_server_with_keypair         | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaKeypair.create_and_delete_keypair                   | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaKeypair.create_and_list_keypairs                    | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaServers.boot_and_bounce_server                      | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaServers.boot_and_delete_server                      | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaServers.boot_and_list_server                        | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaServers.boot_and_rebuild_server                     | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaServers.boot_server_from_volume_and_delete          | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaServers.pause_and_unpause_server                    | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| NovaServers.snapshot_server                             | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| Quotas.cinder_update_and_delete                         | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
| Quotas.nova_update_and_delete                           | 0   | failure_rate | PASS   | Failure rate criteria 0.00% <= 0.00% <= 0.00% - Passed |
+---------------------------------------------------------+-----+--------------+--------+--------------------------------------------------------+
```
