### PR TITLE
Update BGP daemon from bird (1.x) to bird2.

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -220,7 +220,6 @@ networking:
   mtu: 1500
 
 use_primary_transit_interface: true
-configure_bgp: true
 configure_service_ip: true
 configure_network_interfaces: true
 

--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -244,3 +244,10 @@ ubuntu_apt:
       url: http://security.ubuntu.com/ubuntu
     - dist: bionic-updates
       url: http://archive.ubuntu.com/ubuntu
+
+###############################################################################
+# bird
+###############################################################################
+bird:
+  distribution:
+    name: bionic-backports

--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -219,7 +219,6 @@ host_aggregates: []
 networking:
   mtu: 1500
 
-use_primary_transit_interface: true
 configure_service_ip: true
 configure_network_interfaces: true
 

--- a/ansible/playbooks/roles/common/tasks/configure-bgp.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-bgp.yml
@@ -1,3 +1,6 @@
+- import_tasks: define-transits.yml
+- import_tasks: upgrade-bird.yml
+
 - name: generate apt preferences for bird2 and dependencies
   template:
     src: bird/apt-preferences.j2
@@ -46,6 +49,6 @@
     executable: /bin/bash
   retries: 30
   delay: 5
+  changed_when: false
   register: result
   until: result.rc == 0
-  when: ansible_virtualization_type != 'virtualbox'

--- a/ansible/playbooks/roles/common/tasks/configure-bgp.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-bgp.yml
@@ -1,6 +1,11 @@
+- name: generate apt preferences for bird2 and dependencies
+  template:
+    src: bird/apt-preferences.j2
+    dest: /etc/apt/preferences.d/98bird
+
 - name: install bird
   apt:
-    name: bird
+    name: bird2
 
 - name: create /var/log/bird
   file:

--- a/ansible/playbooks/roles/common/tasks/configure-network-interfaces.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-network-interfaces.yml
@@ -1,3 +1,6 @@
+- import_tasks: configure-etc-hosts.yml
+  tags: [configure-etc-hosts]
+
 - name: rename default netplan config
   command: mv /etc/netplan/01-netcfg.yaml /etc/netplan/01-netcfg.yaml.orig
   args:

--- a/ansible/playbooks/roles/common/tasks/configure-networking.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-networking.yml
@@ -33,6 +33,9 @@
 - import_tasks: configure-ubuntu-apt-sources.yml
   tags: [configure-ubuntu-apt-sources]
 
+- import_tasks: upgrade-bird.yml
+  when: configure_bgp | default(true)
+
 - import_tasks: configure-bgp.yml
   when: configure_bgp | default(true)
 

--- a/ansible/playbooks/roles/common/tasks/configure-networking.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-networking.yml
@@ -1,16 +1,6 @@
-- name: gather host facts
+- name: gather network and hardware/vm facts
   setup:
-    gather_subset: all
-
-- name: define ansible_host
-  set_fact:
-    ansible_host: "{{ interfaces['transit'] | primary_ip(hostvars[inventory_hostname]) }}"
-  when: use_primary_transit_interface
-
-- name: define transit_interfaces
-  set_fact:
-    transit_interfaces: >
-      {{ interfaces['transit'] | transit_interfaces(ansible_facts) }}
+    gather_subset: "!all,!min,hardware,network,virtual"
 
 - name: define libvirt_kvm_guest
   set_fact:
@@ -18,9 +8,6 @@
       {{ ansible_virtualization_type == 'kvm'
           and ansible_virtualization_role == 'guest'
           and ansible_system_vendor == 'QEMU' }}
-
-- import_tasks: configure-etc-hosts.yml
-  tags: [configure-etc-hosts]
 
 - import_tasks: configure-root-user-ssh.yml
   tags: [configure-root-user-ssh]
@@ -33,17 +20,14 @@
 - import_tasks: configure-ubuntu-apt-sources.yml
   tags: [configure-ubuntu-apt-sources]
 
-- import_tasks: upgrade-bird.yml
-  when: configure_bgp | default(true)
-
-- import_tasks: configure-bgp.yml
-  when: configure_bgp | default(true)
+- import_tasks: configure-network-interfaces.yml
+  when: configure_network_interfaces | default(true)
 
 - import_tasks: configure-service-ip.yml
   when: configure_service_ip | default(true)
 
-- import_tasks: configure-network-interfaces.yml
-  when: configure_network_interfaces | default(true)
+- import_tasks: configure-bgp.yml
+  tags: [configure-bgp]
 
 - import_tasks: configure-chrony.yml
   tags: [configure-chrony]

