### PR TITLE
Libvirt apt cache

### DIFF
--- a/virtual/Vagrantfile.libvirt
+++ b/virtual/Vagrantfile.libvirt
@@ -48,12 +48,6 @@ def load_hardware
   end
 end
 
-def mount_apt_cache(config)
-  user_data_path = Vagrant.user_data_path.to_s
-  cache_dir = File.join(user_data_path, 'cache', 'apt', config.vm.box)
-  apt_cache_dir = '/var/cache/apt/archives'
-  config.vm.synced_folder cache_dir, apt_cache_dir, create: true, type: '9p'
-end
 
 topology = load_topology
 hardware = load_hardware
@@ -76,8 +70,7 @@ Vagrant.configure('2') do |config|
       if ENV['BCC_LIBVIRT_KVM_HUGEPAGES'] == 'true'
         lv.memorybacking :hugepages
       end
-      config.vm.synced_folder './', '/vagrant', type: '9p'
-      #mount_apt_cache(config)
+      Util.mount_apt_cache(config)
     end
   end
 


### PR DESCRIPTION
libvirt build had the apt cache commented out

**Describe your changes**
Remove unused code for apt cache. Adopt apt cache method used in virtualbox build

**Testing performed**
After making this change I was able to successfully perform make create to get the network vm and several cluster members VMs as normal.
