### PR TITLE
add suffix to virtualbox VMs and network names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.swo
 assets/
 ansible/inventory.yml
+ansible/group_vars/all/overrides.yml
 chef/roles/node.json
 chef/roles/bootstrap.json
 chef/roles/headnode.json
@@ -14,3 +15,5 @@ chef/roles/storagenode.json
 chef/environments/
 chef/databags/
 virtual/files/ssh/id_*
+hardware.overrides.yml
+topology.overrides.yml

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.swo
 assets/
 ansible/inventory.yml
-ansible/group_vars/all/overrides.yml
 chef/roles/node.json
 chef/roles/bootstrap.json
 chef/roles/headnode.json
@@ -15,5 +14,3 @@ chef/roles/storagenode.json
 chef/environments/
 chef/databags/
 virtual/files/ssh/id_*
-hardware.overrides.yml
-topology.overrides.yml

--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -100,8 +100,8 @@ Vagrant.configure('2') do |config|
 
       transit.each do |t_iface|
         subconfig.vm.network('private_network', Util.privnet_args(
-		t_iface['neighbor']['name'],
-		macaddr: t_iface['mac'].delete(':') ))
+            t_iface['neighbor']['name'],
+            macaddr: t_iface['mac'].delete(':')))
       end
 
       subconfig.vm.provider 'virtualbox' do |vb|

--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -27,6 +27,15 @@ def mount_apt_cache(config)
   config.vm.synced_folder cache_dir, apt_cache_dir, create: true, owner: '_apt'
 end
 
+# get virtualbox private network suffix to use
+# * set to environment variable 'VBOX_NET_SUFFIX'
+# * default to login name (eg: _login)
+# * eg: vbox_net_suffix = ENV['VBOX_NET_SUFFIX'] || '_'+ENV['USER']
+vbox_net_suffix = '_' + ENV['USER']
+if ENV.has_key? 'VBOX_NET_SUFFIX'
+  vbox_net_suffix = ENV['VBOX_NET_SUFFIX']
+end
+
 # load the vm topology profile
 topology = './topology/topology.yml'
 topology_overrides = './topology/topology.overrides.yml'
@@ -99,7 +108,7 @@ Vagrant.configure('2') do |config|
 
       transit.each do |t_iface|
         args = {}.tap do |a|
-          a[:virtualbox__intnet] = t_iface['neighbor']['name']
+          a[:virtualbox__intnet] = t_iface['neighbor']['name']+vbox_net_suffix
           a[:nic_type] = '82543GC'
           a[:auto_config] = false
           a[:mac] = t_iface['mac'].delete(':')

--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -21,12 +21,7 @@ base_box_version = '201812.27.0'
 require 'yaml'
 
 # load util module
-util_path = './lib/util.rb'
-if File.file?(File.expand_path(util_path))
-  require File.expand_path(util_path)
-else
-  raise "#{util_path} not found"
-end
+require './lib/util.rb'
 
 # load the vm topology profile
 topology = './topology/topology.yml'

--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -20,20 +20,12 @@ base_box_version = '201812.27.0'
 
 require 'yaml'
 
-def mount_apt_cache(config)
-  user_data_path = Vagrant.user_data_path.to_s
-  cache_dir = File.join(user_data_path, 'cache', 'apt', config.vm.box)
-  apt_cache_dir = '/var/cache/apt/archives'
-  config.vm.synced_folder cache_dir, apt_cache_dir, create: true, owner: '_apt'
-end
-
-# get virtualbox private network suffix to use
-# * set to environment variable 'VBOX_NET_SUFFIX'
-# * default to login name (eg: _login)
-# * eg: vbox_net_suffix = ENV['VBOX_NET_SUFFIX'] || '_'+ENV['USER']
-vbox_net_suffix = '_' + ENV['USER']
-if ENV.has_key? 'VBOX_NET_SUFFIX'
-  vbox_net_suffix = ENV['VBOX_NET_SUFFIX']
+# load util module
+util_path = './lib/util.rb'
+if File.file?(File.expand_path(util_path))
+  require File.expand_path(util_path)
+else
+  raise "#{util_path} not found"
 end
 
 # load the vm topology profile
