### PR TITLE
Add a RabbitMQ node role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ export playbooks = ansible/playbooks
 export ANSIBLE_CONFIG = ansible/ansible.cfg
 
 headnodes = $$(ansible headnodes -i ${inventory} --list | tail -n +2 | wc -l)
+rmqnodes = $$(ansible rmqnodes -i ${inventory} --list | tail -n +2 | wc -l)
 storagenodes = \
         $$(ansible storagenodes -i ${inventory} --list | tail -n +2 | wc -l)
 
@@ -93,6 +94,7 @@ configure-common-node :
 
 run-chef-client : \
 	run-chef-client-bootstraps \
+	run-chef-client-rmqnodes \
 	run-chef-client-headnodes \
 	run-chef-client-worknodes \
 	run-chef-client-storagenodes
@@ -102,6 +104,22 @@ run-chef-client-bootstraps :
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/site.yml \
 		-t chef-client --limit bootstraps
+
+run-chef-client-rmqnodes :
+
+	@if [ "${rmqnodes}" -gt 0 ]; then \
+		ansible-playbook -v \
+			-i ${inventory} ${playbooks}/site.yml \
+			-t chef-client --limit rmqnodes \
+			-e "step=1"; \
+		\
+		if [ "${rmqnodes}" -gt 1 ]; then \
+			ansible-playbook -v \
+				-i ${inventory} ${playbooks}/site.yml \
+				-t chef-client --limit rmqnodes \
+				-e "step=1"; \
+		fi \
+	fi
 
 run-chef-client-headnodes :
 

--- a/ansible/playbooks/rmqnodes.yml
+++ b/ansible/playbooks/rmqnodes.yml
@@ -1,0 +1,6 @@
+- hosts: rmqnodes
+  gather_facts: no
+  serial: "{{ step | default(ansible_play_batch | length) }}"
+  roles:
+    - common
+    - chef-node

--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -61,7 +61,6 @@ chef_roles:
       - role[node]
       - recipe[bcpc::haproxy]
       - recipe[bcpc::etcd-member]
-      - recipe[bcpc::rabbitmq]
       - recipe[bcpc::memcached]
       - recipe[bcpc::unbound]
       - recipe[bcpc::consul]
@@ -80,6 +79,14 @@ chef_roles:
       - recipe[bcpc::os-quota]
       - recipe[bcpc::flavors]
       - recipe[bcpc::watcher]
+
+  - name: rmqnode
+    description: cloud infrastructure MQ services
+    json_class: Chef::Role
+    chef_type: role
+    run_list:
+      - role[node]
+      - recipe[bcpc::rabbitmq]
 
   - name: node
     description: common role for all bcpc nodes

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,5 +1,6 @@
 - import_playbook: localhost.yml
 - import_playbook: bootstraps.yml
 - import_playbook: headnodes.yml
+- import_playbook: rmqnodes.yml
 - import_playbook: worknodes.yml
 - import_playbook: storagenodes.yml

--- a/chef/cookbooks/bcpc/libraries/utils.rb
+++ b/chef/cookbooks/bcpc/libraries/utils.rb
@@ -26,12 +26,22 @@ def init_cloud?
   nodes.empty?
 end
 
+def init_rmq?
+  nodes = search(:node, 'roles:rmqnode')
+  nodes = nodes.reject { |n| n['hostname'] == node['hostname'] }
+  nodes.empty?
+end
+
 def bootstrap?
   search(:node, "role:bootstrap AND hostname:#{node['hostname']}").any?
 end
 
 def headnode?
   search(:node, "role:headnode AND hostname:#{node['hostname']}").any?
+end
+
+def rmqnode?
+  search(:node, "role:rmqnode AND hostname:#{node['hostname']}").any?
 end
 
 def worknode?
@@ -57,6 +67,21 @@ def headnodes(exclude: nil, all: false)
     nodes = search(:node, 'role:headnode')
   else
     nodes = search(:node, 'roles:headnode')
