### PR TITLE
Work-around change put in for TTA-2019-002 that prevents VXLAN use by VMs

### DIFF
--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -13,3 +13,14 @@ default['bcpc']['calico']['calicoctl']['remote']['source'] =
  "#{default['bcpc']['web_server']['url']}/calicoctl"
 default['bcpc']['calico']['calicoctl']['remote']['checksum'] =
  '4600d5d7f08ed9cf479fc8fa87518dbbca32a473d0a4a212cfecb610c18216aa'
+
+# calico-felix
+#
+# Although neither VXLAN or IP in IP encapsulation is used here by Calico,
+# the change in https://github.com/projectcalico/felix/pull/2063 to address
+# a security issue (see Tigera Technical Advisory TTA-2019-002) prevents
+# instances from using VXLAN or IP in IP encapsulation themselves. As a
+# work-around for the VXLAN case, an alternate port can be set for Calico
+# to "use" which allows the use of the standard VXLAN port by instances
+# within OpenStack.
+default['bcpc']['calico']['calico-felix']['vxlan_port'] = 9

--- a/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
@@ -45,3 +45,6 @@ FailsafeOutboundHostPorts = tcp:53,udp:53,udp:123,tcp:179,tcp:2379,tcp:2380
 
 # IPv6 support for Felix
 Ipv6Support = false
+
+# Port to use for VXLAN traffic.
+VXLANPort = <%= node['bcpc']['calico']['calico-felix']['vxlan_port'] %>


### PR DESCRIPTION
Although neither VXLAN or IP in IP encapsulation is used here by Calico,
the change in https://github.com/projectcalico/felix/pull/2063 to address
a security issue (see Tigera Technical Advisory TTA-2019-002) prevents
instances from using VXLAN or IP in IP encapsulation themselves. As a
work-around for the VXLAN case, an alternate port can be set for Calico
to "use" which allows the use of the standard VXLAN port by instances
within OpenStack.

Signed-off-by: David Comay <dcomay@bloomberg.net>