### PR TITLE
Add props to configure neutron's DB pool size

### DIFF
--- a/chef/cookbooks/bcpc/attributes/neutron.rb
+++ b/chef/cookbooks/bcpc/attributes/neutron.rb
@@ -35,3 +35,7 @@ default['bcpc']['neutron']['quota']['default']['quota_floatingip'] = 0
 
 # per-project quota settings
 default['bcpc']['neutron']['quota']['project']['admin']['rbac-policies'] = -1
+
+# database connection pool settings
+default['bcpc']['neutron']['db']['max_pool_size'] = 64
+default['bcpc']['neutron']['db']['max_overflow'] = 128

--- a/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
@@ -28,6 +28,8 @@ etcd_key_file = <%= node['bcpc']['etcd']['client-rw']['key']['filepath'] %>
 
 [database]
 connection = mysql+pymysql://<%= "#{@db['username']}:#{@db['password']}@#{node['bcpc']['mysql']['host']}/#{@db['dbname']}" %>
+max_pool_size = <%= node['bcpc']['neutron']['db']['max_pool_size'] %>
+max_overflow = <%= node['bcpc']['neutron']['db']['max_overflow'] %>
 
 [keystone_authtoken]
 auth_uri = <%= "https://#{node['bcpc']['cloud']['fqdn']}:5000" %>


### PR DESCRIPTION
Added properties to allow users to configure neutron's backend DB pool
size. The default values of these properties have also been increased
from 5 (pool size) and 50 (overflow) to 50 and 150, respectively.

**Testing performed**
Tested on my local 3h3w BVE set up; tempest tests no longer fail due to the neutron db backend running out of connections.
