### PR TITLE
per zone allocation

### DIFF
--- a/chef/cookbooks/bcpc/libraries/zone_config.rb
+++ b/chef/cookbooks/bcpc/libraries/zone_config.rb
@@ -229,4 +229,28 @@ class NovaComputeConfig
     zone = databag[@zone_config.zone]
     zone['libvirt']['secret']
   end
+
+  def cpu_allocation_ratio
+    effective_nova_config('cpu_allocation_ratio')
+  end
+
+  def ram_allocation_ratio
+    effective_nova_config('ram_allocation_ratio')
+  end
+
+  private
+
+  # effective nova config taking into account of per-network-zone overrides
+  def effective_nova_config(key)
+    default_val = @zone_config.node['bcpc']['nova'][key]
+    unless @zone_config.enabled?
+      return default_val
+    end
+    zone = @zone_config.zone_attr(zone: @zone_config.zone)
+    zone_val = zone['nova'][key]
+    if zone_val.nil?
+      return default_val
+    end
+    zone_val
+  end
 end

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -181,6 +181,7 @@ template '/etc/nova/nova.conf' do
   variables(
     db: database,
     config: config,
+    nova_compute_config: nova_compute_config,
     headnodes: headnodes,
     vip: node['bcpc']['cloud']['vip']
   )

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -11,12 +11,12 @@ key = /etc/nova/ssl-bcpc.key
 cert = /etc/nova/ssl-bcpc.pem
 my_ip = <%= node['service_ip'] %>
 enable_new_services = false
-cpu_allocation_ratio = <%= node['bcpc']['nova']['cpu_allocation_ratio'] %>
+cpu_allocation_ratio = <%= @nova_compute_config.cpu_allocation_ratio %>
 <% if node['bcpc']['nova']['vcpu_pin_set'] %>
 vcpu_pin_set =  <%= node['bcpc']['nova']['vcpu_pin_set'] %>
 <% end %>
 force_config_drive = true
-ram_allocation_ratio = <%= node['bcpc']['nova']['ram_allocation_ratio'] %>
+ram_allocation_ratio = <%= @nova_compute_config.ram_allocation_ratio %>
 reserved_host_memory_mb = <%= node['bcpc']['nova']['reserved_host_memory_mb'] %>
 resume_guests_state_on_host_boot = <%= node['bcpc']['nova']['resume_guests_state_on_host_boot'] %>
 max_concurrent_builds = <%= node['bcpc']['nova']['max_concurrent_builds'] %>


### PR DESCRIPTION
allow per-network-zone overrides to be effective for cpu/ram allocation ratio

**Testing performed**
Built multi-zone cluster for the test.
Re-Cheffing resulted with expected allocation ratios in nova.conf.
Allocate VMs to exercise the cpu allocation limit have expected results.
