### PR TITLE
Enable auto-trimming of the RTC by Chrony

### DIFF
--- a/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
+++ b/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
@@ -18,6 +18,7 @@ logdir /var/log/chrony
 maxupdateskew 100.0
 
 rtcfile /var/lib/chrony/rtc
+rtcautotrim 1
 
 # Step the system clock instead of slewing it if the adjustment is larger than
 # one second, but only in the first three clock updates.


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

After enabling RTC logging in Chrony, it's been observed that the RTC can drift significantly from the system time. With the intent to keep these in sync as much as possible so that on reboot the system time gets reinitialized with something "closer", I think "trimming" the RTC as described in `chrony.conf(5)` would be useful.

Along with virtual builds, I've also tested this on real hosts and have observed the RTC tracking much closes to the system time that is synced via configured NTP servers.
