### PR TITLE
Add kexec-tools installation to Ansible steps

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -183,3 +183,8 @@
     - "linux-modules-extra-{{ kernel_version }}-{{ kernel_variant }}"
     # HWE kernel-specific tools are pulled in by {{ version }}-generic metapackages.
     - "linux-tools-{{ kernel_version }}-{{ 'generic' if kernel_variant != 'lowlatency' else 'lowlatency' }}"
+
+# Install kexec-tools
+- name: Install kexec-tools
+  apt:
+    name: kexec-tools


### PR DESCRIPTION
Installing `kexec-tools` early in the deployment process
enables workflows which need to reboot quickly or load
alternative kernels/initrds.