+  end
+
+  nodes.sort! { |a, b| a['hostname'] <=> b['hostname'] }
+end
+
+def rmqnodes(exclude: nil, all: false)
+  nodes = []
+
+  if !exclude.nil?
+    nodes = search(:node, 'roles:rmqnode')
+    nodes = nodes.reject { |h| h['hostname'] == exclude }
+  elsif all == true
+    nodes = search(:node, 'role:rmqnode')
+  else
+    nodes = search(:node, 'roles:rmqnode')
   end
 
   nodes.sort! { |a, b| a['hostname'] <=> b['hostname'] }

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -271,6 +271,7 @@ template '/etc/cinder/cinder.conf' do
     backends: cinder_config.backends,
     config: config,
     headnodes: headnodes(all: true),
+    rmqnodes: rmqnodes(all: true),
     scheduler_default_filters: cinder_config.filters
   )
 

--- a/chef/cookbooks/bcpc/recipes/glance.rb
+++ b/chef/cookbooks/bcpc/recipes/glance.rb
@@ -224,7 +224,8 @@ template '/etc/glance/glance-api.conf' do
     db: database,
     os: openstack,
     config: config,
-    headnodes: headnodes(all: true)
+    headnodes: headnodes(all: true),
+    rmqnodes: rmqnodes(all: true)
   )
   notifies :restart, 'service[glance-api]', :immediately
 end

--- a/chef/cookbooks/bcpc/recipes/heat.rb
+++ b/chef/cookbooks/bcpc/recipes/heat.rb
@@ -316,6 +316,7 @@ template '/etc/heat/heat.conf' do
     config: config,
     is_headnode: headnode?,
     headnodes: headnodes(all: true),
+    rmqnodes: rmqnodes(all: true),
     vip: node['bcpc']['cloud']['vip']
   )
   notifies :run, 'execute[heat-manage db_sync]', :immediately

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -199,7 +199,8 @@ template '/etc/neutron/neutron.conf' do
     db: database,
     os: openstack,
     config: config,
-    headnodes: headnodes(all: true)
+    headnodes: headnodes(all: true),
+    rmqnodes: rmqnodes(all: true)
   )
   notifies :restart, 'service[neutron-server]', :immediately
 end

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -184,6 +184,7 @@ template '/etc/nova/nova.conf' do
     db: database,
     config: config,
     headnodes: headnodes,
+    rmqnodes: rmqnodes,
     vip: node['bcpc']['cloud']['vip']
   )
   notifies :restart, 'service[nova-compute]', :immediately

--- a/chef/cookbooks/bcpc/recipes/nova-head.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-head.rb
@@ -348,6 +348,7 @@ template '/etc/nova/nova.conf' do
     config: config,
     is_headnode: headnode?,
     headnodes: headnodes(all: true),
+    rmqnodes: rmqnodes(all: true),
     vip: node['bcpc']['cloud']['vip']
   )
 

--- a/chef/cookbooks/bcpc/recipes/rabbitmq.rb
+++ b/chef/cookbooks/bcpc/recipes/rabbitmq.rb
@@ -81,8 +81,8 @@ end
 
 begin
   # add this node to the existing rabbitmq cluster if one exists
-  unless init_cloud?
-    members = headnodes(exclude: node['hostname'])
+  unless init_rmq?
+    members = rmqnodes(exclude: node['hostname'])
 
     hosts = members.collect do |m|
       "rabbit@#{m['hostname']}"
@@ -141,13 +141,13 @@ execute 'set rabbitmq user password' do
   command "rabbitmqctl change_password #{username} #{password}"
 end
 
