### PR TITLE
added functionality for scheduling nova db archive-deleted-rows

### DIFF
--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -96,3 +96,16 @@ default['bcpc']['nova']['quota']['project']['admin']['gigabytes'] = -1
 #
 default['bcpc']['nova']['vendordata']['name'] = nil
 default['bcpc']['nova']['vendordata']['port'] = 8444
+
+# nova db archive deleted rows
+#
+
+# is nova db archive enabled
+default['bcpc']['nova']['db-archive']['enabled'] = false
+
+# if enabled, what is the schedule to run
+default['bcpc']['nova']['db-archive']['cron_month'] = '*'
+default['bcpc']['nova']['db-archive']['cron_day'] = '*'
+default['bcpc']['nova']['db-archive']['cron_weekday'] = '6'
+default['bcpc']['nova']['db-archive']['cron_hour'] = '4'
+default['bcpc']['nova']['db-archive']['cron_minute'] = '0'

--- a/chef/cookbooks/bcpc/recipes/nova-head.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-head.rb
@@ -405,3 +405,19 @@ execute 'wait for nova to come online' do
   retries 30
   command 'openstack compute service list'
 end
+
+cron 'nova-manage db archive' do
+  action  :create
+  minute  node['bcpc']['nova']['db-archive']['cron_minute']
+  hour    node['bcpc']['nova']['db-archive']['cron_hour']
+  weekday node['bcpc']['nova']['db-archive']['cron_weekday']
+  day     node['bcpc']['nova']['db-archive']['cron_day']
+  month   node['bcpc']['nova']['db-archive']['cron_month']
+  user    'root'
+  command <<-DOC
+    /usr/local/bcpc/bin/if_leader \
+    nova-manage db archive_deleted_rows --until-complete --verbose 2>&1 \
+    | logger -t nova-db-archive-deleted-rows
+  DOC
+  only_if { node['bcpc']['nova']['db-archive']['enabled'] }
+end


### PR DESCRIPTION
**Describe your changes**
Added functionality to archive rows for deleted instances from instance tables in nova database to the shadow tables. Unless someone specifically enables this functionality, it is not enabled by default. So, no changes are applied to the system unless one explicitly enables this functionality in chef.yml file.

**Testing performed**
I have tested these changes in my lab setup (bve), both with this functionality enabled and disabled, though it is left disabled in this commit.

**Additional context**
As instances are deleted, their records are left unnecessarily in the instance tables. Over the period of time, this makes these tables large resulting in performance overheads. Archiving these rows into shadow tables periodically 
