### PR TITLE
Set default memcached memory limit to 64MB.

### DIFF
--- a/chef/cookbooks/bcpc/attributes/memcached.rb
+++ b/chef/cookbooks/bcpc/attributes/memcached.rb
@@ -4,4 +4,4 @@
 
 # Specifies memcached maximum limit of RAM to use for item
 # storage (in megabytes). Note carefully that this isn't a global memory limit
-default['bcpc']['memcached']['memory'] = 1024
+default['bcpc']['memcached']['memory'] = 64


### PR DESCRIPTION
This commit sets the default attribute for memcached's
memory limit back to Ubuntu's packaging defaults (64MB).

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>