### PR TITLE
Explicitly manage apache2 log rotation

### DIFF
--- a/chef/cookbooks/bcpc/attributes/apache2.rb
+++ b/chef/cookbooks/bcpc/attributes/apache2.rb
@@ -2,6 +2,20 @@
 # apache2
 ###############################################################################
 
+# apache2 WSGI daemons will be bounced when the logs reload, so for production
+# clusters, it is a good idea to stagger these bounces across the headnodes.
+# Similarly, it may not be desirable to bounce apache2 alongside the rest of
+# the cron.daily tasks.
+#
+# These attributes serve to control both aspects of reloads/log rotations.
+#   * start_hour and start_minute defines the hour and minute, respectfully,
+#     at which to start bounces/log rotations for apache2.
+#   * ...during which process, each headnode's reload will be separated by
+#     splay_minutes.
+default['bcpc']['apache2']['logrotation']['start_hour'] = 22
+default['bcpc']['apache2']['logrotation']['start_minute'] = 0
+default['bcpc']['apache2']['logrotation']['splay_minutes'] = 1
+
 # Explicitly disable HTTP keep-alive for now.  As part of log rotation (or
 # when a "systemctl reload apache2" is run), a graceful restart is triggered
 # on Ubuntu.  Normally, this is not a problem... however, mod_wsgi in

--- a/chef/cookbooks/bcpc/recipes/apache2.rb
+++ b/chef/cookbooks/bcpc/recipes/apache2.rb
@@ -29,6 +29,28 @@ package %w(
 
 service 'apache2'
 
+# log rotation configuration
+template '/etc/cron.d/logrotate-apache2' do
+  source 'apache2/cron-logrotate.erb'
+  variables(
+    headnodes: headnodes(all: true)
+  )
+end
+
+remote_file '/etc/apache2/logrotate.conf' do
+  only_if { ::File.exist?('/etc/logrotate.d/apache2') }
+  source 'file:///etc/logrotate.d/apache2'
+  owner 'root'
+  group 'root'
+  mode 0644
+  action :create
+end
+
+file '/etc/logrotate.d/apache2' do
+  action :delete
+  backup false
+end
+
 # server configuration
 template '/etc/apache2/conf-available/keepalive.conf' do
   source 'apache2/keepalive.conf.erb'

--- a/chef/cookbooks/bcpc/templates/default/apache2/cron-logrotate.erb
+++ b/chef/cookbooks/bcpc/templates/default/apache2/cron-logrotate.erb
@@ -1,0 +1,13 @@
+# /etc/cron.d/apache2
+# Rotates apache2 logs and reloads apache2 at the specified time
+
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# m h dom mon dow user	command
+<% logrotation = node['bcpc']['apache2']['logrotation'] %>
+<% headnode_index = @headnodes.sort.index(@headnodes.find { |x| x['hostname'] == node['hostname'] }) %>
+<% headnode_splay_minutes = headnode_index * logrotation['splay_minutes'] %>
+<% st_minute = (logrotation['start_minute'] + headnode_splay_minutes) % 60 %>
+<% st_hour = logrotation['start_hour'] + (logrotation['start_minute'] + headnode_splay_minutes) / 60 %>
+<%= st_hour %> <%= st_minute %>	* * *	root    cd / && /usr/sbin/logrotate /etc/apache2/logrotate.conf


### PR DESCRIPTION
Allow for time and splay of apache2 reload/log rotation
across headnodes to be configured via chef.