### PR TITLE
Enable RTC logging in Chrony

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-chrony.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-chrony.yml
@@ -22,12 +22,17 @@
       After=network.target network-online.target
       Wants=network-online.target
     dest: /etc/systemd/system/chrony.service.d/custom.conf
-  register: chrony
+  register: chrony_custom
 
-- name: restart chrony
+- name: reload chrony
   systemd:
     name: chrony
     daemon_reload: yes
     enabled: yes
+  when: chrony_custom.changed
+
+- name: restart chrony
+  systemd:
+    name: chrony
     state: restarted
   when: chrony.changed

--- a/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
+++ b/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
@@ -1,3 +1,6 @@
+# Welcome to the chrony configuration file. See chrony.conf(5) for more
+# information about usuable directives.
+
 {% for server in ntp['servers'] %}
 pool {{server}}
 {% endfor %}
@@ -6,7 +9,7 @@ pool {{server}}
 # information.
 driftfile /var/lib/chrony/chrony.drift
 
-log tracking measurements statistics
+log measurements rtc statistics tracking
 
 # Log files location.
 logdir /var/log/chrony
@@ -14,9 +17,7 @@ logdir /var/log/chrony
 # Stop bad estimates upsetting machine clock.
 maxupdateskew 100.0
 
-# This directive enables kernel synchronisation (every 11 minutes) of the
-# real-time clock. Note that it can~@~Yt be used along with the 'rtcfile' directive.
-rtcsync
+rtcfile /var/lib/chrony/rtc
 
 # Step the system clock instead of slewing it if the adjustment is larger than
 # one second, but only in the first three clock updates.


### PR DESCRIPTION
Enable RTC logging in Chrony
Separate reload and restart registration in Chrony task

Signed-off-by: David Comay <dcomay@bloomberg.net>

This change enables logging of the RTC in Chrony. During testing, it was seem that separating the service reloading registration from the restarting was useful. Changes were tested running the `configure-chrony` task target and with a full build being done.

After the change was deployed, I verified that the RTC data was being logged under `/var/log/chrony/rtc.log`.