### PR TITLE
Fix build failures due to PR #1672

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -11,12 +11,14 @@ key = /etc/nova/ssl-bcpc.key
 cert = /etc/nova/ssl-bcpc.pem
 my_ip = <%= node['service_ip'] %>
 enable_new_services = false
+<% unless @is_headnode %>
 cpu_allocation_ratio = <%= @nova_compute_config.cpu_allocation_ratio %>
+ram_allocation_ratio = <%= @nova_compute_config.ram_allocation_ratio %>
+<% end %>
 <% if node['bcpc']['nova']['vcpu_pin_set'] %>
 vcpu_pin_set =  <%= node['bcpc']['nova']['vcpu_pin_set'] %>
 <% end %>
 force_config_drive = true
-ram_allocation_ratio = <%= @nova_compute_config.ram_allocation_ratio %>
 reserved_host_memory_mb = <%= node['bcpc']['nova']['reserved_host_memory_mb'] %>
 resume_guests_state_on_host_boot = <%= node['bcpc']['nova']['resume_guests_state_on_host_boot'] %>
 max_concurrent_builds = <%= node['bcpc']['nova']['max_concurrent_builds'] %>


### PR DESCRIPTION
fix PR #1672 - as template nova.conf.erb is used both in headnode and worknode recipe, there needs to be a guard for accessing nova-compute settings.

Signed-off-by: Peter Lee <plee38@bloomberg.net>

**Testing performed**
Rebuild using make destory; make create all;
