### PR TITLE
Add a backend optimization var to cinder.conf

### DIFF
--- a/chef/cookbooks/bcpc/attributes/cinder.rb
+++ b/chef/cookbooks/bcpc/attributes/cinder.rb
@@ -7,6 +7,7 @@ default['bcpc']['cinder']['db']['dbname'] = 'cinder'
 default['bcpc']['cinder']['debug'] = false
 default['bcpc']['cinder']['workers'] = nil
 default['bcpc']['cinder']['allow_az_fallback'] = true
+default['bcpc']['cinder']['backend_native_threads_pool_size'] = nil
 default['bcpc']['cinder']['rbd_flatten_volume_from_snapshot'] = true
 default['bcpc']['cinder']['rbd_max_clone_depth'] = 5
 default['bcpc']['cinder']['database']['max_overflow'] = 10

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -347,8 +347,9 @@ cinder_config.backends.each do |backend|
   end
 end
 
-service 'cinder-volume' do
-  action :start
+execute 'make sure cinder-volume comes up' do # ~FC004
+  action :nothing
   retries 30
+  command 'systemctl start cinder-volume'
   not_if 'systemctl status cinder-volume'
 end

--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -22,6 +22,11 @@ enable_v3_api = true
 scheduler_default_filters = <%= @scheduler_default_filters.join(',') %>
 <% end %>
 
+<% if !node['bcpc']['cinder']['backend_native_threads_pool_size'].nil? %>
+[backend_defaults]
+backend_native_threads_pool_size = <%= node['bcpc']['cinder']['backend_native_threads_pool_size'] %>
+
+<% end %>
 [database]
 connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}/#{@db['dbname']}" %>
 max_overflow = <%= node['bcpc']['cinder']['database']['max_overflow'] %>


### PR DESCRIPTION
This PR allows for us to control the value of `cinder`'s
`backend_native_threads_pool_size` via Chef attributes.