### PR TITLE
Update FailsafeInboundHostPorts to allow in-bound BGP & `etcd` connections

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
@@ -35,7 +35,7 @@ UsageReportingEnabled = false
 
 # UDP/TCP/SCTP protocol/port pairs that Felix will allow incoming traffic
 # to host endpoints on irrespective of the security policy.
-FailsafeInboundHostPorts = none
+FailsafeInboundHostPorts = tcp:179,tcp:2379,tcp:2380
 
 # UDP/TCP/SCTP protocol/port pairs that Felix will allow outgoing traffic
 # from host endpoints to irrespective of the security policy.


### PR DESCRIPTION
This addresses an issue seen where the BGP hold timers can expire while Calico is loading policy & sets into the kernel at system startup. We include both port 179 (BGP) as well as ports 2379 & 2380 so that `etcd` is able to communicate with other members before policy has been pushed.