### PR TITLE
getty: Disable previous ttyS[01] functionality.

### DIFF
--- a/chef/cookbooks/bcpc/recipes/getty.rb
+++ b/chef/cookbooks/bcpc/recipes/getty.rb
@@ -19,6 +19,6 @@
 
 node['bcpc']['getty']['ttys'].each do |ttyname|
   systemd_unit "getty@#{ttyname}.service" do
-    action %i(enable start)
+    action %i(disable stop)
   end
 end


### PR DESCRIPTION
This was observed to not work on all platforms as-is
and causes a lot of log churn as getty@* will restart
constantly if the ttys do not exist or the device files
do not resemble ttys.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>