### PR TITLE
various linting fixes

### DIFF
--- a/.travis/run_linters.sh
+++ b/.travis/run_linters.sh
@@ -1,5 +1,19 @@
 #!/bin/bash -x
 
+# Copyright 2021, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -ev
 
 function main {
@@ -7,7 +21,7 @@ function main {
     find . -name "*.sh" -exec bashate -e E006 {} \;
     find . -name "*.py" -exec flake8 {} \;
     find ansible -name "*.yml" -exec ansible-lint -x 503 {} \;
-    foodcritic chef/cookbooks
+    foodcritic chef/cookbooks --tags -FC004
     cookstyle .
 }
 

--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -194,6 +194,7 @@
   command: grep -q AuthenticAMD /proc/cpuinfo
   ignore_errors: true
   register: is_amd
+  changed_when: false
 
 - name: Install amd64-microcode package
   apt:
@@ -214,6 +215,7 @@
   command: grep -q GenuineIntel /proc/cpuinfo
   ignore_errors: true
   register: is_intel
+  changed_when: false
 
 - name: Install intel-microcode package
   apt:

--- a/chef/cookbooks/bcpc/.rubocop.yml
+++ b/chef/cookbooks/bcpc/.rubocop.yml
@@ -1,9 +1,3 @@
-ChefModernize/ExecuteSysctl:
-  Enabled: false
-
-ChefModernize/FoodcriticComments:
-  Enabled: false
-
 Style/RedundantBegin:
   Enabled: false
 

--- a/chef/cookbooks/bcpc/attributes/mysql.rb
+++ b/chef/cookbooks/bcpc/attributes/mysql.rb
@@ -35,4 +35,3 @@ default['bcpc']['mysql']['slow_query_log'] = true
 default['bcpc']['mysql']['slow_query_log_file'] = '/var/log/mysql/slow.log'
 default['bcpc']['mysql']['long_query_time'] = 10
 default['bcpc']['mysql']['log_queries_not_using_indexes'] = false
-

--- a/chef/cookbooks/bcpc/attributes/powerdns.rb
+++ b/chef/cookbooks/bcpc/attributes/powerdns.rb
@@ -30,4 +30,3 @@ default['bcpc']['powerdns']['soa-ttl']['refresh'] = 600
 default['bcpc']['powerdns']['soa-ttl']['retry'] = 300
 default['bcpc']['powerdns']['soa-ttl']['expiry'] = 86400
 default['bcpc']['powerdns']['soa-ttl']['nx'] = 120
-

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: cinder
 #
-# Copyright:: 2020 Bloomberg Finance L.P.
+# Copyright:: 2021 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -356,7 +356,7 @@ cinder_config.backends.each do |backend|
   end
 end
 
-execute 'make sure cinder-volume comes up' do # ~FC004
+execute 'make sure cinder-volume comes up' do
   action :nothing
   retries 30
   command 'systemctl start cinder-volume'

--- a/virtual/network/provisioner.sh
+++ b/virtual/network/provisioner.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020, Bloomberg Finance L.P.
+# Copyright 2021, Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ set -eux
 on_edge_flag=0
 
 DHCP_CONF='      dhcp4: true'
+# shellcheck disable=SC1004
 STATIC_CONF='      addresses:\n        - 10.0.2.15/24\n      nameservers:\
         addresses:\n          - 10.0.2.3'
 
@@ -55,7 +56,7 @@ base_config() {
     else
         sudo dhclient -x
         sed "s|${DHCP_CONF}|${STATIC_CONF}|" \
-          "/vagrant/netplan/${1}.yaml" | sudo tee /etc/netplan/01-netcfg.yaml
+            "/vagrant/netplan/${1}.yaml" | sudo tee /etc/netplan/01-netcfg.yaml
     fi
     sudo netplan apply
     sudo systemctl restart lldpd


### PR DESCRIPTION
  - run_linters.sh
    - added copyright
    - updated foodcritic invocation to ignore FC004
      - FC004: Use a service resource to start and stop services
  - configure-system
    - added numerous changed_when: false statements
  - .rubocop.yml
    - removed deprecated namespaces
  - cinder.rb
    - removed deprecated inline foodcritic ignore syntax

Signed-off-by: Justin Pacheco <jpacheco39@bloomberg.net>