### PR TITLE
Make memcached memory limit a prop tunable.

### DIFF
--- a/chef/cookbooks/bcpc/attributes/memcached.rb
+++ b/chef/cookbooks/bcpc/attributes/memcached.rb
@@ -1,0 +1,7 @@
+###############################################################################
+# Memcached
+###############################################################################
+
+# Specifies memcached maximum limit of RAM to use for item
+# storage (in megabytes). Note carefully that this isn't a global memory limit
+default['bcpc']['memcached']['memory'] = 1024

--- a/chef/cookbooks/bcpc/templates/default/memcached/memcached.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/memcached/memcached.conf.erb
@@ -24,7 +24,7 @@ logfile /var/log/memcached.log
 # Start with a cap of 64 megs of memory. It's reasonable, and the daemon default
 # Note that the daemon will grow to this size, but does not start out holding this much
 # memory
--m 64
+-m <%= node['bcpc']['memcached']['memory'] %>
 
 # Default connection port is 11211
 -p 11211


### PR DESCRIPTION
**Describe your changes**
change to raise the memcached memory limit from 64M to 1G was made. This is now out of sync with automation. Made the memory limit a prop tunable that gets applied as part of automation.

**Testing performed**
I ran the chef receipe and checked the limit_maxbytes in memcached server.

**Additional context**
1- ssh to the head node
2- using find the port and IP address
ps -ef | grep memcached
3- use this https://lzone.de/cheat-sheet/memcached
To connect and get the stats
telnet 10.0.0.2 11211
stats
Look for limit_maxbytes to get the limit bytes