### PR TITLE
cinder.rb: add delay before restart

### DIFF
--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -295,9 +295,17 @@ if zone_config.enabled?
       fi
 
       if ! grep AccessFilter ${entry_points_txt}; then
+
+        # update entry points file using crudini
         crudini --set ${entry_points_txt} cinder.scheduler.filters \
           AccessFilter cinder.scheduler.filters.access_filter:AccessFilter
+
+        # sleep for a brief moment before restarting cinder-scheduler
+        sleep 10
+
+        # restart cinder-scheduler
         systemctl restart cinder-scheduler
+
       fi
     EOH
   end


### PR DESCRIPTION
  - add a 10 second sleep between updating the entry_points.txt file and
    restarting cinder-scheduler to avoid putting the service into a
    failed state due to frequent service restarts during its
    installation