--- a/ansible/playbooks/roles/common/tasks/configure-operator.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-operator.yml
@@ -1,11 +1,9 @@
 ---
 - name: define connection parameters
   set_fact:
-    ansible_host: "{{ interfaces['transit'] | primary_ip(hostvars[inventory_hostname]) }}"
     ansible_ssh_user: "{{ initial_ssh_user }}"
     ansible_ssh_pass: "{{ initial_ssh_pass }}"
     ansible_sudo_pass: "{{ initial_ssh_pass }}"
-  when: use_primary_transit_interface | default(true)
 
 - name: "create the cloud operator group"
   group:

--- a/ansible/playbooks/roles/common/tasks/define-transits.yml
+++ b/ansible/playbooks/roles/common/tasks/define-transits.yml
@@ -1,0 +1,8 @@
+- name: gather host facts for interfaces
+  setup:
+    gather_subset: "!all,!min,network"
+
+- name: define transit_interfaces
+  set_fact:
+    transit_interfaces: >
+      {{ interfaces['transit'] | transit_interfaces(ansible_facts) }}

--- a/ansible/playbooks/roles/common/tasks/upgrade-bird.yml
+++ b/ansible/playbooks/roles/common/tasks/upgrade-bird.yml
@@ -1,0 +1,62 @@
+---
+- name: query_for_bird_installation
+  command: dpkg-query -s bird
+  register: dpkg_query_bird
+  failed_when: dpkg_query_bird.rc != 0
+  ignore_errors: true
+  changed_when: false
+
+# Install new bird2 package
+- name: Upgrade bird to bird2
+  block:
+    - name: Check if existing /etc/bird/bird.conf exists
+      stat:
+        path: /etc/bird/bird.conf
+      register: existing_bird_conf
+
+    - name: Backup existing bird config file
+      copy:
+        remote_src: yes
+        src: /etc/bird/bird.conf
+        dest: /tmp/bird.conf.old
+      when: existing_bird_conf.stat.exists
+
+    - name: Generate apt preferences for bird2 and dependencies
+      template:
+        src: bird/apt-preferences.j2
+        dest: /etc/apt/preferences.d/98bird
+
+    - name: Drop new bird2 config file
+      template:
+        src: bird/bird.conf.j2
+        dest: /tmp/bird.conf.new
+        owner: root
+        group: root
+        mode: 0640
+
+    - name: Download bird2 to apt's package cache
+      command:
+        cmd: /usr/bin/apt-get install -d -y bird2
+        warn: false
+
+    - name: Run upgrade commmands
+      shell:
+        cmd: |
+          systemctl stop bird bird6; \
+          apt-get purge -y bird; \
+          apt-get install -y bird2; \
+          mv /tmp/bird.conf.new /etc/bird/bird.conf; \
+          mkdir -p /var/log/bird; \
+          touch /var/log/bird/bird.log; \
+          chown bird:bird /etc/bird/bird.conf /var/log/bird /var/log/bird/bird.log; \
+          systemctl restart bird
+        warn: false
+      async: 600
+      poll: 10
+
+    - name: Remove the backup bird config file
+      file:
+        path: /tmp/bird.conf.old
+        state: absent
+
+  when: dpkg_query_bird is successful

--- a/ansible/playbooks/roles/common/templates/bird/apt-preferences.j2
+++ b/ansible/playbooks/roles/common/templates/bird/apt-preferences.j2
@@ -1,0 +1,7 @@
+Package: bird2
+Pin: release a={{ bird.distribution.name }}
+Pin-Priority: 500
+
+Package: init-system-helpers
+Pin: release a={{ bird.distribution.name }}
+Pin-Priority: 500

--- a/ansible/playbooks/roles/common/templates/bird/bird.conf.j2
+++ b/ansible/playbooks/roles/common/templates/bird/bird.conf.j2
@@ -27,16 +27,18 @@ protocol kernel {
   scan time 2;    # Scan kernel routing table every 2 seconds
   merge paths on;
   graceful restart;
-  export filter to_kernel;
-  import filter from_kernel;
+  ipv4 {
+    export filter to_kernel;
+    import filter from_kernel;
+  };
 }
-
 {% set interfaces = ['"lo"','"service*"'] %}
