### PR TITLE
Add a new task with a tag to configure chrony

### DIFF
--- a/ansible/playbooks/roles/common/tasks/main.yml
+++ b/ansible/playbooks/roles/common/tasks/main.yml
@@ -14,3 +14,7 @@
 - import_tasks: configure-networking.yml
   become: true
   tags: [never,configure-networking]
+
+- import_tasks: configure-chrony.yml
+  become: true
+  tags: [never,configure-chrony]

--- a/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
+++ b/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
@@ -6,7 +6,6 @@ pool {{server}}
 # information.
 driftfile /var/lib/chrony/chrony.drift
 
-# Uncomment the following line to turn logging on.
 log tracking measurements statistics
 
 # Log files location.


### PR DESCRIPTION
Add a new task with a tag to configure chrony
  - remove un-necessary comment from chrony

Signed-off-by: Srinivas Sakhamuri <ssakhamuri@bloomberg.net>

Add a new sub task to setup chrony

Tested on plain build and make sure it is working and chrony conf is updated as expected