### PR TITLE
multiple apt package installs

### DIFF
--- a/chef/cookbooks/bcpc/recipes/apache2.rb
+++ b/chef/cookbooks/bcpc/recipes/apache2.rb
@@ -20,14 +20,12 @@
 region = node['bcpc']['cloud']['region']
 config = data_bag_item(region, 'config')
 
-%w(
+package %w(
   apache2
   apache2-utils
   libapache2-mod-fcgid
   libapache2-mod-wsgi
-).each do |pkg|
-  package pkg
-end
+)
 
 service 'apache2'
 

--- a/chef/cookbooks/bcpc/recipes/calico-work.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-work.rb
@@ -18,13 +18,11 @@
 include_recipe 'bcpc::etcd3gw'
 include_recipe 'bcpc::calico-apt'
 
-%w(
+package %w(
   calico-common
   calico-compute
   calico-dhcp-agent
-).each do |pkg|
-  package pkg
-end
+)
 
 service 'calico-dhcp-agent'
 

--- a/chef/cookbooks/bcpc/recipes/ceph-packages.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-packages.rb
@@ -22,6 +22,7 @@ apt_repository 'ceph' do
   only_if { node['bcpc']['ceph']['repo']['enabled'] }
 end
 
-%w(ceph ceph-deploy).each do |pkg|
-  package pkg
-end
+package %w(
+  ceph
+  ceph-deploy
+)

--- a/chef/cookbooks/bcpc/recipes/common-packages.rb
+++ b/chef/cookbooks/bcpc/recipes/common-packages.rb
@@ -15,62 +15,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# system related packages
-package 'lldpd'
+package %w(
+  lldpd
+  ethtool
+  bmon
+  tshark
+  nmap
+  iperf
+  curl
+  conntrack
+  dhcpdump
+  traceroute
+  fio
+  bc
+  iotop
+  htop
+  sysstat
+  linux-tools-common
+  sosreport
+  python-pip
+  python-memcache
+  python-mysqldb
+  python-six
+  python-ldap
+  python-configparser
+  xinetd
+  python-openstackclient
+  jq
+  tmux
+  crudini
+  screen
+  vim
+  ksh
+  bash-completion
+)
 
-# Network troubleshooting tools
-package 'ethtool'
-package 'bmon'
-package 'tshark'
-package 'nmap'
-package 'iperf'
-package 'curl'
-package 'conntrack'
-package 'dhcpdump'
-package 'traceroute'
-
-# I/O troubleshooting tools
-package 'fio'
-package 'bc'
-package 'iotop'
-
-# System troubleshooting tools
-package 'htop'
-package 'sysstat'
-package 'linux-tools-common'
-package 'sosreport'
-
-# various python packages
-package 'python-pip'
-package 'python-memcache'
-package 'python-mysqldb'
-package 'python-six'
-package 'python-ldap'
-package 'python-configparser'
-
-# used for monitoring various services
-package 'xinetd'
-
-# openstack client cli
-package 'python-openstackclient'
-
-# packages used for operatons and file edits
-package 'jq'
-package 'tmux'
-package 'crudini'
-
-package 'screen'
 cookbook_file '/etc/screenrc' do
   source 'screen/screenrc'
 end
 
-package 'vim'
 cookbook_file '/etc/vim/vimrc' do
   source 'vim/vimrc'
 end
-
-# some people like kornshell ¯\_(ツ)_/¯
-package 'ksh'
-
-# bash completion for operators
-package 'bash-completion'

--- a/chef/cookbooks/bcpc/recipes/etckeeper.rb
+++ b/chef/cookbooks/bcpc/recipes/etckeeper.rb
@@ -16,8 +16,10 @@
 # limitations under the License.
 #
 
-package 'git'
-package 'etckeeper'
+package %w(
+  git
+  etckeeper
+)
 
 cookbook_file '/etc/etckeeper/etckeeper.conf' do
   source 'etckeeper/etckeeper.conf'

--- a/chef/cookbooks/bcpc/recipes/glance.rb
+++ b/chef/cookbooks/bcpc/recipes/glance.rb
@@ -121,8 +121,10 @@ template '/etc/haproxy/haproxy.d/glance.cfg' do
 end
 
 # glance package installation and service definition
-package 'glance'
-package 'qemu-utils'
+package %w(
+  glance
+  qemu-utils
+)
 service 'glance-api'
 service 'haproxy-glance' do
   service_name 'haproxy'