-# Use n/2+1 queue mirrors as long as we have at least three headnodes.
-# If we have fewer than three headnodes, fallback to ha-all.
-headnodes = headnodes(all: true)
-ha_exactly = { 'ha-mode' => 'exactly', 'ha-params' => headnodes.length / 2 + 1 }
+# Use n/2+1 queue mirrors as long as we have at least three rmqnodes.
+# If we have fewer than three rmqnodes, fallback to ha-all.
+rmqnodes = rmqnodes(all: true)
+ha_exactly = { 'ha-mode' => 'exactly', 'ha-params' => rmqnodes.length / 2 + 1 }
 ha_all = { 'ha-mode': 'all' }
 
-ha_policy = headnodes.length >= 3 ? ha_exactly : ha_all
+ha_policy = rmqnodes.length >= 3 ? ha_exactly : ha_all
 
 execute 'set rabbitmq ha policy' do
   command <<-DOC

--- a/chef/cookbooks/bcpc/recipes/watcher.rb
+++ b/chef/cookbooks/bcpc/recipes/watcher.rb
@@ -180,6 +180,7 @@ template '/etc/watcher/watcher.conf' do
     config: config,
     is_headnode: headnode?,
     headnodes: headnodes(all: true),
+    rmqnodes: rmqnodes(all: true),
     vip: node['bcpc']['cloud']['vip']
   )
   notifies :run, 'execute[watcher-manage db_sync]', :immediately

--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -13,7 +13,7 @@ osapi_volume_workers = <%= node['bcpc']['cinder']['workers'] %>
 osapi_volume_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% end %>
 my_ip = <%= node['service_ip'] %>
-transport_url = rabbit://<%= @headnodes.map {|n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
+transport_url = rabbit://<%= @rmqnodes.map {|n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
 glance_api_servers = <%= "https://#{node['bcpc']['cloud']['fqdn']}:9292" %>
 glance_api_insecure = true
 enabled_backends = <%= @backends.map {|b| b['name']}.join(',') %>

--- a/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
@@ -20,7 +20,7 @@ workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 admin_role = <%= node['bcpc']['keystone']['roles']['admin'] %>
 image_cache_dir = /var/lib/glance/image-cache/
 log_file = /var/log/glance/api.log
-transport_url = rabbit://<%= @headnodes.map{|x| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{x['service_ip']}:5672" }.join(',') %>
+transport_url = rabbit://<%= @rmqnodes.map{|x| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{x['service_ip']}:5672" }.join(',') %>
 image_member_quota = -1
 
 [database]

--- a/chef/cookbooks/bcpc/templates/default/haproxy/haproxy.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/haproxy/haproxy.cfg.erb
@@ -75,7 +75,7 @@ backend rabbitmq-web-backend
   option httpchk GET /
   http-check expect status 200
   reqrep ^([^\ :]*)\ /rabbitmq/(.*) \1\ /\2
-<% @headnodes.each do |n| -%>
+<% @rmqnodes.each do |n| -%>
   server <%= n['hostname'] %> <%= n['service_ip'] %>:55672 check inter 5s rise 1 fall 1
 <% end -%>
 

--- a/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
@@ -23,7 +23,7 @@ num_engine_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 # oslo_messaging.TransportURL at
 # https://docs.openstack.org/oslo.messaging/latest/reference/transport.html
 # (string value)
-transport_url = rabbit://<%= @headnodes.map{|n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
+transport_url = rabbit://<%= @rmqnodes.map{|n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
 
 
 [clients_keystone]

--- a/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
@@ -3,7 +3,7 @@ debug = false
 core_plugin = calico
 bind_host = <%= node['service_ip'] %>
 auth_strategy = keystone