@@ -69,7 +61,7 @@ Vagrant.configure('2') do |config|
   config.vm.box = base_box
   config.vm.box_version = base_box_version
   config.vm.box_download_insecure = true
-  mount_apt_cache(config)
+  Util.mount_apt_cache(config)
 
   topology['nodes'].each do |node|
     vm_name = node['host']
@@ -107,14 +99,9 @@ Vagrant.configure('2') do |config|
       transit = host_vars['interfaces']['transit']
 
       transit.each do |t_iface|
-        args = {}.tap do |a|
-          a[:virtualbox__intnet] = t_iface['neighbor']['name']+vbox_net_suffix
-          a[:nic_type] = '82543GC'
-          a[:auto_config] = false
-          a[:mac] = t_iface['mac'].delete(':')
-        end
-
-        subconfig.vm.network('private_network', args)
+        subconfig.vm.network('private_network', Util.privnet_args(
+		t_iface['neighbor']['name'],
+		macaddr: t_iface['mac'].delete(':') ))
       end
 
       subconfig.vm.provider 'virtualbox' do |vb|

--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -94,13 +94,16 @@ Vagrant.configure('2') do |config|
       transit = host_vars['interfaces']['transit']
 
       transit.each do |t_iface|
-        subconfig.vm.network('private_network', Util.privnet_args(
-            t_iface['neighbor']['name'],
-            macaddr: t_iface['mac'].delete(':')))
+        subconfig.vm.network('private_network',
+          virtualbox__intnet: Util.vbox_name(t_iface['neighbor']['name']),
+          mac: t_iface['mac'].delete(':'),
+          nic_type: '82543GC',
+          auto_config: false)
       end
 
       subconfig.vm.provider 'virtualbox' do |vb|
-        vb.name = vm_name
+        vbox_vm_name = Util.vbox_name(vm_name)
+        vb.name = vbox_vm_name
         vb.cpus = hw_profile['cpus']
         vb.memory = hw_profile['ram_gb'] * 1024
         vb.customize ['modifyvm', :id, '--groups', project_name]
@@ -119,7 +122,7 @@ Vagrant.configure('2') do |config|
 
           drive_letters.each_with_index do |l, i|
             drive_file = "sd#{l}.vdi"
-            drive_fp = File.join(vb_folder, project_name, vm_name, drive_file)
+            drive_fp = File.join(vb_folder, project_name, vbox_vm_name, drive_file)
 
             next if File.exist?(drive_fp)
 

--- a/virtual/lib/util.rb
+++ b/virtual/lib/util.rb
@@ -4,7 +4,17 @@ module Util
   # * control by environment variable 'ENABLE_VBOX_SUFFIX'
   # * set and non-empty -> set to a static hash base off full path of this file
   # * not set or empty -> set to empty (as if there's no suffix)
-  VBOX_SUFFIX = begin
+def self.vbox_name(name:) 
+  # return name if suffix not enabled
+  unless ENV.key?('ENABLE_VBOX_SUFFIX')
+    return name
+  end
+
+  # return name + hashed __dir__
+  require 'digest/sha1'
+  hash = Digest::SHA1.hexdigest(__dir__)[0,7]
+  return name + '_' + hash
+end
     if ENV.key?('ENABLE_VBOX_SUFFIX') && !ENV['ENABLE_VBOX_SUFFIX'].empty?
       require 'digest'
       seed = Digest::SHA1.hexdigest __dir__

--- a/virtual/lib/util.rb
+++ b/virtual/lib/util.rb
@@ -23,12 +23,7 @@ module Util
     vbox_args[:virtualbox__intnet] = name + VBOX_NET_SUFFIX
     vbox_args[:nic_type] = nic_type
     vbox_args[:auto_config] = false
-    unless macaddr.nil?
-      unless macaddr.scan(/\D/).empty?
-        raise "mac addr to virtualbox should only be numbers (got #{macaddr})"
-      end
-      vbox_args[:mac] = macaddr
-    end
+    vbox_args[:mac] = macaddr unless macaddr.nil?
     vbox_args
   end
 

--- a/virtual/lib/util.rb
+++ b/virtual/lib/util.rb
@@ -3,19 +3,25 @@ module Util
 
 # get virtualbox private network suffix to use
 # * set to environment variable 'VBOX_NET_SUFFIX'
