### PR TITLE
added zone config zone attribute check

### DIFF
--- a/chef/cookbooks/bcpc/recipes/default.rb
+++ b/chef/cookbooks/bcpc/recipes/default.rb
@@ -19,6 +19,10 @@ region = node['bcpc']['cloud']['region']
 zone_config = ZoneConfig.new(node, region, method(:data_bag_item))
 
 if zone_config.enabled? && worknode?
+  if zone_config.zone.nil?
+    raise 'zones are enabled but this node is not configured to be in a zone'
+  end
+
   unless File.file?(zone_config.state_file)
     FileUtils.mkdir_p File.dirname(zone_config.state_file)
     File.write(zone_config.state_file, "#{zone_config.zone}\n")


### PR DESCRIPTION
  - updated default.rb to check for the zone param in the zone_config
    class if zone config is enabled.

    this prevents an empty zone file from creating if there is no zone
    set
