### PR TITLE
Changes to better align `create-virtual-hosts` step with metal nodes

### DIFF
--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Copyright:: 2019 Bloomberg Finance L.P.
+# Copyright:: 2020 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 base_box = 'bento/ubuntu-18.04'
-base_box_version = '201812.27.0'
+base_box_version = '202005.21.0'
 
 require 'yaml'
 

--- a/virtual/Vagrantfile.libvirt
+++ b/virtual/Vagrantfile.libvirt
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Copyright:: 2019 Bloomberg Finance L.P.
+# Copyright:: 2020 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 base_box = 'bento/ubuntu-18.04'
-base_box_version = '201812.27.0'
+base_box_version = '202005.21.0'
 
 require 'yaml'
 

--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Copyright:: 2019 Bloomberg Finance L.P.
+# Copyright:: 2020 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 base_box = 'bento/ubuntu-18.04'
-base_box_version = '201812.27.0'
+base_box_version = '202005.21.0'
 
 def setup_proxy(node)
   http_proxy  = ENV['http_proxy']  || ''
@@ -30,7 +30,7 @@ end
 require '../lib/util.rb'
 
 Vagrant.configure(2) do |config|
-  if ENV['BCC_DEPLOY_NETWORK_VM'] == 'true'
+  if ENV.key?('BCC_DEPLOY_NETWORK_VM')
 
     config.vm.define 'network' do |node|
       config.vm.provider 'virtualbox' do |vb|

--- a/virtual/network/Vagrantfile.libvirt
+++ b/virtual/network/Vagrantfile.libvirt
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Copyright:: 2019 Bloomberg Finance L.P.
+# Copyright:: 2020 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 base_box = 'bento/ubuntu-18.04'
-base_box_version = '201812.27.0'
+base_box_version = '202005.21.0'
 
 def setup_proxy(node)
   http_proxy = ENV['http_proxy'] || ''


### PR DESCRIPTION
Update Bento box version for ubuntu-18.04 to 202005.21.0
Treat BCC_DEPLOY_NETWORK_VM the same as other boolean environment variables
Do the Ansible equivalent of a apt(8) dist upgrade as part of provisioning

Signed-off-by: David Comay <dcomay@bloomberg.net>