### PR TITLE
Add the --no-install-recommends option to all apt package installs

### DIFF
--- a/chef/cookbooks/bcpc/recipes/apache2.rb
+++ b/chef/cookbooks/bcpc/recipes/apache2.rb
@@ -25,7 +25,9 @@ package %w(
   apache2-utils
   libapache2-mod-fcgid
   libapache2-mod-wsgi
-)
+) do
+  options '--no-install-recommends'
+end
 
 service 'apache2'
 

--- a/chef/cookbooks/bcpc/recipes/calico-work.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-work.rb
@@ -29,6 +29,7 @@ package %w(
   neutron-dhcp-agent
 ) do
   action :upgrade
+  options '--no-install-recommends'
 end
 
 execute 'reload sysctl' do

--- a/chef/cookbooks/bcpc/recipes/ceph-packages.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-packages.rb
@@ -25,4 +25,6 @@ end
 package %w(
   ceph
   ceph-deploy
-)
+) do
+  options '--no-install-recommends'
+end

--- a/chef/cookbooks/bcpc/recipes/common-packages.rb
+++ b/chef/cookbooks/bcpc/recipes/common-packages.rb
@@ -48,7 +48,9 @@ package %w(
   vim
   ksh
   bash-completion
-)
+) do
+  options '--no-install-recommends'
+end
 
 cookbook_file '/etc/screenrc' do
   source 'screen/screenrc'

--- a/chef/cookbooks/bcpc/recipes/common-packages.rb
+++ b/chef/cookbooks/bcpc/recipes/common-packages.rb
@@ -39,6 +39,7 @@ package %w(
   python-six
   python-ldap
   python-configparser
+  python-setuptools
   xinetd
   python-openstackclient
   jq

--- a/chef/cookbooks/bcpc/recipes/etcd3gw.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd3gw.rb
@@ -15,7 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package 'python-futurist'
+package %w(
+  python-futurist
+  python-setuptools
+) do
+  options '--no-install-recommends'
+end
 
 target = node['bcpc']['etcd3gw']['remote_file']['file']
 save_path = "#{Chef::Config[:file_cache_path]}/#{target}"

--- a/chef/cookbooks/bcpc/recipes/etcd3gw.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd3gw.rb
@@ -15,10 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package %w(
-  python-futurist
-  python-setuptools
-) do
+package 'python-futurist' do
   options '--no-install-recommends'
 end
 

--- a/chef/cookbooks/bcpc/recipes/etckeeper.rb
+++ b/chef/cookbooks/bcpc/recipes/etckeeper.rb
@@ -19,7 +19,9 @@
 package %w(
   git
   etckeeper
-)
+) do
+  options '--no-install-recommends'
+end
 
 cookbook_file '/etc/etckeeper/etckeeper.conf' do
   source 'etckeeper/etckeeper.conf'

--- a/chef/cookbooks/bcpc/recipes/glance.rb
+++ b/chef/cookbooks/bcpc/recipes/glance.rb
@@ -124,7 +124,10 @@ end
 package %w(
   glance
   qemu-utils
-)
+) do
+  options '--no-install-recommends'
+end
+
 service 'glance-api'
 service 'haproxy-glance' do
   service_name 'haproxy'

--- a/chef/cookbooks/bcpc/recipes/keystone.rb
+++ b/chef/cookbooks/bcpc/recipes/keystone.rb
@@ -40,7 +40,9 @@ package %w(
   keystone
   python-ldap
   python-ldappool
-)
+) do
+  options '--no-install-recommends'
+end
 
 service 'keystone' do
   service_name 'apache2'

--- a/chef/cookbooks/bcpc/recipes/mysql.rb
+++ b/chef/cookbooks/bcpc/recipes/mysql.rb
@@ -29,7 +29,9 @@ end
 package %w(
   debconf-utils
   percona-xtradb-cluster-57
-)
+) do
+  options '--no-install-recommends'
+end
 
 service 'mysql'
 service 'xinetd'

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -134,9 +134,12 @@ end
 #
 package 'calico-control' do
   action :upgrade
+  options '--no-install-recommends'
 end
 
-package 'neutron-server'
+package 'neutron-server' do
+  options '--no-install-recommends'
+end
 service 'neutron-server'
 
 service 'haproxy-neutron' do

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -34,7 +34,9 @@ package %w(
   ovmf
   pm-utils
   sysfsutils
-)
+) do
+  options '--no-install-recommends'
+end
 
 service 'nova-compute'
 service 'nova-api-metadata'

--- a/chef/cookbooks/bcpc/recipes/nova-head.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-head.rb
@@ -214,7 +214,9 @@ package %w(
   nova-novncproxy
   nova-scheduler
   nova-placement-api
-)
+) do
+  options '--no-install-recommends'
+end
 
 service 'nova-api'
 service 'nova-consoleauth'

--- a/chef/cookbooks/bcpc/recipes/postfix.rb
+++ b/chef/cookbooks/bcpc/recipes/postfix.rb
@@ -25,7 +25,9 @@ end
 package %w(
   bsd-mailx
   postfix
-)
+) do
+  options '--no-install-recommends'
+end
 service 'postfix'
 
 template '/etc/postfix/main.cf' do

--- a/chef/cookbooks/bcpc/recipes/powerdns.rb
+++ b/chef/cookbooks/bcpc/recipes/powerdns.rb
@@ -63,7 +63,9 @@ end
 package %w(
   pdns-server
   pdns-backend-mysql
-)
+) do
+  options '--no-install-recommends'
+end
 service 'pdns'
 
 # remove default pdns.d directory

--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -46,7 +46,9 @@ env['CURL_CA_BUNDLE'] = '' unless node['bcpc']['rally']['ssl_verify']
 package %w(
   virtualenv
   python3-dev
-)
+) do
+  options '--no-install-recommends'
+end
 
 group 'rally'
 


### PR DESCRIPTION
Sample removal of build-essential. I intend to improve, not for merging.