### PR TITLE
Bump up default VM topology/hardware specs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,18 @@ deploy the chef-bcpc on hardware.
 ### Prerequisites
 
 * OS X or Linux
-* CPU that supports VT-x virtualization extensions
-* 16 GB of memory
+* Quad-core CPU that supports VT-x virtualization extensions
+* 32 GB of memory
 * 100 GB of free disk space
 * Vagrant 2.1+
 * VirtualBox 5.2+
 * git, curl, rsync, ssh, jq, make, ansible
+
+**NOTE**: It is likely possible to build an environment with 16GB of RAM or less
+if one is willing to make slight modifications to the virtual topology and/or
+change some of the build settings and overrides.  However, we've opted to spec
+the minimum requirements slightly more aggressively and target hosts with 32GB
+RAM or more to provide the best out-of-the-box experience.
 
 
 ### Local Build

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ deploy the chef-bcpc on hardware.
 ### Prerequisites
 
 * OS X or Linux
-* Quad-core CPU that supports VT-x virtualization extensions
+* Quad-core CPU that supports VT-x or AMD-V virtualization extensions
 * 32 GB of memory
 * 128 GB of free disk space
 * Vagrant 2.1+

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ deploy the chef-bcpc on hardware.
 * git, curl, rsync, ssh, jq, make, ansible
 
 **NOTE**: It is likely possible to build an environment with 16GB of RAM or less
-if one is willing to make slight modifications to the virtual topology and/or
-change some of the build settings and overrides.  However, we've opted to spec
-the minimum requirements slightly more aggressively and target hosts with 32GB
-RAM or more to provide the best out-of-the-box experience.
+if one is willing to make slight modifications to the
+ [virtual topology](virtual/topology/hardware.yml) and/or change some of the
+build settings and overrides.  However, we've opted to spec the minimum
+requirements slightly more aggressively and target hosts with 32GB RAM or more
+to provide the best out-of-the-box experience.
 
 
 ### Local Build

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ to provide the best out-of-the-box experience.
 * Review `virtual/topology/topology.yml` for the topology you will build and
 make changes as required, e.g. assign more or less RAM based on your topology
 and your build environment. Other topologies exist in the same directory.
+* To make changes to the virtual topology without dirtying the tree, copy the
+[hardware.yml](virtual/topology/hardware.yml) and
+[topology.yml](virtual/topology/topology.yml) to files named
+`hardware.overrides.yml` and `topology.overrides.yml`, respectively, and make
+changes to them instead.
 * If a proxy server is required for internet access, set the variables TBD
 * If additional CA certificates are required (e.g. for a proxy), set the variables TBD
 * From the root of the chef-bcpc git repository run the following command:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ deploy the chef-bcpc on hardware.
 * OS X or Linux
 * Quad-core CPU that supports VT-x virtualization extensions
 * 32 GB of memory
-* 100 GB of free disk space
+* 128 GB of free disk space
 * Vagrant 2.1+
 * VirtualBox 5.2+
 * git, curl, rsync, ssh, jq, make, ansible

--- a/virtual/topology/hardware.yml
+++ b/virtual/topology/hardware.yml
@@ -1,14 +1,14 @@
 profiles:
   bootstrap:
-    ram_gb: 1
-    cpus: 1
-  headnode:
-    ram_gb: 5
+    ram_gb: 2
     cpus: 2
+  headnode:
+    ram_gb: 8
+    cpus: 4
     swap_gb: 10
   worknode:
-    ram_gb: 3
-    cpus: 2
+    ram_gb: 8
+    cpus: 4
     swap_gb: 10
     ext_disks:
       count: 4

--- a/virtual/topology/hardware.yml
+++ b/virtual/topology/hardware.yml
@@ -5,11 +5,11 @@ profiles:
   headnode:
     ram_gb: 8
     cpus: 4
-    swap_gb: 10
+    swap_gb: 16
   worknode:
     ram_gb: 8
     cpus: 4
-    swap_gb: 10
+    swap_gb: 16
     ext_disks:
       count: 4
-      size_gb: 10
+      size_gb: 16


### PR DESCRIPTION
We've noticed an increased amount of false-positive build
failures recently due to haproxy timeouts and other items
that suggest the default topology/hardware.yml is too
conservative for recent changes to `chef-bcpc`.
    
This PR bumps up the amount of vCPUs/RAM allocated to
each VM (by default) to avoid false-positive build failures
and to reduce the amount of swapping that occurs during
builds.
    
With these changes, 1h1w builds ought to still easily work
on a host with quad-core CPU and 32GB of RAM, which is more
obtainable today in 2020 than it was a few years ago when
these settings were first instated.