-# * default to login name (eg: _login)
-# * eg: VBOX_NET_SUFFIX = ENV['VBOX_NET_SUFFIX'] || '_'+ENV['USER']
+# * default to a static hash
+# * eg: VBOX_NET_SUFFIX = ENV['VBOX_NET_SUFFIX'] || '_'+hash(__dir__)
 VBOX_NET_SUFFIX = begin 
-  suffix = '_' + ENV['USER']
   if ENV.has_key? 'VBOX_NET_SUFFIX'
     suffix = ENV['VBOX_NET_SUFFIX']
+  else
+    require 'digest'
+    seed = Digest::SHA1.hexdigest __dir__
+    rgen = Random::new(seed.hex)
+    space = [('a'..'z'), ('A'..'Z'), ('0'..'9')].map(&:to_a).flatten
+    hash = (0...5).map { space[rgen.rand(space.length)] }.join
+    suffix = '_' + hash
   end
   suffix
 end
 
 def Util.privnet_args(name, nic_type: '82543GC', macaddr: nil)
   vbox_args = { }
-  vbox_args[:virtualbox__intnet] = name+VBOX_NET_SUFFIX
+  vbox_args[:virtualbox__intnet] = name + VBOX_NET_SUFFIX
   vbox_args[:nic_type] = nic_type
   vbox_args[:auto_config] = false
   if not macaddr.nil?

--- a/virtual/lib/util.rb
+++ b/virtual/lib/util.rb
@@ -1,43 +1,42 @@
 module Util
-
-
-# get virtualbox private network suffix to use
-# * set to environment variable 'VBOX_NET_SUFFIX'
-# * default to a static hash
-# * eg: VBOX_NET_SUFFIX = ENV['VBOX_NET_SUFFIX'] || '_'+hash(__dir__)
-VBOX_NET_SUFFIX = begin 
-  if ENV.has_key? 'VBOX_NET_SUFFIX'
-    suffix = ENV['VBOX_NET_SUFFIX']
-  else
-    require 'digest'
-    seed = Digest::SHA1.hexdigest __dir__
-    rgen = Random::new(seed.hex)
-    space = [('a'..'z'), ('A'..'Z'), ('0'..'9')].map(&:to_a).flatten
-    hash = (0...5).map { space[rgen.rand(space.length)] }.join
-    suffix = '_' + hash
-  end
-  suffix
-end
-
-def Util.privnet_args(name, nic_type: '82543GC', macaddr: nil)
-  vbox_args = { }
-  vbox_args[:virtualbox__intnet] = name + VBOX_NET_SUFFIX
-  vbox_args[:nic_type] = nic_type
-  vbox_args[:auto_config] = false
-  if not macaddr.nil?
-    if not macaddr.scan(/\D/).empty?
-      raise "mac address to virtualbox should only be numbers (got #{macaddr})"
+  # initialize constants
+  # ## virtualbox private network suffix to use
+  # * set to environment variable 'VBOX_NET_SUFFIX'
+  # * default to a static hash
+  # * eg: VBOX_NET_SUFFIX = ENV['VBOX_NET_SUFFIX'] || '_'+hash(__dir__)
+  VBOX_NET_SUFFIX = begin
+    if ENV.key? 'VBOX_NET_SUFFIX'
+      suffix = ENV['VBOX_NET_SUFFIX']
+    else
+      require 'digest'
+      seed = Digest::SHA1.hexdigest __dir__
+      rgen = Random.new(seed.hex)
+      space = [('a'..'z'), ('A'..'Z'), ('0'..'9')].map(&:to_a).flatten
+      hash = (0...5).map { space[rgen.rand(space.length)] }.join
+      suffix = '_' + hash
     end
-    vbox_args[:mac] = macaddr
+    suffix
   end
-  return vbox_args
-end
 
-def Util.mount_apt_cache(config)
-  user_data_path = Vagrant.user_data_path.to_s
-  cache_dir = File.join(user_data_path, 'cache', 'apt', config.vm.box)
-  apt_cache_dir = '/var/cache/apt/archives'
-  config.vm.synced_folder cache_dir, apt_cache_dir, create: true, owner: '_apt'
-end
+  def self.privnet_args(name, nic_type: '82543GC', macaddr: nil)
+    vbox_args = {}
+    vbox_args[:virtualbox__intnet] = name + VBOX_NET_SUFFIX
+    vbox_args[:nic_type] = nic_type
+    vbox_args[:auto_config] = false
+    unless macaddr.nil?
+      unless macaddr.scan(/\D/).empty?
+        raise "mac addr to virtualbox should only be numbers (got #{macaddr})"
+      end
+      vbox_args[:mac] = macaddr
+    end
+    vbox_args
+  end
 
