### PR TITLE
Explicitly declare `neutron-dhcp-agent` as a package to upgrade

### DIFF
--- a/chef/cookbooks/bcpc/recipes/calico-work.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-work.rb
@@ -22,9 +22,12 @@ package 'calico-compute' do
   action :remove
 end
 
-package 'neutron-dhcp-agent'
-
-package %w(calico-felix networking-calico calico-dhcp-agent) do
+package %w(
+  calico-dhcp-agent
+  calico-felix
+  networking-calico
+  neutron-dhcp-agent
+) do
   action :upgrade
 end
 


### PR DESCRIPTION
Tested an upgrade from Calico 3.6 to 3.15 and Rocky Neutron from 13.0.4 to 13.0.7 (switch in dated repositories). After the upgrade was complete, `apt-get autoremove` only identified `iptables-persistent` & `netfilter-persistent` as subject for removal.