### PR TITLE
chef: Add etcd/calico-felix node's to run_list.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ all : \
 	configure-chef-workstation \
 	configure-chef-nodes \
 	configure-web-server \
+	configure-common-node \
 	run-chef-client \
 	reweight-ceph-osds \
 	add-cloud-images \
@@ -84,18 +85,17 @@ configure-chef-nodes :
 		-i ${inventory} ${playbooks}/site.yml \
 		-t chef-node --limit cloud
 
+configure-common-node :
+
+	ansible-playbook -v \
+		-i ${inventory} ${playbooks}/configure-common-node.yml \
+		--limit cloud
+
 run-chef-client : \
-	run-chef-client-node-role \
 	run-chef-client-bootstraps \
 	run-chef-client-headnodes \
 	run-chef-client-worknodes \
 	run-chef-client-storagenodes
-
-run-chef-client-node-role :
-
-	ansible -v \
-		-i ${inventory} cloud \
-		-ba 'chef-client -o role[node]'
 
 run-chef-client-bootstraps :
 

--- a/ansible/playbooks/configure-common-node.yml
+++ b/ansible/playbooks/configure-common-node.yml
@@ -1,0 +1,31 @@
+# When we bring-up a new cluster, there are some circular dependencies that
+# present themselves (depending on how roles are broken out).  This playbook
+# attempts to resolve those dependencies before chef is used to converge
+# each node so that things go smoothly.
+#
+# The list of dependencies we resolve in configure-web-server [1] and here [2]:
+#   * [1] etcd requires bcpc::web-server (to obtain packages)
+#   * [2] etcd-proxy (non-headnodes) requires etcd (headnodes)
+#   * [2] calico-felix requires etcd-proxy or etcd-member
+#
+# In the future, we should move Consul, etcd, etc. out of Chef and into
+# Ansible so these dependencies can be resolved more elegantly.
+- hosts: headnodes
+  gather_facts: no
+  become: yes
+  order: inventory
+  tasks:
+    - name: provision the first etcd server
+      become: true
+      command: chef-client -o bcpc::etcd-member
+      run_once: true
+      changed_when: false
+
+- hosts: cloud
+  gather_facts: no
+  become: yes
+  tasks:
+    - name: run chef-client with role[node]'s run_list
+      become: true
+      command: chef-client -o role[node]
+      changed_when: false

--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -52,8 +52,6 @@ chef_roles:
       - recipe[bcpc::ufw]
       - recipe[bcpc::rally]
       - recipe[bcpc::rally-deploy]
-      - recipe[bcpc::etcd-proxy]
-      - recipe[bcpc::calico-felix]
 
   - name: headnode
     description: cloud infrastructure services
@@ -63,7 +61,6 @@ chef_roles:
       - role[node]
       - recipe[bcpc::haproxy]
       - recipe[bcpc::etcd-member]
-      - recipe[bcpc::calico-felix]
       - recipe[bcpc::rabbitmq]
       - recipe[bcpc::memcached]
       - recipe[bcpc::unbound]
@@ -100,6 +97,8 @@ chef_roles:
       - recipe[bcpc::cpupower]
       - recipe[bcpc::getty]
       - recipe[bcpc::hwrng]
+      - recipe[bcpc::etcd-proxy]
+      - recipe[bcpc::calico-felix]
 
   - name: storagenode
     description: storage node
@@ -107,8 +106,6 @@ chef_roles:
     chef_type: role
     run_list:
       - role[node]
-      - recipe[bcpc::etcd-proxy]
-      - recipe[bcpc::calico-felix]
       - recipe[bcpc::ceph-osd]
 
   - name: worknode
@@ -117,8 +114,6 @@ chef_roles:
     chef_type: role
     run_list:
       - role[node]
-      - recipe[bcpc::etcd-proxy]
-      - recipe[bcpc::calico-felix]
       - recipe[bcpc::calico-work]
       - recipe[bcpc::nova-compute]
 

--- a/ansible/playbooks/roles/web-server/tasks/chef-web-server.yml
+++ b/ansible/playbooks/roles/web-server/tasks/chef-web-server.yml
@@ -1,0 +1,4 @@
+- name: provision the bootstraps' web-servers
+  become: true
+  command: chef-client -o bcpc::web-server
+  changed_when: false

--- a/ansible/playbooks/roles/web-server/tasks/web-server.yml
+++ b/ansible/playbooks/roles/web-server/tasks/web-server.yml
@@ -7,3 +7,5 @@
 
 - include: upload-web-server-file.yml
   with_items: "{{ all_web_server_assets }}"
+
+- include: chef-web-server.yml

--- a/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: etcd-proxy
 #
-# Copyright:: 2019 Bloomberg Finance L.P.
+# Copyright:: 2020 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Headnodes have etcd-member and don't need etcd-proxy.
+return if headnode?
 
 include_recipe 'bcpc::etcd-packages'
 include_recipe 'bcpc::etcd-ssl'


### PR DESCRIPTION
Every BCPC node runs `calico-felix` for policy enforcement,
which itself requires an etcd connection for policy to be
obtained.  Headnodes obtain an etcd connection by virtue
that they are the etcd members.  All othernodes require an
`etcd-proxy` service.
    
Add a recipe which installs `etcd-proxy` on all non-
headnodes, and amend the cluster bootstrapping process
so that prereqs for both `etcd-proxy` and `calico-felix`
come up very early.  Finally, add both `etcd-proxy` and
`calico-felix` to `role[node]`'s run_list.