### PR TITLE
Several reversions necessary for bring-ups of non-virtual environments

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -219,6 +219,7 @@ host_aggregates: []
 networking:
   mtu: 1500
 
+use_primary_transit_interface: true
 configure_service_ip: true
 configure_network_interfaces: true
 

--- a/ansible/playbooks/roles/common/tasks/configure-network-interfaces.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-network-interfaces.yml
@@ -1,6 +1,3 @@
-- import_tasks: configure-etc-hosts.yml
-  tags: [configure-etc-hosts]
-
 - name: rename default netplan config
   command: mv /etc/netplan/01-netcfg.yaml /etc/netplan/01-netcfg.yaml.orig
   args:

--- a/ansible/playbooks/roles/common/tasks/configure-networking.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-networking.yml
@@ -9,6 +9,9 @@
           and ansible_virtualization_role == 'guest'
           and ansible_system_vendor == 'QEMU' }}
 
+- import_tasks: configure-etc-hosts.yml
+  tags: [configure-etc-hosts]
+
 - import_tasks: configure-root-user-ssh.yml
   tags: [configure-root-user-ssh]
 

--- a/ansible/playbooks/roles/common/tasks/configure-operator.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-operator.yml
@@ -4,6 +4,7 @@
     ansible_ssh_user: "{{ initial_ssh_user }}"
     ansible_ssh_pass: "{{ initial_ssh_pass }}"
     ansible_sudo_pass: "{{ initial_ssh_pass }}"
+  when: use_primary_transit_interface | default(true)
 
 - name: "create the cloud operator group"
   group:

--- a/ansible/playbooks/roles/common/tasks/configure-systemd-resolved.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-systemd-resolved.yml
@@ -10,10 +10,10 @@
     dest: /etc/resolv.conf
     state: link
     force: true
-  register: resolved
+  register: resolv_conf
 
 - name: restart systemd-resolved
   service:
     name: systemd-resolved
     state: restarted
-  when: resolved.changed
+  when: resolved.changed or resolv_conf.changed


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

Reintroduce `use_primary_transit_interface`
`configure-etc-hosts.yml` should be moved back into `configure-networking.yml`
Changes to `/etc/systemd/resolved.conf` & `/etc/resolv.conf` should be tracked separately