### PR TITLE
Ignore download if exists key defined for an asset

### DIFF
--- a/ansible/playbooks/roles/localhost/tasks/download-asset.yml
+++ b/ansible/playbooks/roles/localhost/tasks/download-asset.yml
@@ -12,3 +12,4 @@
     dest: "{{ assets_download_dir }}/{{ item.filename }}"
     validate_certs: "{{ validate_certs | default(true) }}"
   environment: "{{ local_environment | default({}) }}"
+  when: not (item.skip_download | default(false))


### PR DESCRIPTION
When dynamically generated asset we don't have a download path. Make sure we don't attempt to download those assets

Specify the file that need to be skipped download
```
  - name: archive
    filename: archive.tar.gz
    exists: true
```
**Testing performed**
Tested on vanilla builds with this, noticed that the download assets code skips this file