+  def self.mount_apt_cache(config)
+    user_data_path = Vagrant.user_data_path.to_s
+    cache_dir = File.join(user_data_path, 'cache', 'apt', config.vm.box)
+    apt_cache_dir = '/var/cache/apt/archives'
+    config.vm.synced_folder cache_dir, apt_cache_dir,
+        create: true, owner: '_apt'
+  end
 end

--- a/virtual/lib/util.rb
+++ b/virtual/lib/util.rb
@@ -1,0 +1,37 @@
+module Util
+
+
+# get virtualbox private network suffix to use
+# * set to environment variable 'VBOX_NET_SUFFIX'
+# * default to login name (eg: _login)
+# * eg: VBOX_NET_SUFFIX = ENV['VBOX_NET_SUFFIX'] || '_'+ENV['USER']
+VBOX_NET_SUFFIX = begin 
+  suffix = '_' + ENV['USER']
+  if ENV.has_key? 'VBOX_NET_SUFFIX'
+    suffix = ENV['VBOX_NET_SUFFIX']
+  end
+  suffix
+end
+
+def Util.privnet_args(name, nic_type: '82543GC', macaddr: nil)
+  vbox_args = { }
+  vbox_args[:virtualbox__intnet] = name+VBOX_NET_SUFFIX
+  vbox_args[:nic_type] = nic_type
+  vbox_args[:auto_config] = false
+  if not macaddr.nil?
+    if not macaddr.scan(/\D/).empty?
+      raise "mac address to virtualbox should only be numbers (got #{macaddr})"
+    end
+    vbox_args[:mac] = macaddr
+  end
+  return vbox_args
+end
+
+def Util.mount_apt_cache(config)
+  user_data_path = Vagrant.user_data_path.to_s
+  cache_dir = File.join(user_data_path, 'cache', 'apt', config.vm.box)
+  apt_cache_dir = '/var/cache/apt/archives'
+  config.vm.synced_folder cache_dir, apt_cache_dir, create: true, owner: '_apt'
+end
+
+end

--- a/virtual/lib/util.rb
+++ b/virtual/lib/util.rb
@@ -1,35 +1,15 @@
 module Util
-  # initialize constants
-  # ## virtualbox private network suffix to use
-  # * control by environment variable 'ENABLE_VBOX_SUFFIX'
-  # * set and non-empty -> set to a static hash base off full path of this file
-  # * not set or empty -> set to empty (as if there's no suffix)
-def self.vbox_name(name:) 
-  # return name if suffix not enabled
-  unless ENV.key?('ENABLE_VBOX_SUFFIX')
-    return name
-  end
-
-  # return name + hashed __dir__
-  require 'digest/sha1'
-  hash = Digest::SHA1.hexdigest(__dir__)[0,7]
-  return name + '_' + hash
-end
-    if ENV.key?('ENABLE_VBOX_SUFFIX') && !ENV['ENABLE_VBOX_SUFFIX'].empty?
-      require 'digest'
-      seed = Digest::SHA1.hexdigest __dir__
-      rgen = Random.new(seed.hex)
-      space = [('a'..'z'), ('A'..'Z'), ('0'..'9')].map(&:to_a).flatten
-      hash = (0...5).map { space[rgen.rand(space.length)] }.join
-      suffix = '_' + hash
-    else
-      suffix = ''
-    end
-    suffix
-  end
-
+  # returns vbox_name with or without suffix base on set vs unset
+  # of the environment var 'ENABLE_VBOX_SUFFIX'
   def self.vbox_name(name)
-    name + VBOX_SUFFIX
+    # return name if suffix not enabled
+    unless ENV.key?('ENABLE_VBOX_SUFFIX')
+      return name
+    end
+    # return name + hashed __dir__
+    require 'digest/sha1'
+    hash = Digest::SHA1.hexdigest(__dir__)[0, 7]
+    name + '_' + hash
   end
 
   def self.mount_apt_cache(config)

