### PR TITLE
rally.rb: add python3-dev

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -44,6 +44,7 @@ end
 env['CURL_CA_BUNDLE'] = '' unless node['bcpc']['rally']['ssl_verify']
 
 package 'virtualenv'
+package 'python3-dev'
 
 group 'rally'
 


### PR DESCRIPTION
  - update the rally recipe to install the python3-dev package to build time dependencies on python.h

Signed-off-by: Justin J. Pacheco <justinjpacheco@gmail.com>
