### PR TITLE
Revert "Use 3/1 timers for virtual network ToRs/spines."

### DIFF
--- a/virtual/network/bird/network.conf
+++ b/virtual/network/bird/network.conf
@@ -73,8 +73,6 @@ protocol bgp 'tor1:r1n0' {
         neighbor 10.121.84.2 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor1:r1n1' {
@@ -82,8 +80,6 @@ protocol bgp 'tor1:r1n1' {
         neighbor 10.121.84.3 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor1:r1n2' {
@@ -91,8 +87,6 @@ protocol bgp 'tor1:r1n2' {
         neighbor 10.121.84.4 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor1:r1n3' {
@@ -100,8 +94,6 @@ protocol bgp 'tor1:r1n3' {
         neighbor 10.121.84.5 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor2:r2n1' {
@@ -109,8 +101,6 @@ protocol bgp 'tor2:r2n1' {
         neighbor 10.121.85.3 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor2:r2n2' {
@@ -118,8 +108,6 @@ protocol bgp 'tor2:r2n2' {
         neighbor 10.121.85.4 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor2:r3n3' {
@@ -127,8 +115,6 @@ protocol bgp 'tor2:r3n3' {
         neighbor 10.121.85.5 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor3:r3n1' {
@@ -136,8 +122,6 @@ protocol bgp 'tor3:r3n1' {
         neighbor 10.121.86.3 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor3:r3n2' {
@@ -145,8 +129,6 @@ protocol bgp 'tor3:r3n2' {
         neighbor 10.121.86.4 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor3:r3n3' {
@@ -154,6 +136,4 @@ protocol bgp 'tor3:r3n3' {
         neighbor 10.121.86.5 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }

--- a/virtual/network/bird/spine1.conf
+++ b/virtual/network/bird/spine1.conf
@@ -67,8 +67,6 @@ protocol bgp 'spine1:tor1' {
         neighbor 172.16.0.0 as 4200858701;
         export all;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'spine1:tor2' {
@@ -76,8 +74,6 @@ protocol bgp 'spine1:tor2' {
         neighbor 172.16.0.4 as 4200858703;
         export all;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'spine1:tor3' {
@@ -85,6 +81,4 @@ protocol bgp 'spine1:tor3' {
         neighbor 172.16.0.8 as 4200858705;
         export all;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }

--- a/virtual/network/bird/spine2.conf
+++ b/virtual/network/bird/spine2.conf
@@ -67,8 +67,6 @@ protocol bgp 'spine2:tor1' {
         neighbor 172.16.0.2 as 4200858701;
         export all;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'spine2:tor2' {
@@ -76,8 +74,6 @@ protocol bgp 'spine2:tor2' {
         neighbor 172.16.0.6 as 4200858703;
         export all;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'spine2:tor3' {
@@ -85,6 +81,4 @@ protocol bgp 'spine2:tor3' {
         neighbor 172.16.0.10 as 4200858705;
         export all;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }

--- a/virtual/network/bird/tor1.conf
+++ b/virtual/network/bird/tor1.conf
@@ -71,8 +71,6 @@ protocol bgp 'spine1:tor1' {
         neighbor 172.16.0.1 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'spine2:tor1' {
@@ -80,8 +78,6 @@ protocol bgp 'spine2:tor1' {
         neighbor 172.16.0.3 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor1:r1n0' {
@@ -89,8 +85,6 @@ protocol bgp 'tor1:r1n0' {
         neighbor 10.121.84.2 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor1:r1n1' {
@@ -98,8 +92,6 @@ protocol bgp 'tor1:r1n1' {
         neighbor 10.121.84.3 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor1:r1n2' {
@@ -107,8 +99,6 @@ protocol bgp 'tor1:r1n2' {
         neighbor 10.121.84.4 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor1:r1n3' {
@@ -116,6 +106,4 @@ protocol bgp 'tor1:r1n3' {
         neighbor 10.121.84.5 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }

--- a/virtual/network/bird/tor2.conf
+++ b/virtual/network/bird/tor2.conf
@@ -71,8 +71,6 @@ protocol bgp 'spine1:tor2' {
         neighbor 172.16.0.5 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'spine2:tor2' {
@@ -80,8 +78,6 @@ protocol bgp 'spine2:tor2' {
         neighbor 172.16.0.7 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor2:r2n1' {
@@ -89,8 +85,6 @@ protocol bgp 'tor2:r2n1' {
         neighbor 10.121.85.3 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor2:r2n2' {
@@ -98,8 +92,6 @@ protocol bgp 'tor2:r2n2' {
         neighbor 10.121.85.4 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor2:r3n3' {
@@ -107,6 +99,4 @@ protocol bgp 'tor2:r3n3' {
         neighbor 10.121.85.5 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }

--- a/virtual/network/bird/tor3.conf
+++ b/virtual/network/bird/tor3.conf
@@ -71,8 +71,6 @@ protocol bgp 'spine1:tor3' {
         neighbor 172.16.0.9 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'spine2:tor3' {
@@ -80,8 +78,6 @@ protocol bgp 'spine2:tor3' {
         neighbor 172.16.0.11 as 4200858601;
         export filter hypervisors;
         import filter mynetworks;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor3:r3n1' {
@@ -89,8 +85,6 @@ protocol bgp 'tor3:r3n1' {
         neighbor 10.121.86.3 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor3:r3n2' {
@@ -98,8 +92,6 @@ protocol bgp 'tor3:r3n2' {
         neighbor 10.121.86.4 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }
 
 protocol bgp 'tor3:r3n3' {
@@ -107,6 +99,4 @@ protocol bgp 'tor3:r3n3' {
         neighbor 10.121.86.5 as 4200858801;
         export filter mynetworks;
         import filter hypervisors;
-        hold time 3;
-        keepalive time 1;
 }


### PR DESCRIPTION
Some lab systems were observed to fail to build when this
is applied to BVE without the relevant bird fixes.
Reverting for now; will cherry-pick in the bird2 PR
instead.