### PR TITLE
Add a library function to fetch chef roles

### DIFF
--- a/chef/cookbooks/bcpc/libraries/utils.rb
+++ b/chef/cookbooks/bcpc/libraries/utils.rb
@@ -106,6 +106,13 @@ def all_nodes
   nodes.sort! { |a, b| a['hostname'] <=> b['hostname'] }
 end
 
+def node_roles
+  matches = search(:node, "hostname:#{node['hostname']}")
+  raise "the node '#{node['hostname']}' does not exist or has "\
+    'multiple matches' if matches.length != 1
+  matches[0]['roles']
+end
+
 def generate_service_catalog_uri(svcprops, access_level)
   fqdn = node['bcpc']['cloud']['fqdn']
   port = svcprops['ports'][access_level]


### PR DESCRIPTION
Make it easier to fetch the chef roles implemented by a given node.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
Added a chef library function that returns an array of chef roles implemented by the given node.

**Testing performed**
The added function was tested manually via chef-shell and through its use in internal chef recipes.

**Additional context**
N/A
