### PR TITLE
Update QoS to help debug internal issue

### DIFF
--- a/chef/cookbooks/bcpc/attributes/haproxy.rb
+++ b/chef/cookbooks/bcpc/attributes/haproxy.rb
@@ -14,6 +14,9 @@ default['bcpc']['haproxy']['qos']['enabled'] = false
 # The amount of time to wait for HTTP headers to be sent
 default['bcpc']['haproxy']['qos']['http_request_timeout'] = '5s'
 
+# The amount of time to wait for another HTTP request to be received
+default['bcpc']['haproxy']['qos']['http_keep_alive_timeout'] = '10s'
+
 # The maximum number of entries in the stick table
 default['bcpc']['haproxy']['qos']['max_entries'] = '1m'
 

--- a/chef/cookbooks/bcpc/templates/default/haproxy/haproxy.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/haproxy/haproxy.cfg.erb
@@ -22,8 +22,10 @@ defaults
   retries 3
 <% if node['bcpc']['haproxy']['qos']['enabled'] %>
   timeout http-request <%= node['bcpc']['haproxy']['qos']['http_request_timeout'] %>
+  timeout http-keep-alive <%= node['bcpc']['haproxy']['qos']['http_keep_alive_timeout'] %>
 <% else %>
   timeout http-request 10s
+  timeout http-keep-alive 10s
 <% end %>
   timeout queue 1m
   timeout connect 5s


### PR DESCRIPTION
This commit addresses the following:
- rolls back the http timeout from 5 back to 10
- adds 127.0.0.1 to the QoS exemption list
- updates the 429.http file to contain proper line endings as per the
relevant RFCs
- print the SLO url instead of using html markup; most clients will
encounter this error when using the openstack client and thus the html
markup will not render properly

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See the commit message above.

**Testing performed**
Tested on a BVE.
