### PR TITLE
Fix a potential build issue.

### DIFF
--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -160,7 +160,7 @@ cinder_config.ceph_pools.each do |pool|
       ceph osd pool application enable #{pool_name} rbd
     DOC
 
-    not_if "ceph osd pool ls | grep -w #{pool_name}"
+    not_if "ceph osd pool ls | grep -w ^#{pool_name}$"
   end
 
   execute 'set ceph pool size' do

--- a/chef/cookbooks/bcpc/recipes/nova-head.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-head.rb
@@ -259,7 +259,7 @@ nova_config.ceph_pools.each do |pool|
       ceph osd pool application enable #{pool_name} rbd
     DOC
 
-    not_if "ceph osd pool ls | grep -w #{pool_name}"
+    not_if "ceph osd pool ls | grep -w ^#{pool_name}$"
   end
 
   execute 'set ceph pool size' do


### PR DESCRIPTION
If pool names are created in the following order:
```
super-stuff
stuff
...
```

The 'stuff' pool is not created in the cinder and nova-head
recipes because the grep 'stuff' for the pool_name check
matches 'super-stuff' in the above example.  This results
in subsequent automation failing.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>