### PR TITLE
enable nova's auto converge feature

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
@@ -24,3 +24,4 @@ cpu_model = <%= node['bcpc']['nova']['cpu_config']['cpu_model'] %>
 <% unless node['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'].empty? %>
 cpu_model_extra_flags = <%= node['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'].join(',') %>
 <% end -%>
+live_migration_permit_auto_converge = true


### PR DESCRIPTION
  - from the docs:

    One strategy for a successful live migration of a memory-intensive
    instance is slowing the instance down. This is called
    auto-convergence. Both libvirt and QEMU implement this feature by
    automatically throttling the instance's CPU when memory copy delays
    are detected.