-transport_url = rabbit://<%= @headnodes.map{ |n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
+transport_url = rabbit://<%= @rmqnodes.map{ |n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
 state_path = /var/lib/neutron
 <% if node['bcpc']['neutron']['workers'] %>
 api_workers = <%= node['bcpc']['neutron']['workers'] %>

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -24,7 +24,7 @@ sync_power_state_interval = <%= node['bcpc']['nova']['sync_power_state_interval'
 send_arp_for_ha = true
 state_path = /var/lib/nova
 
-transport_url = rabbit://<%= @headnodes.map{|n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
+transport_url = rabbit://<%= @rmqnodes.map{|n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
 
 <% if @is_headnode -%>
 osapi_compute_link_prefix = <%= "https://#{node["bcpc"]['cloud']["fqdn"]}:8774" %>

--- a/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
@@ -1,6 +1,6 @@
 [DEFAULT]
 control_exchange = watcher
-transport_url = rabbit://<%= @headnodes.map{|n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
+transport_url = rabbit://<%= @rmqnodes.map{|n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
 
 [api]
 bind_host = <%= node['service_ip'] %>

--- a/virtual/network/bird/network.conf
+++ b/virtual/network/bird/network.conf
@@ -115,6 +115,17 @@ protocol bgp 'tor1:r1n3' {
         };
 }
 
+protocol bgp 'tor1:r1n4' {
+        local as 4200858701;
+        neighbor 10.121.84.6 as 4200858801;
+        hold time 3;
+        keepalive time 1;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
+}
+
 protocol bgp 'tor2:r2n1' {
         local as 4200858703;
         neighbor 10.121.85.3 as 4200858801;
@@ -137,9 +148,20 @@ protocol bgp 'tor2:r2n2' {
         };
 }
 
