### PR TITLE
Disable rally by default

### DIFF
--- a/chef/cookbooks/bcpc/attributes/rally.rb
+++ b/chef/cookbooks/bcpc/attributes/rally.rb
@@ -2,7 +2,7 @@
 # rally
 ###############################################################################
 
-default['bcpc']['rally']['enabled'] = true
+default['bcpc']['rally']['enabled'] = false
 default['bcpc']['rally']['rally_openstack']['version'] = '1.6.0'
 default['bcpc']['rally']['rally']['version'] = '2.1.0'
 default['bcpc']['rally']['ssl_verify'] = false


### PR DESCRIPTION
Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
Rally is no longer installed by default.

**Testing performed**
An existing installation was updated with the new configuration and all rally-related automation was skipped as expected. No other components rely on rally.
