### PR TITLE
clean up Libvirt apt cache

### DIFF
--- a/virtual/Vagrantfile.libvirt
+++ b/virtual/Vagrantfile.libvirt
@@ -48,12 +48,6 @@ def load_hardware
   end
 end
 
-def mount_apt_cache(config)
-  user_data_path = Vagrant.user_data_path.to_s
-  cache_dir = File.join(user_data_path, 'cache', 'apt', config.vm.box)
-  apt_cache_dir = '/var/cache/apt/archives'
-  config.vm.synced_folder cache_dir, apt_cache_dir, create: true, type: '9p'
-end
 
 topology = load_topology
 hardware = load_hardware
@@ -77,7 +71,6 @@ Vagrant.configure('2') do |config|
         lv.memorybacking :hugepages
       end
       config.vm.synced_folder './', '/vagrant', type: '9p'
-      #mount_apt_cache(config)
     end
   end
 

--- a/virtual/network/Vagrantfile.libvirt
+++ b/virtual/network/Vagrantfile.libvirt
@@ -27,13 +27,6 @@ def setup_proxy(node)
                              args: [http_proxy, https_proxy]
 end
 
-def mount_apt_cache(config)
-  user_data_path = Vagrant.user_data_path.to_s
-  cache_dir = File.join(user_data_path, 'cache', 'apt', config.vm.box)
-  apt_cache_dir = '/var/cache/apt/archives'
-  config.vm.synced_folder cache_dir, apt_cache_dir, create: true, type: '9p'
-end
-
 def load_network
   # load the network topology
   network = './netplan/network.yaml'
@@ -61,11 +54,10 @@ Vagrant.configure(2) do |config|
       lv.driver = 'kvm'
       lv.nested = true
       lv.cpu_mode = 'host-passthrough'
-      config.vm.synced_folder './', '/vagrant', type: '9p'
       if ENV['BCC_LIBVIRT_KVM_HUGEPAGES'] == 'true'
         lv.memorybacking :hugepages
       end
-      #mount_apt_cache(config)
+      config.vm.synced_folder './', '/vagrant', type: '9p'
     end
     lv.cpus = 1
     lv.memory = 1024


### PR DESCRIPTION
Just tidies up the code, no real change to operational behavior.

A previous way of having an apt cache was left in the code but disabled/not used, which lead to the common assumption that the libvirt build path had no apt cache, however it was working all the time. This just removes the confusing inoperative code.