### PR TITLE
chef: Check-in missed file from rmqnodes PR.

### DIFF
--- a/chef/cookbooks/bcpc/recipes/haproxy.rb
+++ b/chef/cookbooks/bcpc/recipes/haproxy.rb
@@ -65,6 +65,7 @@ template '/etc/haproxy/haproxy.cfg' do
   variables(
     user: config['haproxy'],
     headnodes: headnodes(all: true),
+    rmqnodes: rmqnodes(all: true),
     vip: node['bcpc']['cloud']['vip']
   )
   notifies :reload, 'service[haproxy]', :immediately


### PR DESCRIPTION
Forgot to check-in a file; the `haproxy` template was
edited to reference the `rmqnodes`, but the variable needs
to be defined in the recipe as well.