### PR TITLE
systemd resolved fixes

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-networking.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-networking.yml
@@ -25,6 +25,7 @@
 - import_tasks: configure-root-user-ssh.yml
 
 - import_tasks: configure-systemd-resolved.yml
+  tags: [configure-systemd-resolved]
 
 - import_tasks: configure-local-proxy.yml
 

--- a/ansible/playbooks/roles/common/tasks/configure-systemd-resolved.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-systemd-resolved.yml
@@ -6,7 +6,7 @@
 
 - name: resolv.conf symlink
   file:
-    src: /run/systemd/resolve/resolv.conf
+    src: /run/systemd/resolve/stub-resolv.conf
     dest: /etc/resolv.conf
     state: link
     force: true

--- a/ansible/playbooks/roles/common/templates/systemd/resolved.conf.j2
+++ b/ansible/playbooks/roles/common/templates/systemd/resolved.conf.j2
@@ -3,7 +3,7 @@
 ###############################################################################
 
 [Resolve]
-DNS={{ cloud_ip }} {{ dns['servers'] | join (' ') }}
+DNS={{ cloud_ip }}
 FallbackDNS={{ dns['servers'] | join (' ') }}
 Cache=no
 #Domains=

--- a/chef/cookbooks/bcpc/recipes/unbound.rb
+++ b/chef/cookbooks/bcpc/recipes/unbound.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: unbound
 #
-# Copyright:: 2019 Bloomberg Finance L.P.
+# Copyright:: 2020 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,13 +16,7 @@
 # limitations under the License.
 
 package 'unbound'
-
-# libnss-resolve package is needed for glibc based binaries that require name
-# resolution from /etc/resolv.conf which is now managed by systemd-resolve
-package 'libnss-resolve'
-
 service 'unbound'
-service 'systemd-resolved'
 
 template '/etc/default/unbound' do
   source 'unbound/default.erb'


### PR DESCRIPTION
- fixed systemd resolved config file template
  - fallback dns servers are no longer listed in primary dns section
- removed lib-nssresolve package from unbound recipe