### PR TITLE
Upgrade to Calico 3.15.3, etcd3gw 0.2.6

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -167,8 +167,8 @@ assets_files:
     filename: etcd-v3.3.10-linux-amd64.tar.gz
 
   - name: calicoctl
-    url: https://github.com/projectcalico/calicoctl/releases/download/v3.15.0/calicoctl-linux-amd64
-    checksum: sha256:4600d5d7f08ed9cf479fc8fa87518dbbca32a473d0a4a212cfecb610c18216aa
+    url: https://github.com/projectcalico/calicoctl/releases/download/v3.15.3/calicoctl-linux-amd64
+    checksum: sha256:ab63a161ad9882b50531cd3835ed7cd090deda8ed18e9b5c3eb6fafebda09574
     filename: calicoctl
 
   - name: consul
@@ -192,9 +192,9 @@ assets_files:
     filename: logrotate-2.2.0.tar.gz
 
   - name: etcd3gw
-    url: https://files.pythonhosted.org/packages/ea/17/a6f33e3681ec7c07b5885a636cf601b03486e7184eb1f419bd99617f6560/etcd3gw-0.2.5.tar.gz
-    checksum: sha256:a382ecbe9c15464d30520a802b9ca1e29cb06fd751393c80389566f1fd8747bf
-    filename: etcd3gw-0.2.5.tar.gz
+    url: https://files.pythonhosted.org/packages/3b/1a/155c139adcf50c382f7ff8eb5a00b5aa725ee8ea438ec2b8109dfe67be9b/etcd3gw-0.2.6.tar.gz
+    checksum: sha256:4a765a382ae18ebd4fccbc1388d1ac5226db0540bccd1f081052600df89145fd
+    filename: etcd3gw-0.2.6.tar.gz
 
 # all file assets
 all_file_assets: "{{ assets_files + additional_assets_files | default([]) }}"

--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -12,15 +12,4 @@ default['bcpc']['calico']['calicoctl']['remote']['file'] = 'calicoctl'
 default['bcpc']['calico']['calicoctl']['remote']['source'] =
  "#{default['bcpc']['web_server']['url']}/calicoctl"
 default['bcpc']['calico']['calicoctl']['remote']['checksum'] =
- '4600d5d7f08ed9cf479fc8fa87518dbbca32a473d0a4a212cfecb610c18216aa'
-
-# calico-felix
-#
-# Although neither VXLAN or IP in IP encapsulation is used here by Calico,
-# the change in https://github.com/projectcalico/felix/pull/2063 to address
-# a security issue (see Tigera Technical Advisory TTA-2019-002) prevents
-# instances from using VXLAN or IP in IP encapsulation themselves. As a
-# work-around for the VXLAN case, an alternate port can be set for Calico
-# to "use" which allows the use of the standard VXLAN port by instances
-# within OpenStack.
-default['bcpc']['calico']['calico-felix']['vxlan_port'] = 9
+ 'ab63a161ad9882b50531cd3835ed7cd090deda8ed18e9b5c3eb6fafebda09574'

--- a/chef/cookbooks/bcpc/attributes/etcd3gw.rb
+++ b/chef/cookbooks/bcpc/attributes/etcd3gw.rb
@@ -3,6 +3,6 @@
 ###############################################################################
 
 default['bcpc']['etcd3gw']['remote_file'] = {
-  'file' => 'etcd3gw-0.2.5.tar.gz',
-  'checksum' => 'a382ecbe9c15464d30520a802b9ca1e29cb06fd751393c80389566f1fd8747bf',
+  'file' => 'etcd3gw-0.2.6.tar.gz',
+  'checksum' => '4a765a382ae18ebd4fccbc1388d1ac5226db0540bccd1f081052600df89145fd',
 }

--- a/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
@@ -46,5 +46,8 @@ FailsafeOutboundHostPorts = tcp:53,udp:53,udp:123,tcp:179,tcp:2379,tcp:2380
 # IPv6 support for Felix
 Ipv6Support = false
 
-# Port to use for VXLAN traffic.
-VXLANPort = <%= node['bcpc']['calico']['calico-felix']['vxlan_port'] %>
+# Set to true to allow VXLAN encapsulated traffic from workloads.
+AllowVXLANPacketsFromWorkloads = true
+
+# Set to true to allow IPIP encapsulated traffic from workloads.
+AllowIPIPPacketsFromWorkloads = true


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

These changes upgrade Calico to 3.15.3 and etcd3gw to 0.2.6. It's been sanity tested with both a 1h1w and 3h6w configurations and verified that both VXLAN and IP-in-IP encapsulation by instances is no longer blocked by Felix.