### PR TITLE
Add logging to chrony to get visibility

### DIFF
--- a/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
+++ b/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
@@ -7,7 +7,7 @@ pool {{server}}
 driftfile /var/lib/chrony/chrony.drift
 
 # Uncomment the following line to turn logging on.
-#log tracking measurements statistics
+log tracking measurements statistics
 
 # Log files location.
 logdir /var/log/chrony


### PR DESCRIPTION
Signed-off-by: Srinivas Sakhamuri <ssakhamuri@bloomberg.net>

Enable logging to chrony

**Describe your changes**
Logging to chrony will allow us get visibility into ntp related metrics

**Testing performed**
enabled it and tested the measurements are logging, also checked that logrotate is in place to rotate the logs