### PR TITLE
nova-compute: Avoid rendering of invalid config

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
@@ -18,10 +18,12 @@ live_migration_uri = qemu+ssh://nova@%s/system
 <% unless node['bcpc']['nova']['cpu_config']['cpu_mode'].nil? %>
 cpu_mode = <%= node['bcpc']['nova']['cpu_config']['cpu_mode'] %>
 <% end -%>
+<% unless node['bcpc']['nova']['cpu_config']['cpu_mode'].nil? or node['bcpc']['nova']['cpu_config']['cpu_mode'] =~ %r"^host-" %>
 <% unless node['bcpc']['nova']['cpu_config']['cpu_model'].nil? %>
 cpu_model = <%= node['bcpc']['nova']['cpu_config']['cpu_model'] %>
 <% end -%>
 <% unless node['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'].empty? %>
 cpu_model_extra_flags = <%= node['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'].join(',') %>
+<% end -%>
 <% end -%>
 live_migration_permit_auto_converge = true


### PR DESCRIPTION
If cpu_mode is host-(model|passthrough), then cpu_model
should be disregarded; otherwise, one would have requested
a "custom" CPU model or not specified to use the hosts'
configuration.

In fact, `nova` throws an exception during scheduling if
the `nova-compute` specifies `cpu_model` when `cpu_mode`
is one of host-model, host-passthrough:

```
Invalid: A CPU model name should not be set when a host CPU
model is requested
```

Thus, even if the chef-databag specifies this invalid
set of parameters, this commit ensures that the resulting
config will not result in scheduling efforts (by prefering
the host CPU mode configuration item).

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>