### PR TITLE
Apply various QoS-related improvements

### DIFF
--- a/chef/cookbooks/bcpc/attributes/haproxy.rb
+++ b/chef/cookbooks/bcpc/attributes/haproxy.rb
@@ -12,7 +12,7 @@ default['bcpc']['haproxy']['apt']['url'] = 'http://ppa.launchpad.net/vbernat/hap
 default['bcpc']['haproxy']['qos']['enabled'] = false
 
 # The amount of time to wait for HTTP headers to be sent
-default['bcpc']['haproxy']['qos']['http_request_timeout'] = '5s'
+default['bcpc']['haproxy']['qos']['http_request_timeout'] = '10s'
 
 # The maximum number of entries in the stick table
 default['bcpc']['haproxy']['qos']['max_entries'] = '1m'

--- a/chef/cookbooks/bcpc/templates/default/haproxy/429.http.erb
+++ b/chef/cookbooks/bcpc/templates/default/haproxy/429.http.erb
@@ -1,8 +1,9 @@
-HTTP/1.0 429 Too Many Requests
-Cache-Control: no-cache
-Connection: close
-Content-Type: text/html
-
+HTTP/1.0 429 Too Many Requests
+Cache-Control: no-cache
+Connection: close
+Content-Type: text/html
+
 <html><body><h1>429 Too Many Requests</h1>
-You have executed too many requests and have been rate limited. Please see the service <% if not node['bcpc']['haproxy']['qos']['slo_url'].nil? %><a href="<%= node['bcpc']['haproxy']['qos']['slo_url'] %>">SLO</a><% else %>SLO<% end %> for more information.
+You have executed too many requests and have been rate limited. Please see the service SLO<% if not node['bcpc']['haproxy']['qos']['slo_url'].nil? %> at <%= node['bcpc']['haproxy']['qos']['slo_url'] %><% end %> for more information.
 </body></html>
+

--- a/chef/cookbooks/bcpc/templates/default/haproxy/qos-exempt.acl.erb
+++ b/chef/cookbooks/bcpc/templates/default/haproxy/qos-exempt.acl.erb
@@ -1,3 +1,4 @@
+localhost
 <%= node['bcpc']['cloud']['vip'] %>
 <%= node['bcpc']['networking']['networks']['primary']['aggregate-cidr'] %>
 <% node['bcpc']['haproxy']['qos']['exemptions'].each do |exemption| %>


### PR DESCRIPTION
This commit performs the following:
- rolls back the http timeout from 5 back to 10, the previous default
- adds localhost to the QoS exemption list
- updates the 429.http file to contain proper line endings as per the
relevant RFCs
- print the SLO url instead of using html markup; most clients will
encounter this error when using the openstack client and thus the html
markup will not render properly

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See the commit message above.

**Testing performed**
Tested on a BVE and production cluster.