-{% for transit in transit_interfaces %}
-  {{ interfaces.append('"' + transit['name'] + '"') }}
-{% endfor %}
+{% for transit in transit_interfaces -%}
+  {% set interfaces = interfaces.append('"' + transit['name'] + '"') %}
+{%- endfor %}
 
 protocol direct {
+  ipv4;
   interface {{ interfaces | join(', ') }};
 }
 
@@ -47,12 +49,14 @@ protocol device {
 {% for transit in transit_interfaces %}
 protocol bgp '{{ transit['neighbor']['name'] }}:{{ transit['name'] }}' {
   multihop;
-  next hop self;
   graceful restart;
   local {{ transit['ip'] | ipaddr('address') }} as {{ bgp['asn'] }};
   neighbor {{ transit['neighbor']['ip'] }} as {{ transit['neighbor']['asn'] }};
-  import all;
-  export filter to_tor;
+  ipv4 {
+    next hop self;
+    import all;
+    export filter to_tor;
+  };
 }
 
 {% endfor %}

--- a/virtual/network/apt-preferences
+++ b/virtual/network/apt-preferences
@@ -1,0 +1,7 @@
+Package: bird2
+Pin: release a=bionic-backports
+Pin-Priority: 500
+
+Package: init-system-helpers
+Pin: release a=bionic-backports
+Pin-Priority: 500

--- a/virtual/network/bird/network.conf
+++ b/virtual/network/bird/network.conf
@@ -53,8 +53,10 @@ protocol kernel {
         persist;
         scan time 60;
         merge paths on;
-        export filter hypervisors;
-        import filter mynetworks;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 # The Device protocol is not a real routing protocol. It doesn't generate any
@@ -65,75 +67,96 @@ protocol device {
 }
 
 protocol direct {
+        ipv4;
         interface "eth3", "eth4", "eth5";
 }
 
 protocol bgp 'tor1:r1n0' {
         local as 4200858701;
         neighbor 10.121.84.2 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor1:r1n1' {
         local as 4200858701;
         neighbor 10.121.84.3 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor1:r1n2' {
         local as 4200858701;
         neighbor 10.121.84.4 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor1:r1n3' {
         local as 4200858701;
         neighbor 10.121.84.5 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor2:r2n1' {
         local as 4200858703;
         neighbor 10.121.85.3 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor2:r2n2' {
         local as 4200858703;
         neighbor 10.121.85.4 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor2:r3n3' {
         local as 4200858703;
         neighbor 10.121.85.5 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor3:r3n1' {
         local as 4200858705;
         neighbor 10.121.86.3 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor3:r3n2' {
         local as 4200858705;
         neighbor 10.121.86.4 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor3:r3n3' {
         local as 4200858705;
         neighbor 10.121.86.5 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }

--- a/virtual/network/bird/network.conf
+++ b/virtual/network/bird/network.conf
@@ -74,6 +74,8 @@ protocol direct {
 protocol bgp 'tor1:r1n0' {
         local as 4200858701;
         neighbor 10.121.84.2 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -83,6 +85,8 @@ protocol bgp 'tor1:r1n0' {
 protocol bgp 'tor1:r1n1' {
         local as 4200858701;
         neighbor 10.121.84.3 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -92,6 +96,8 @@ protocol bgp 'tor1:r1n1' {
 protocol bgp 'tor1:r1n2' {
         local as 4200858701;
         neighbor 10.121.84.4 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -101,6 +107,8 @@ protocol bgp 'tor1:r1n2' {
 protocol bgp 'tor1:r1n3' {
         local as 4200858701;
         neighbor 10.121.84.5 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -110,6 +118,8 @@ protocol bgp 'tor1:r1n3' {
 protocol bgp 'tor2:r2n1' {
         local as 4200858703;
         neighbor 10.121.85.3 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -119,6 +129,8 @@ protocol bgp 'tor2:r2n1' {
 protocol bgp 'tor2:r2n2' {
         local as 4200858703;
         neighbor 10.121.85.4 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -128,6 +140,8 @@ protocol bgp 'tor2:r2n2' {
 protocol bgp 'tor2:r3n3' {
         local as 4200858703;
         neighbor 10.121.85.5 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -137,6 +151,8 @@ protocol bgp 'tor2:r3n3' {
 protocol bgp 'tor3:r3n1' {
         local as 4200858705;
         neighbor 10.121.86.3 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -146,6 +162,8 @@ protocol bgp 'tor3:r3n1' {
 protocol bgp 'tor3:r3n2' {
         local as 4200858705;
         neighbor 10.121.86.4 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -155,6 +173,8 @@ protocol bgp 'tor3:r3n2' {
 protocol bgp 'tor3:r3n3' {
         local as 4200858705;
         neighbor 10.121.86.5 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;

--- a/virtual/network/bird/spine1.conf
+++ b/virtual/network/bird/spine1.conf
@@ -68,6 +68,8 @@ protocol direct {
 protocol bgp 'spine1:tor1' {
         local as 4200858601;
         neighbor 172.16.0.0 as 4200858701;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export all;
                 import filter hypervisors;
@@ -77,6 +79,8 @@ protocol bgp 'spine1:tor1' {
 protocol bgp 'spine1:tor2' {
         local as 4200858601;
         neighbor 172.16.0.4 as 4200858703;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export all;
                 import filter hypervisors;
@@ -86,6 +90,8 @@ protocol bgp 'spine1:tor2' {
 protocol bgp 'spine1:tor3' {
         local as 4200858601;
         neighbor 172.16.0.8 as 4200858705;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export all;
                 import filter hypervisors;

--- a/virtual/network/bird/spine1.conf
+++ b/virtual/network/bird/spine1.conf
@@ -44,11 +44,13 @@ prefix set mynetworks_nets;
 # routing tables with the OS kernel.
 protocol kernel {
         scan time 60;
-        import filter mynetworks;
-        export filter hypervisors;
         merge paths on;
         # necessary to include DHCP-derived default route
         learn;
+        ipv4 {
+                import filter mynetworks;
+                export filter hypervisors;
+        };
 }
 
 # The Device protocol is not a real routing protocol. It doesn't generate any
@@ -59,26 +61,33 @@ protocol device {
 }
 
 protocol direct {
+        ipv4;
         interface "eth1", "eth2";
 }
 
 protocol bgp 'spine1:tor1' {
         local as 4200858601;
         neighbor 172.16.0.0 as 4200858701;
-        export all;
-        import filter hypervisors;
+        ipv4 {
+                export all;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'spine1:tor2' {
         local as 4200858601;
         neighbor 172.16.0.4 as 4200858703;
-        export all;
-        import filter hypervisors;
+        ipv4 {
+                export all;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'spine1:tor3' {
         local as 4200858601;
         neighbor 172.16.0.8 as 4200858705;
-        export all;
-        import filter hypervisors;
+        ipv4 {
+                export all;
+                import filter hypervisors;
+        };
 }

--- a/virtual/network/bird/spine2.conf
+++ b/virtual/network/bird/spine2.conf
@@ -44,11 +44,13 @@ prefix set mynetworks_nets;
 # routing tables with the OS kernel.
 protocol kernel {
         scan time 60;
-        import filter mynetworks;
-        export filter hypervisors;
         merge paths on;
         # necessary to include DHCP-derived default route
         learn;
+        ipv4 {
+                import filter mynetworks;
+                export filter hypervisors;
+        };
 }
 
 # The Device protocol is not a real routing protocol. It doesn't generate any
@@ -59,26 +61,33 @@ protocol device {
 }
 
 protocol direct {
+        ipv4;
         interface "eth1", "eth2";
 }
 
 protocol bgp 'spine2:tor1' {
         local as 4200858601;
         neighbor 172.16.0.2 as 4200858701;
-        export all;
-        import filter hypervisors;
+        ipv4 {
+                export all;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'spine2:tor2' {
         local as 4200858601;
         neighbor 172.16.0.6 as 4200858703;
-        export all;
-        import filter hypervisors;
+        ipv4 {
+                export all;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'spine2:tor3' {
         local as 4200858601;
         neighbor 172.16.0.10 as 4200858705;
-        export all;
-        import filter hypervisors;
+        ipv4 {
+                export all;
+                import filter hypervisors;
+        };
 }

--- a/virtual/network/bird/spine2.conf
+++ b/virtual/network/bird/spine2.conf
@@ -68,6 +68,8 @@ protocol direct {
 protocol bgp 'spine2:tor1' {
         local as 4200858601;
         neighbor 172.16.0.2 as 4200858701;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export all;
                 import filter hypervisors;
@@ -77,6 +79,8 @@ protocol bgp 'spine2:tor1' {
 protocol bgp 'spine2:tor2' {
         local as 4200858601;
         neighbor 172.16.0.6 as 4200858703;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export all;
                 import filter hypervisors;
@@ -86,6 +90,8 @@ protocol bgp 'spine2:tor2' {
 protocol bgp 'spine2:tor3' {
         local as 4200858601;
         neighbor 172.16.0.10 as 4200858705;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export all;
                 import filter hypervisors;

--- a/virtual/network/bird/tor1.conf
+++ b/virtual/network/bird/tor1.conf
@@ -49,10 +49,12 @@ prefix set mynetworks_nets;
 # routing tables with the OS kernel.
 protocol kernel {
         scan time 60;
-        export filter hypervisors;
-        import filter mynetworks;
         persist;
         merge paths on;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 # The Device protocol is not a real routing protocol. It doesn't generate any
@@ -63,47 +65,60 @@ protocol device {
 }
 
 protocol direct {
+        ipv4;
         interface "eth3", "eth4", "eth5";
 }
 
 protocol bgp 'spine1:tor1' {
         local as 4200858701;
         neighbor 172.16.0.1 as 4200858601;
-        export filter hypervisors;
-        import filter mynetworks;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 protocol bgp 'spine2:tor1' {
         local as 4200858701;
         neighbor 172.16.0.3 as 4200858601;
-        export filter hypervisors;
-        import filter mynetworks;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 protocol bgp 'tor1:r1n0' {
         local as 4200858701;
         neighbor 10.121.84.2 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor1:r1n1' {
         local as 4200858701;
         neighbor 10.121.84.3 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor1:r1n2' {
         local as 4200858701;
         neighbor 10.121.84.4 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor1:r1n3' {
         local as 4200858701;
         neighbor 10.121.84.5 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }

--- a/virtual/network/bird/tor1.conf
+++ b/virtual/network/bird/tor1.conf
@@ -72,6 +72,8 @@ protocol direct {
 protocol bgp 'spine1:tor1' {
         local as 4200858701;
         neighbor 172.16.0.1 as 4200858601;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -81,6 +83,8 @@ protocol bgp 'spine1:tor1' {
 protocol bgp 'spine2:tor1' {
         local as 4200858701;
         neighbor 172.16.0.3 as 4200858601;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -90,6 +94,8 @@ protocol bgp 'spine2:tor1' {
 protocol bgp 'tor1:r1n0' {
         local as 4200858701;
         neighbor 10.121.84.2 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -99,6 +105,8 @@ protocol bgp 'tor1:r1n0' {
 protocol bgp 'tor1:r1n1' {
         local as 4200858701;
         neighbor 10.121.84.3 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -108,6 +116,8 @@ protocol bgp 'tor1:r1n1' {
 protocol bgp 'tor1:r1n2' {
         local as 4200858701;
         neighbor 10.121.84.4 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -117,6 +127,8 @@ protocol bgp 'tor1:r1n2' {
 protocol bgp 'tor1:r1n3' {
         local as 4200858701;
         neighbor 10.121.84.5 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;

--- a/virtual/network/bird/tor2.conf
+++ b/virtual/network/bird/tor2.conf
@@ -49,10 +49,12 @@ prefix set mynetworks_nets;
 # routing tables with the OS kernel.
 protocol kernel {
         scan time 60;
-        export filter hypervisors;
-        import filter mynetworks;
         persist;
         merge paths on;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 # The Device protocol is not a real routing protocol. It doesn't generate any
@@ -63,40 +65,51 @@ protocol device {
 }
 
 protocol direct {
+        ipv4;
         interface "eth3", "eth4", "eth5";
 }
 
 protocol bgp 'spine1:tor2' {
         local as 4200858703;
         neighbor 172.16.0.5 as 4200858601;
-        export filter hypervisors;
-        import filter mynetworks;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 protocol bgp 'spine2:tor2' {
         local as 4200858703;
         neighbor 172.16.0.7 as 4200858601;
-        export filter hypervisors;
-        import filter mynetworks;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 protocol bgp 'tor2:r2n1' {
         local as 4200858703;
         neighbor 10.121.85.3 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor2:r2n2' {
         local as 4200858703;
         neighbor 10.121.85.4 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor2:r3n3' {
         local as 4200858703;
         neighbor 10.121.85.5 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }

--- a/virtual/network/bird/tor2.conf
+++ b/virtual/network/bird/tor2.conf
@@ -72,6 +72,8 @@ protocol direct {
 protocol bgp 'spine1:tor2' {
         local as 4200858703;
         neighbor 172.16.0.5 as 4200858601;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -81,6 +83,8 @@ protocol bgp 'spine1:tor2' {
 protocol bgp 'spine2:tor2' {
         local as 4200858703;
         neighbor 172.16.0.7 as 4200858601;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -90,6 +94,8 @@ protocol bgp 'spine2:tor2' {
 protocol bgp 'tor2:r2n1' {
         local as 4200858703;
         neighbor 10.121.85.3 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -99,6 +105,8 @@ protocol bgp 'tor2:r2n1' {
 protocol bgp 'tor2:r2n2' {
         local as 4200858703;
         neighbor 10.121.85.4 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -108,6 +116,8 @@ protocol bgp 'tor2:r2n2' {
 protocol bgp 'tor2:r3n3' {
         local as 4200858703;
         neighbor 10.121.85.5 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;

--- a/virtual/network/bird/tor3.conf
+++ b/virtual/network/bird/tor3.conf
@@ -72,6 +72,8 @@ protocol direct {
 protocol bgp 'spine1:tor3' {
         local as 4200858705;
         neighbor 172.16.0.9 as 4200858601;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -81,6 +83,8 @@ protocol bgp 'spine1:tor3' {
 protocol bgp 'spine2:tor3' {
         local as 4200858705;
         neighbor 172.16.0.11 as 4200858601;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -90,6 +94,8 @@ protocol bgp 'spine2:tor3' {
 protocol bgp 'tor3:r3n1' {
         local as 4200858705;
         neighbor 10.121.86.3 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -99,6 +105,8 @@ protocol bgp 'tor3:r3n1' {
 protocol bgp 'tor3:r3n2' {
         local as 4200858705;
         neighbor 10.121.86.4 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;
@@ -108,6 +116,8 @@ protocol bgp 'tor3:r3n2' {
 protocol bgp 'tor3:r3n3' {
         local as 4200858705;
         neighbor 10.121.86.5 as 4200858801;
+        hold time 3;
+        keepalive time 1;
         ipv4 {
                 export filter mynetworks;
                 import filter hypervisors;

--- a/virtual/network/bird/tor3.conf
+++ b/virtual/network/bird/tor3.conf
@@ -49,10 +49,12 @@ prefix set mynetworks_nets;
 # routing tables with the OS kernel.
 protocol kernel {
         scan time 60;
-        export filter hypervisors;
-        import filter mynetworks;
         persist;
         merge paths on;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 # The Device protocol is not a real routing protocol. It doesn't generate any
@@ -63,40 +65,51 @@ protocol device {
 }
 
 protocol direct {
+        ipv4;
         interface "eth3", "eth4", "eth5";
 }
 
 protocol bgp 'spine1:tor3' {
         local as 4200858705;
         neighbor 172.16.0.9 as 4200858601;
-        export filter hypervisors;
-        import filter mynetworks;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 protocol bgp 'spine2:tor3' {
         local as 4200858705;
         neighbor 172.16.0.11 as 4200858601;
-        export filter hypervisors;
-        import filter mynetworks;
+        ipv4 {
+                export filter hypervisors;
+                import filter mynetworks;
+        };
 }
 
 protocol bgp 'tor3:r3n1' {
         local as 4200858705;
         neighbor 10.121.86.3 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor3:r3n2' {
         local as 4200858705;
         neighbor 10.121.86.4 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }
 
 protocol bgp 'tor3:r3n3' {
         local as 4200858705;
         neighbor 10.121.86.5 as 4200858801;
-        export filter mynetworks;
-        import filter hypervisors;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
 }

--- a/virtual/network/provisioner.sh
+++ b/virtual/network/provisioner.sh
@@ -51,13 +51,19 @@ base_config() {
     sudo systemctl restart lldpd
 }
 
+apt_configuration() {
+    # ref: ansible/playbooks/roles/common/tasks/configure-bgp.yml
+    sudo cp "/vagrant/apt-preferences" /etc/apt/preferences.d/98-bird
+}
+
 package_installation() {
     dpkg --remove-architecture i386
     apt="sudo DEBIAN_FRONTEND=noninteractive apt-get -y"
     ${apt} update
-    ${apt} install lldpd traceroute bird iptables-persistent
+    ${apt} install lldpd traceroute bird2 iptables-persistent
 }
 
+apt_configuration
 package_installation
 base_config "${1}"
 switch_config "${1}"


### PR DESCRIPTION
Internal testing has demonstrated that bird2 is better
suited for BGP peering with fast timers.  This commit
introduces a change to the Ansible workflows that will
provision/upgrade to bird2 from bionic-backports.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>