### PR TITLE
Update system.rb

### DIFF
--- a/cookbooks/bcpc/recipes/system.rb
+++ b/cookbooks/bcpc/recipes/system.rb
@@ -95,7 +95,7 @@ end
 begin
   sys_params = node['bcpc']['system']['parameters']
   nf_conntrack_max = sys_params['net.nf_conntrack_max']
-  hashsize = nf_conntrack_max / 8
+  hashsize = nf_conntrack_max / 4
 
   template '/etc/modprobe.d/nf_conntrack.conf' do
     source 'modprobe.d/nf_conntrack.conf.erb'


### PR DESCRIPTION
Update /sys/module/nf_conntrack/parameters/hashsize FROM 1/8 of nf_conntrack_max to 1/4 nf_conntrack max to increase nf_connntrack_buckets to the recommended ratio for modern kernels.
