### PR TITLE
Improve multihead build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ run-chef-client-rmqnodes :
 			ansible-playbook -v \
 				-i ${inventory} ${playbooks}/site.yml \
 				-t chef-client --limit rmqnodes \
-				-e "step=1"; \
 		fi \
 	fi
 
@@ -133,7 +132,6 @@ run-chef-client-headnodes :
 		ansible-playbook -v \
 			-i ${inventory} ${playbooks}/site.yml \
 			-t chef-client --limit headnodes \
-			-e "step=1"; \
 	fi
 
 run-chef-client-worknodes :


### PR DESCRIPTION
3h3w3r took ~70 minutes before this commit, ~61 minutes
afterwards.

While there are reasons to serially do passes around the
headnodes on the first build, subsequent builds can
leverage existing roles and have their client runs
performed in parallel.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>