### PR TITLE
chrony task fixes

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-networking.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-networking.yml
@@ -40,5 +40,6 @@
   when: configure_network_interfaces | default(true)
 
 - import_tasks: configure-chrony.yml
+  tags: [configure-chrony]
 
 - import_tasks: configure-sshd.yml

--- a/ansible/playbooks/roles/common/tasks/main.yml
+++ b/ansible/playbooks/roles/common/tasks/main.yml
@@ -14,7 +14,3 @@
 - import_tasks: configure-networking.yml
   become: true
   tags: [never,configure-networking]
-
-- import_tasks: configure-chrony.yml
-  become: true
-  tags: [never,configure-chrony]


### PR DESCRIPTION
  - removed dedicated chrony task definition
  - updated chrony task definitioin in configure-network to have
    'configure-chrony' tag for targetted deployment
