### PR TITLE
Makefile: Run node role runlists in parallel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,17 @@ configure-chef-nodes :
 		-t chef-node --limit cloud
 
 run-chef-client : \
+	run-chef-client-node-role \
 	run-chef-client-bootstraps \
 	run-chef-client-headnodes \
 	run-chef-client-worknodes \
 	run-chef-client-storagenodes
+
+run-chef-client-node-role :
+
+	ansible -v \
+		-i ${inventory} cloud \
+		-ba 'chef-client -o role[node]'
 
 run-chef-client-bootstraps :
 


### PR DESCRIPTION
All host runlists include the runlist of role[node]. For
a small build time improvement, run role[node]'s runlist
on all nodes in parallel before stepping through the
roles one-by-one.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>