### PR TITLE
disable implicit dependance on ipv6

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
@@ -25,3 +25,6 @@ FailsafeInboundHostPorts = none
 # TCP 53 (DNS), UDP 53 (DNS), UDP 123 (NTP), TCP 179 (BGP),
 # TCP 2379 & 2380 (etcd)
 FailsafeOutboundHostPorts = tcp:53,udp:53,udp:123,tcp:179,tcp:2379,tcp:2380
+
+# disable ipv6 support
+Ipv6Support = false

--- a/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
@@ -92,3 +92,6 @@ security-poll-suffix = <%= node['bcpc']['powerdns']['security_poll_suffix'] %>
 only-notify =
 also-notify = <%= node['bcpc']['powerdns']['also-notify']['ips'].join(',') %>
 <% end %>
+
+# disable ipv6 listening
+local-ipv6 =


### PR DESCRIPTION
  - services
    - calico felix
    - powerdns
