### PR TITLE
Adding SSH to the Failsafe ruleset

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
@@ -35,7 +35,7 @@ UsageReportingEnabled = false
 
 # UDP/TCP/SCTP protocol/port pairs that Felix will allow incoming traffic
 # to host endpoints on irrespective of the security policy.
-FailsafeInboundHostPorts = tcp:179,tcp:2379,tcp:2380
+FailsafeInboundHostPorts = tcp:22,tcp:179,tcp:2379,tcp:2380
 
 # UDP/TCP/SCTP protocol/port pairs that Felix will allow outgoing traffic
 # from host endpoints to irrespective of the security policy.


### PR DESCRIPTION
Adding SSH(22) to the failsafe to protect against empty/bad ETCd causing endpoint isoloation.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