--- a/virtual/lib/util.rb
+++ b/virtual/lib/util.rb
@@ -1,30 +1,25 @@
 module Util
   # initialize constants
   # ## virtualbox private network suffix to use
-  # * set to environment variable 'VBOX_NET_SUFFIX'
-  # * default to a static hash
-  # * eg: VBOX_NET_SUFFIX = ENV['VBOX_NET_SUFFIX'] || '_'+hash(__dir__)
-  VBOX_NET_SUFFIX = begin
-    if ENV.key? 'VBOX_NET_SUFFIX'
-      suffix = ENV['VBOX_NET_SUFFIX']
-    else
+  # * control by environment variable 'ENABLE_VBOX_SUFFIX'
+  # * set and non-empty -> set to a static hash base off full path of this file
+  # * not set or empty -> set to empty (as if there's no suffix)
+  VBOX_SUFFIX = begin
+    if ENV.key?('ENABLE_VBOX_SUFFIX') && !ENV['ENABLE_VBOX_SUFFIX'].empty?
       require 'digest'
       seed = Digest::SHA1.hexdigest __dir__
       rgen = Random.new(seed.hex)
       space = [('a'..'z'), ('A'..'Z'), ('0'..'9')].map(&:to_a).flatten
       hash = (0...5).map { space[rgen.rand(space.length)] }.join
       suffix = '_' + hash
+    else
+      suffix = ''
     end
     suffix
   end
 
-  def self.privnet_args(name, nic_type: '82543GC', macaddr: nil)
-    vbox_args = {}
-    vbox_args[:virtualbox__intnet] = name + VBOX_NET_SUFFIX
-    vbox_args[:nic_type] = nic_type
-    vbox_args[:auto_config] = false
-    vbox_args[:mac] = macaddr unless macaddr.nil?
-    vbox_args
+  def self.vbox_name(name)
+    name + VBOX_SUFFIX
   end
 
   def self.mount_apt_cache(config)

--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -18,7 +18,6 @@
 base_box = 'bento/ubuntu-18.04'
 base_box_version = '201812.27.0'
 
-
 def setup_proxy(node)
   http_proxy  = ENV['http_proxy']  || ''
   https_proxy = ENV['https_proxy'] || ''

--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure(2) do |config|
 
     config.vm.define 'network' do |node|
       config.vm.provider 'virtualbox' do |vb|
-        vb.name = 'network'
+        vb.name = Util.vbox_name('network')
         vb.memory = 512
       end
       node.vm.hostname = 'network'
@@ -42,9 +42,15 @@ Vagrant.configure(2) do |config|
       config.vm.box_version = base_box_version
       node.vm.box_download_insecure = true
       Util.mount_apt_cache(node)
-      node.vm.network('private_network', Util.privnet_args('management1'))
-      node.vm.network('private_network', Util.privnet_args('management2'))
-      node.vm.network('private_network', Util.privnet_args('management3'))
+      node.vm.network('private_network',
+        virtualbox__intnet: Util.vbox_name('management1'),
+        auto_config: false)
+      node.vm.network('private_network',
+        virtualbox__intnet: Util.vbox_name('management2'),
+        auto_config: false)
+      node.vm.network('private_network',
+        virtualbox__intnet: Util.vbox_name('management3'),
+        auto_config: false)
       setup_proxy(node)
       node.vm.provision 'shell', path: 'provisioner.sh', args: 'network'
     end
@@ -55,18 +61,28 @@ Vagrant.configure(2) do |config|
     (1..3).each do |i|
       config.vm.define "tor#{i}" do |node|
         node.vm.provider 'virtualbox' do |vb|
-          vb.name = "tor#{i}"
+          vb.name = Util.vbox_name("tor#{i}")
           vb.memory = 512
         end
         node.vm.box = base_box
         config.vm.box_version = base_box_version
         node.vm.box_download_insecure = true
         Util.mount_apt_cache(node)
