### PR TITLE
update cinder recipe to allow package upgrades

### DIFF
--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -121,8 +121,9 @@ template '/etc/haproxy/haproxy.d/cinder.cfg' do
 end
 
 # cinder package installation and service definition
-package 'cinder-scheduler'
-package 'cinder-volume'
+package ['cinder-scheduler', 'cinder-volume'] do
+  action :upgrade
+end
 
 service 'cinder-api' do
   service_name 'apache2'


### PR DESCRIPTION
tested by pushing to subscription date for openstack to 2020-06-10 (up from 2019) the newer packages get installed and automation puts everything where it should be