### PR TITLE
Use python3 as runtime environment for rally

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -78,7 +78,7 @@ execute 'install rally in virtualenv' do
   retries 3
   user 'rally'
   command <<-EOH
-    virtualenv --no-download #{venv_dir}
+    virtualenv --no-download #{venv_dir} -p /usr/bin/python3
     . #{venv_dir}/bin/activate
     pip install --upgrade pbr
     pip install --upgrade rally-openstack==#{rally_openstack_version} rally==#{rally_version}


### PR DESCRIPTION
Rally is failing to install since some of the components are now deprecated for 2.7

**Describe your changes**
Install virtualenv with python3 runtime

**Testing performed**
Deployed the changes on test cluster and made sure the deployment is completed