-protocol bgp 'tor2:r3n3' {
+protocol bgp 'tor2:r2n3' {
         local as 4200858703;
         neighbor 10.121.85.5 as 4200858801;
+        hold time 3;
+        keepalive time 1;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'tor2:r2n4' {
+        local as 4200858703;
+        neighbor 10.121.85.6 as 4200858801;
         hold time 3;
         keepalive time 1;
         ipv4 {
@@ -173,6 +195,17 @@ protocol bgp 'tor3:r3n2' {
 protocol bgp 'tor3:r3n3' {
         local as 4200858705;
         neighbor 10.121.86.5 as 4200858801;
+        hold time 3;
+        keepalive time 1;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'tor3:r3n4' {
+        local as 4200858705;
+        neighbor 10.121.86.6 as 4200858801;
         hold time 3;
         keepalive time 1;
         ipv4 {

--- a/virtual/network/bird/tor1.conf
+++ b/virtual/network/bird/tor1.conf
@@ -134,3 +134,14 @@ protocol bgp 'tor1:r1n3' {
                 import filter hypervisors;
         };
 }
+
+protocol bgp 'tor1:r1n4' {
+        local as 4200858701;
+        neighbor 10.121.84.6 as 4200858801;
+        hold time 3;
+        keepalive time 1;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
+}

--- a/virtual/network/bird/tor2.conf
+++ b/virtual/network/bird/tor2.conf
@@ -113,9 +113,20 @@ protocol bgp 'tor2:r2n2' {
         };
 }
 
-protocol bgp 'tor2:r3n3' {
+protocol bgp 'tor2:r2n3' {
         local as 4200858703;
         neighbor 10.121.85.5 as 4200858801;
+        hold time 3;
+        keepalive time 1;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'tor2:r2n4' {
+        local as 4200858703;
+        neighbor 10.121.85.6 as 4200858801;
         hold time 3;
         keepalive time 1;
         ipv4 {

--- a/virtual/network/bird/tor3.conf
+++ b/virtual/network/bird/tor3.conf
@@ -123,3 +123,14 @@ protocol bgp 'tor3:r3n3' {
                 import filter hypervisors;
         };
 }
+
+protocol bgp 'tor3:r3n4' {
+        local as 4200858705;
+        neighbor 10.121.86.6 as 4200858801;
+        hold time 3;
+        keepalive time 1;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
+}

--- a/virtual/topology/1h1w1r.yml
+++ b/virtual/topology/1h1w1r.yml
@@ -47,7 +47,6 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
-        - role[rmqnode]
         - role[headnode]
 
   - host: r1n2
@@ -77,3 +76,28 @@ nodes:
         - role[storagenode]
         - role[worknode]
       zone: dev
+
+  - host: r1n3
+    group: rmqnodes
+    hardware_profile: headnode
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.4
+        transit:
+          - ip: 10.121.84.5/28
+            mac: '08:00:27:00:00:16'
+            neighbor:
+              ip: 10.121.84.1
+              asn: 4200858701
+              name: management1
+          - ip: 10.121.88.5/28
+            mac: '08:00:27:00:00:17'
+            neighbor:
+              ip: 10.121.88.1
+              asn: 4200858702
+              name: management4
+      run_list:
+        - role[rmqnode]

--- a/virtual/topology/1h1w1s.yml
+++ b/virtual/topology/1h1w1s.yml
@@ -47,6 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
+        - role[rmqnode]
         - role[headnode]
 
   - host: r1n2

--- a/virtual/topology/1h2w.yml
+++ b/virtual/topology/1h2w.yml
@@ -47,6 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
+        - role[rmqnode]
         - role[headnode]
 
   - host: r1n2

--- a/virtual/topology/3h3w.yml
+++ b/virtual/topology/3h3w.yml
@@ -47,6 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
+        - role[rmqnode]
         - role[headnode]
 
   - host: r1n2
@@ -100,6 +101,7 @@ nodes:
               asn: 4200858704
               name: management5
       run_list:
+        - role[rmqnode]
         - role[headnode]
 
   - host: r2n2
@@ -153,6 +155,7 @@ nodes:
               asn: 4200858706
               name: management6
       run_list:
+        - role[rmqnode]
         - role[headnode]
 
   - host: r3n2

--- a/virtual/topology/3h3w3r.yml
+++ b/virtual/topology/3h3w3r.yml
@@ -47,7 +47,6 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
-        - role[rmqnode]
         - role[headnode]
 
   - host: r1n2
@@ -79,10 +78,9 @@ nodes:
       zone: dev
 
   - host: r1n3
-    group: worknodes
-    hardware_profile: worknode
+    group: rmqnodes
+    hardware_profile: headnode
     host_vars:
-      aggregate: dev-1
       bgp:
         asn: 4200858801
       interfaces:
@@ -102,9 +100,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
-        - role[storagenode]
-        - role[worknode]
-      zone: dev
+        - role[rmqnode]
 
   - host: r2n1
     group: headnodes
@@ -129,7 +125,6 @@ nodes:
               asn: 4200858704
               name: management5
       run_list:
-        - role[rmqnode]
         - role[headnode]
 
   - host: r2n2
@@ -161,10 +156,9 @@ nodes:
       zone: dev
 
   - host: r2n3
-    group: worknodes
-    hardware_profile: worknode
+    group: rmqnodes
+    hardware_profile: headnode
     host_vars:
-      aggregate: dev-2
       bgp:
         asn: 4200858801
       interfaces:
@@ -184,9 +178,7 @@ nodes:
               asn: 4200858704
               name: management5
       run_list:
-        - role[storagenode]
-        - role[worknode]
-      zone: dev
+        - role[rmqnode]
 
   - host: r3n1
     group: headnodes
@@ -211,7 +203,6 @@ nodes:
               asn: 4200858706
               name: management6
       run_list:
-        - role[rmqnode]
         - role[headnode]
 
   - host: r3n2
@@ -243,10 +234,9 @@ nodes:
       zone: dev
 
   - host: r3n3
-    group: worknodes
-    hardware_profile: worknode
+    group: rmqnodes
+    hardware_profile: headnode
     host_vars:
-      aggregate: dev-3
       bgp:
         asn: 4200858801
       interfaces:
@@ -266,6 +256,4 @@ nodes:
               asn: 4200858706
               name: management6
       run_list:
-        - role[storagenode]
-        - role[worknode]
-      zone: dev
+        - role[rmqnode]


### PR DESCRIPTION
Add a 'rmqnode' role, thereby enabling operators to build
"headnodes" which only run RabbitMQ, and no other headnode
services.