-        node.vm.network('private_network', Util.privnet_args("tor#{i}_spine1"))
-        node.vm.network('private_network', Util.privnet_args("tor#{i}_spine2"))
-        node.vm.network('private_network', Util.privnet_args("tor#{i}_hv"))
-        node.vm.network('private_network', Util.privnet_args("management#{i}"))
-        node.vm.network('private_network', Util.privnet_args("storage#{i}"))
+        node.vm.network('private_network',
+          virtualbox__intnet: Util.vbox_name("tor#{i}_spine1"),
+          auto_config: false)
+        node.vm.network('private_network',
+          virtualbox__intnet: Util.vbox_name("tor#{i}_spine2"),
+          auto_config: false)
+        node.vm.network('private_network',
+          virtualbox__intnet: Util.vbox_name("tor#{i}_hv"),
+          auto_config: false)
+        node.vm.network('private_network',
+          virtualbox__intnet: Util.vbox_name("management#{i}"),
+          auto_config: false)
+        node.vm.network('private_network',
+          virtualbox__intnet: Util.vbox_name("storage#{i}"),
+          auto_config: false)
         setup_proxy(node)
         node.vm.provision 'shell', path: 'provisioner.sh', args: "tor#{i}"
         node.vm.hostname = "tor#{i}"
@@ -77,16 +93,22 @@ Vagrant.configure(2) do |config|
     (1..2).each do |i|
       config.vm.define "spine#{i}" do |node|
         node.vm.provider 'virtualbox' do |vb|
-          vb.name = "spine#{i}"
+          vb.name = Util.vbox_name("spine#{i}")
           vb.memory = 512
         end
         node.vm.box = base_box
         config.vm.box_version = base_box_version
         node.vm.box_download_insecure = true
         Util.mount_apt_cache(node)
-        node.vm.network('private_network', Util.privnet_args("tor1_spine#{i}"))
-        node.vm.network('private_network', Util.privnet_args("tor2_spine#{i}"))
-        node.vm.network('private_network', Util.privnet_args("tor3_spine#{i}"))
+        node.vm.network('private_network',
+          virtualbox__intnet: Util.vbox_name("tor1_spine#{i}"),
+          auto_config: false)
+        node.vm.network('private_network',
+          virtualbox__intnet: Util.vbox_name("tor2_spine#{i}"),
+          auto_config: false)
+        node.vm.network('private_network',
+          virtualbox__intnet: Util.vbox_name("tor3_spine#{i}"),
+          auto_config: false)
         setup_proxy(node)
         node.vm.provision 'shell', path: 'provisioner.sh', args: "spine#{i}"
         node.vm.hostname = "spine#{i}"

--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -27,12 +27,7 @@ def setup_proxy(node)
 end
 
 # load util module
-util_path = '../lib/util.rb'
-if File.file?(File.expand_path(util_path))
-  require File.expand_path(util_path)
-else
-  raise "#{util_path} not found"
-end
+require '../lib/util.rb'
 
 Vagrant.configure(2) do |config|
   if ENV['DEPLOY_NETWORK_VM'] == 'true'

--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -18,12 +18,6 @@
 base_box = 'bento/ubuntu-18.04'
 base_box_version = '201812.27.0'
 
-def mount_apt_cache(config)
-  user_data_path = Vagrant.user_data_path.to_s
-  cache_dir = File.join(user_data_path, 'cache', 'apt', config.vm.box)
-  apt_cache_dir = '/var/cache/apt/archives'
-  config.vm.synced_folder cache_dir, apt_cache_dir, create: true, owner: '_apt'
-end
 
 def setup_proxy(node)
   http_proxy  = ENV['http_proxy']  || ''
@@ -33,13 +27,12 @@ def setup_proxy(node)
                              args: [http_proxy, https_proxy]
 end
 
-# get virtualbox private network suffix to use
-# * set to environment variable 'VBOX_NET_SUFFIX'
-# * default to login name (eg: _login)
-# * eg: vbox_net_suffix = ENV['VBOX_NET_SUFFIX'] || '_'+ENV['USER']
-vbox_net_suffix = '_' + ENV['USER']
-if ENV.has_key? 'VBOX_NET_SUFFIX'
-  vbox_net_suffix = ENV['VBOX_NET_SUFFIX']
+# load util module
+util_path = '../lib/util.rb'
+if File.file?(File.expand_path(util_path))
+  require File.expand_path(util_path)
+else
+  raise "#{util_path} not found"
 end
 
 Vagrant.configure(2) do |config|
