### PR TITLE
changed permissions for socket files for ceph and haproxy

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -9,6 +9,7 @@ mon host = <%= @headnodes.map{ |n| n['service_ip'] }.join(',') %>
 max open files = <%= node['bcpc']['ceph']['max_open_files'] %>
 rbd default features = <%= node['bcpc']['ceph']['rbd_default_features'] %>
 osd crush initial weight = <%= node['bcpc']['ceph']['osd_crush_initial_weight'] %>
+admin socket mode = 0775
 
 [mon]
 mon compact on start = true

--- a/chef/cookbooks/bcpc/templates/default/haproxy/haproxy.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/haproxy/haproxy.cfg.erb
@@ -7,7 +7,7 @@ global
   user haproxy
   group haproxy
   pidfile /var/run/haproxy.pid
-  stats socket /var/run/haproxy/haproxy.asok level admin
+  stats socket /var/run/haproxy/haproxy.asok user root group haproxy mode 775 level admin
   log /dev/log local0 info alert
   maxconn 8000
 


### PR DESCRIPTION
Changed the default permissions for the socket files that ceph and haproxy create. The group has the write permission. This is needed so that Telegraf process has permissions  for these socket files even after these services are restarted.

**Testing performed**
Tested this in my lab

