### PR TITLE
Add SSH to the failsafe rule set

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
@@ -35,7 +35,7 @@ UsageReportingEnabled = false
 
 # UDP/TCP/SCTP protocol/port pairs that Felix will allow incoming traffic
 # to host endpoints on irrespective of the security policy.
-FailsafeInboundHostPorts = tcp:179,tcp:2379,tcp:2380
+FailsafeInboundHostPorts = tcp:22,tcp:179,tcp:2379,tcp:2380
 
 # UDP/TCP/SCTP protocol/port pairs that Felix will allow outgoing traffic
 # from host endpoints to irrespective of the security policy.


### PR DESCRIPTION
Adding ssh to the failsafe ruleset to add protection from an empty or bad ETCd