@@ -54,16 +47,10 @@ Vagrant.configure(2) do |config|
       node.vm.box = base_box
       config.vm.box_version = base_box_version
       node.vm.box_download_insecure = true
-      mount_apt_cache(node)
-      node.vm.network 'private_network',
-		virtualbox__intnet: 'management1'+vbox_net_suffix,
-                auto_config: false
-      node.vm.network 'private_network',
-		virtualbox__intnet: 'management2'+vbox_net_suffix,
-		auto_config: false
-      node.vm.network 'private_network',
-		virtualbox__intnet: 'management3'+vbox_net_suffix,
-		auto_config: false
+      Util.mount_apt_cache(node)
+      node.vm.network('private_network', Util.privnet_args('management1'))
+      node.vm.network('private_network', Util.privnet_args('management2'))
+      node.vm.network('private_network', Util.privnet_args('management3'))
       setup_proxy(node)
       node.vm.provision 'shell', path: 'provisioner.sh', args: 'network'
     end
@@ -80,22 +67,12 @@ Vagrant.configure(2) do |config|
         node.vm.box = base_box
         config.vm.box_version = base_box_version
         node.vm.box_download_insecure = true
-        mount_apt_cache(node)
-        node.vm.network 'private_network',
-		virtualbox__intnet: "tor#{i}_spine1"+vbox_net_suffix,
-                auto_config: false
-        node.vm.network 'private_network',
-		virtualbox__intnet: "tor#{i}_spine2"+vbox_net_suffix,
-                auto_config: false
-        node.vm.network 'private_network',
-		virtualbox__intnet: "tor#{i}_hv"+vbox_net_suffix,
-                auto_config: false
-        node.vm.network 'private_network',
-		virtualbox__intnet: "management#{i}"+vbox_net_suffix,
-                auto_config: false
-        node.vm.network 'private_network',
-		virtualbox__intnet: "storage#{i}"+vbox_net_suffix,
-                auto_config: false
+        Util.mount_apt_cache(node)
+        node.vm.network('private_network', Util.privnet_args("tor#{i}_spine1"))
+        node.vm.network('private_network', Util.privnet_args("tor#{i}_spine2"))
+        node.vm.network('private_network', Util.privnet_args("tor#{i}_hv"))
+        node.vm.network('private_network', Util.privnet_args("management#{i}"))
+        node.vm.network('private_network', Util.privnet_args("storage#{i}"))
         setup_proxy(node)
         node.vm.provision 'shell', path: 'provisioner.sh', args: "tor#{i}"
         node.vm.hostname = "tor#{i}"
@@ -112,16 +89,10 @@ Vagrant.configure(2) do |config|
         node.vm.box = base_box
         config.vm.box_version = base_box_version
         node.vm.box_download_insecure = true
-        mount_apt_cache(node)
-        node.vm.network 'private_network', 
-		virtualbox__intnet: "tor1_spine#{i}"+vbox_net_suffix,
-                auto_config: false
-        node.vm.network 'private_network', 
-		virtualbox__intnet: "tor2_spine#{i}"+vbox_net_suffix,
-                auto_config: false
-        node.vm.network 'private_network', 
-		virtualbox__intnet: "tor3_spine#{i}"+vbox_net_suffix,
-                auto_config: false
+        Util.mount_apt_cache(node)
+        node.vm.network('private_network', Util.privnet_args("tor1_spine#{i}"))
+        node.vm.network('private_network', Util.privnet_args("tor2_spine#{i}"))
+        node.vm.network('private_network', Util.privnet_args("tor3_spine#{i}"))
         setup_proxy(node)
         node.vm.provision 'shell', path: 'provisioner.sh', args: "spine#{i}"
         node.vm.hostname = "spine#{i}"

--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -33,6 +33,15 @@ def setup_proxy(node)
                              args: [http_proxy, https_proxy]
 end
 
+# get virtualbox private network suffix to use
+# * set to environment variable 'VBOX_NET_SUFFIX'
+# * default to login name (eg: _login)
+# * eg: vbox_net_suffix = ENV['VBOX_NET_SUFFIX'] || '_'+ENV['USER']
+vbox_net_suffix = '_' + ENV['USER']
+if ENV.has_key? 'VBOX_NET_SUFFIX'
+  vbox_net_suffix = ENV['VBOX_NET_SUFFIX']
+end
+
 Vagrant.configure(2) do |config|
   if ENV['DEPLOY_NETWORK_VM'] == 'true'
 
