### PR TITLE
powerdns: update soa ttl

### DIFF
--- a/chef/cookbooks/bcpc/attributes/powerdns.rb
+++ b/chef/cookbooks/bcpc/attributes/powerdns.rb
@@ -24,3 +24,10 @@ default['bcpc']['powerdns']['nameservers']['ns1'] = node['bcpc']['cloud']['vip']
 # also-notify
 default['bcpc']['powerdns']['also-notify']['enabled'] = false
 default['bcpc']['powerdns']['also-notify']['ips'] = []
+
+# soa ttl
+default['bcpc']['powerdns']['soa-ttl']['refresh'] = 600
+default['bcpc']['powerdns']['soa-ttl']['retry'] = 300
+default['bcpc']['powerdns']['soa-ttl']['expiry'] = 86400
+default['bcpc']['powerdns']['soa-ttl']['nx'] = 120
+

--- a/chef/cookbooks/bcpc/templates/default/powerdns/reverse-zone.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/reverse-zone.erb
@@ -1,12 +1,12 @@
 $ORIGIN .
-$TTL 600
+$TTL <%= node['bcpc']['powerdns']['soa-ttl']['refresh'] %>
 
 <%= @zone['zone'] %> IN SOA <%= node['bcpc']['powerdns']['nameservers'].first[0] %>.<%= node['bcpc']['cloud']['domain'] %>. <%= @email %>. (
-    <%= @serial %> ; serial
-    600 ; refresh
-    300 ; retry
-    86400 ; expire
-    600 ; minimum
+    <%= @serial %>
+    <%= node['bcpc']['powerdns']['soa-ttl']['refresh'] %>
+    <%= node['bcpc']['powerdns']['soa-ttl']['retry'] %>
+    <%= node['bcpc']['powerdns']['soa-ttl']['expiry'] %>
+    <%= node['bcpc']['powerdns']['soa-ttl']['nx'] %>
 )
 
 <% node['bcpc']['powerdns']['nameservers'].each do |host, ip| %>

--- a/chef/cookbooks/bcpc/templates/default/powerdns/zone.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/zone.erb
@@ -1,12 +1,12 @@
 $ORIGIN <%= node['bcpc']['cloud']['domain'] %>.
-$TTL 600
+$TTL <%= node['bcpc']['powerdns']['soa-ttl']['refresh'] %>
 
 @ IN SOA <%= node['bcpc']['powerdns']['nameservers'].first[0] %> <%= @email %>. (
-    <%= @serial %> ; serial
-    600 ; refresh
-    300 ; retry
-    86400 ; expire
-    600 ; minimum
+    <%= @serial %>
+    <%= node['bcpc']['powerdns']['soa-ttl']['refresh'] %>
+    <%= node['bcpc']['powerdns']['soa-ttl']['retry'] %>
+    <%= node['bcpc']['powerdns']['soa-ttl']['expiry'] %>
+    <%= node['bcpc']['powerdns']['soa-ttl']['nx'] %>
 )
 
 <% node['bcpc']['powerdns']['nameservers'].each do |host, ip| %>
@@ -14,7 +14,7 @@ $TTL 600
 <% end %>
 
 <% node['bcpc']['powerdns']['nameservers'].each do |host, ip| %>
-<%= host %> 600 IN A <%= ip %>
+<%= host %> <%= node['bcpc']['powerdns']['soa-ttl']['refresh'] %> IN A <%= ip %>
 <% end %>
 
 <%= node['bcpc']['cloud']['fqdn'] %>. IN A <%= node['bcpc']['cloud']['vip'] %>


### PR DESCRIPTION
  - update recipe to use attribute variables
  - nx ttl reduced from 600 to 120