### PR TITLE
remove limit of 30 projects in horizon dropdown box

### DIFF
--- a/chef/cookbooks/bcpc/libraries/utils.rb
+++ b/chef/cookbooks/bcpc/libraries/utils.rb
@@ -196,12 +196,10 @@ def cloud_networks(network: nil)
 end
 
 def node_primary_interface
-  interface = node_interface(
+  node_interface(
     type: 'primary',
     ip_address: node['service_ip']
   )
-
-  interface
 end
 
 def node_interface(type: nil, ip_address: nil)

--- a/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
+++ b/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
@@ -165,3 +165,5 @@ SECURITY_GROUP_RULES = {
     'to_port': '3389',
   },
 }
+
+DROPDOWN_MAX_ITEMS = None


### PR DESCRIPTION
From https://access.redhat.com/solutions/2595611 :

```
By default, DROPDOWN_MAX_ITEMS has a value of 30.

If you have projects more than 30, Project dropdown will only list 30 projects randomly.

You can set the value of DROPDOWN_MAX_ITEMS to a specific number to list that many items. None specifies unlimited dropdown items.
```

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
This commit removes the limit of 30 projects in the horizon dropdown box

**Testing performed**
Tested in Virtualbox

**Additional context**
Add any other context about your contribution here.