@@ -46,12 +55,15 @@ Vagrant.configure(2) do |config|
       config.vm.box_version = base_box_version
       node.vm.box_download_insecure = true
       mount_apt_cache(node)
-      node.vm.network 'private_network', virtualbox__intnet: 'management1',
-                                         auto_config: false
-      node.vm.network 'private_network', virtualbox__intnet: 'management2',
-                                         auto_config: false
-      node.vm.network 'private_network', virtualbox__intnet: 'management3',
-                                         auto_config: false
+      node.vm.network 'private_network',
+		virtualbox__intnet: 'management1'+vbox_net_suffix,
+                auto_config: false
+      node.vm.network 'private_network',
+		virtualbox__intnet: 'management2'+vbox_net_suffix,
+		auto_config: false
+      node.vm.network 'private_network',
+		virtualbox__intnet: 'management3'+vbox_net_suffix,
+		auto_config: false
       setup_proxy(node)
       node.vm.provision 'shell', path: 'provisioner.sh', args: 'network'
     end
@@ -69,16 +81,21 @@ Vagrant.configure(2) do |config|
         config.vm.box_version = base_box_version
         node.vm.box_download_insecure = true
         mount_apt_cache(node)
-        node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_spine1",
-                                           auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_spine2",
-                                           auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "tor#{i}_hv",
-                                           auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "management#{i}",
-                                           auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "storage#{i}",
-                                           auto_config: false
+        node.vm.network 'private_network',
+		virtualbox__intnet: "tor#{i}_spine1"+vbox_net_suffix,
+                auto_config: false
+        node.vm.network 'private_network',
+		virtualbox__intnet: "tor#{i}_spine2"+vbox_net_suffix,
+                auto_config: false
+        node.vm.network 'private_network',
+		virtualbox__intnet: "tor#{i}_hv"+vbox_net_suffix,
+                auto_config: false
+        node.vm.network 'private_network',
+		virtualbox__intnet: "management#{i}"+vbox_net_suffix,
+                auto_config: false
+        node.vm.network 'private_network',
+		virtualbox__intnet: "storage#{i}"+vbox_net_suffix,
+                auto_config: false
         setup_proxy(node)
         node.vm.provision 'shell', path: 'provisioner.sh', args: "tor#{i}"
         node.vm.hostname = "tor#{i}"
@@ -96,12 +113,15 @@ Vagrant.configure(2) do |config|
         config.vm.box_version = base_box_version
         node.vm.box_download_insecure = true
         mount_apt_cache(node)
-        node.vm.network 'private_network', virtualbox__intnet: "tor1_spine#{i}",
-                                           auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "tor2_spine#{i}",
-                                           auto_config: false
-        node.vm.network 'private_network', virtualbox__intnet: "tor3_spine#{i}",
-                                           auto_config: false
+        node.vm.network 'private_network', 
+		virtualbox__intnet: "tor1_spine#{i}"+vbox_net_suffix,
+                auto_config: false
+        node.vm.network 'private_network', 
+		virtualbox__intnet: "tor2_spine#{i}"+vbox_net_suffix,
+                auto_config: false
+        node.vm.network 'private_network', 
+		virtualbox__intnet: "tor3_spine#{i}"+vbox_net_suffix,
+                auto_config: false
         setup_proxy(node)
         node.vm.provision 'shell', path: 'provisioner.sh', args: "spine#{i}"
         node.vm.hostname = "spine#{i}"


### PR DESCRIPTION
Allow multiple users to create multiple chef-bcpc builds by adding a suffix to virtualbox object names during VM creation. This feature is control by `ENABLE_VBOX_SUFFIX` environment variable. Set to enable, unset to run as  current. As this affects how VM are 'named' it is best place this in profile.

Testing
`make create` - resulted in same virtualbox names as before this PR
`ENABLE_VBOX_SUFFIX='true' make create` - created suffix added virtualbox object names (VMs and intnets - eg: tor2_ssV1i, management1_ssV1i)