### PR TITLE
Avoid rust dep by updating rally's venv pip

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -83,7 +83,7 @@ execute 'install rally in virtualenv' do
   command <<-EOH
     virtualenv --no-download #{venv_dir} -p /usr/bin/python3
     . #{venv_dir}/bin/activate
-    pip install --upgrade pbr
+    pip install --upgrade 'pip>=19.1.1'
     pip install --upgrade rally-openstack==#{rally_openstack_version} rally==#{rally_version}
   EOH
   not_if "rally --version | grep rally-openstack | grep #{rally_openstack_version}"


### PR DESCRIPTION
The latest PyCA cryptography package now requires rust to be installed.
Instead of pinning the cryptography package to an older version this
commit updates the version of pip to the minimum level required to avoid
this issue, as recommended [here](https://github.com/pyca/cryptography/issues/5771) and as done by the openstack/bifrost 
project.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See commit message.

**Testing performed**
Tested via a BVE created by our internal Jenkins pipeline.

**Additional context**
N/A
