### PR TITLE
ansible.cfg: reduce possible forks

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 deprecation_warnings = False
-forks = 256
+forks = 128
 stdout_callback = debug
 stderr_callback = debug
 


### PR DESCRIPTION
  - reduced the amount of forks to 128 to increase the likelihood of a
    successful execution with chef-client related operations
