### PR TITLE
`calico-felix` starts without TLS information in place for `etcd`

### DIFF
--- a/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
@@ -15,11 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Headnodes have etcd-member and don't need etcd-proxy.
-return if headnode?
-
 include_recipe 'bcpc::etcd-packages'
 include_recipe 'bcpc::etcd-ssl'
+
+# Headnodes have etcd-member and don't need etcd-proxy.
+return if headnode?
 
 service 'etcd'
 


### PR DESCRIPTION
Tested by building a `3h3w` configuration and verifying that `calico-felix` on all nodes (and in particular, the second and third head nodes) was able to connect to `etcd`.