### PR TITLE
change default ceph pool pg[p]-num

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -9,6 +9,9 @@ chef_environment:
   chef_type: environment
   override_attributes:
     bcpc:
+      ceph:
+        pg_num: 32
+        pgp_num: 32
       cloud:
         domain: "{{ cloud_domain }}"
         fqdn: "{{ cloud_fqdn }}"

--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -5,8 +5,8 @@
 default['bcpc']['ceph']['repo']['enabled'] = false
 default['bcpc']['ceph']['repo']['url'] = ''
 
-default['bcpc']['ceph']['pg_num'] = 64
-default['bcpc']['ceph']['pgp_num'] = 64
+default['bcpc']['ceph']['pg_num'] = 8
+default['bcpc']['ceph']['pgp_num'] = 8
 default['bcpc']['ceph']['osds'] = %w(sdb sdc sdd sde)
 default['bcpc']['ceph']['choose_leaf_type'] = 0
 default['bcpc']['ceph']['osd_scrub_load_threshold'] = 0.5


### PR DESCRIPTION
systems building for the first time with multiple ceph pools (due to
zone partitioning) will be unable to create those pools with the
previous pg[p]-num setting of 64. lowering this value to 8 gives us a bit
more runway