--- a/chef/cookbooks/bcpc/recipes/keystone.rb
+++ b/chef/cookbooks/bcpc/recipes/keystone.rb
@@ -36,9 +36,11 @@ template '/etc/haproxy/haproxy.d/keystone.cfg' do
 end
 
 # package installation and service definition starts
-%w(keystone python-ldap python-ldappool).each do |pkg|
-  package pkg
-end
+package %w(
+  keystone
+  python-ldap
+  python-ldappool
+)
 
 service 'keystone' do
   service_name 'apache2'

--- a/chef/cookbooks/bcpc/recipes/mysql.rb
+++ b/chef/cookbooks/bcpc/recipes/mysql.rb
@@ -26,8 +26,10 @@ apt_repository 'percona' do
   only_if { repo['enabled'] }
 end
 
-package 'debconf-utils'
-package 'percona-xtradb-cluster-57'
+package %w(
+  debconf-utils
+  percona-xtradb-cluster-57
+)
 
 service 'mysql'
 service 'xinetd'

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -132,9 +132,11 @@ end
 
 # neutron package installation and service definition starts
 #
-%w(calico-control calico-common neutron-server).each do |pkg|
-  package pkg
-end
+package %w(
+  calico-control
+  calico-common
+  neutron-server
+)
 
 service 'neutron-server'
 service 'haproxy-neutron' do

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -27,12 +27,14 @@ database = {
   'password' => config['nova']['creds']['db']['password'],
 }
 
-package 'ceph'
-package 'nova-compute'
-package 'nova-api-metadata'
-package 'ovmf'
-package 'pm-utils'
-package 'sysfsutils'
+package %w(
+  ceph
+  nova-compute
+  nova-api-metadata
+  ovmf
+  pm-utils
+  sysfsutils
+)
 
 service 'nova-compute'
 service 'nova-api-metadata'

--- a/chef/cookbooks/bcpc/recipes/nova-head.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-head.rb
@@ -207,12 +207,14 @@ template '/etc/haproxy/haproxy.d/nova.cfg' do
 end
 
 # nova package installation and service definition
-package 'nova-api'
-package 'nova-conductor'
-package 'nova-consoleauth'
-package 'nova-novncproxy'
-package 'nova-scheduler'
-package 'nova-placement-api'
+package %w(
+  nova-api
+  nova-conductor
+  nova-consoleauth
+  nova-novncproxy
+  nova-scheduler
+  nova-placement-api
+)
 
 service 'nova-api'
 service 'nova-consoleauth'

--- a/chef/cookbooks/bcpc/recipes/postfix.rb
+++ b/chef/cookbooks/bcpc/recipes/postfix.rb
@@ -22,8 +22,10 @@ package 'exim4' do
   action :remove
 end
 
-package 'bsd-mailx'
-package 'postfix'
+package %w(
+  bsd-mailx
+  postfix
+)
 service 'postfix'
 
 template '/etc/postfix/main.cf' do

--- a/chef/cookbooks/bcpc/recipes/powerdns.rb
+++ b/chef/cookbooks/bcpc/recipes/powerdns.rb
@@ -60,9 +60,10 @@ execute 'create pdns database' do
 end
 #
 # create/manage pdns database ends
-
-package 'pdns-server'
-package 'pdns-backend-mysql'
+package %w(
+  pdns-server
+  pdns-backend-mysql
+)
 service 'pdns'
 
 # remove default pdns.d directory

--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -43,8 +43,10 @@ end
 
 env['CURL_CA_BUNDLE'] = '' unless node['bcpc']['rally']['ssl_verify']
 
-package 'virtualenv'
-package 'python3-dev'
+package %w(
+  virtualenv
+  python3-dev
+)
 
 group 'rally'
 


### PR DESCRIPTION
- use Chef's support for installing multiple apt package in one invocation
- reduces the build time for a minimal default 1h1w by 23%
- only package installs from the same recipe are collected
- package installs in subsequent recipes stay there

Signed-off-by: Chris Morgan <mihalis68@gmail.com>

replaces https://github.com/bloomberg/chef-bcpc/pull/1698

**Describe your changes**
replace sequences like 
package a
package b

from the same recipe

with 
package %w(
  a
  b
)

**Testing performed**
perform complete clean default build in a clone of this project. Build succeeded

make destroy
make clean all

build succeeded, same output, approximately 23% faster

**Additional context**
none