### PR TITLE
Make mysql attributes more consistent

### DIFF
--- a/chef/cookbooks/bcpc/attributes/cinder.rb
+++ b/chef/cookbooks/bcpc/attributes/cinder.rb
@@ -2,7 +2,10 @@
 # cinder
 ###############################################################################
 
+# specify database and configure SQLAlchemy overflow/QueuePool sizes
 default['bcpc']['cinder']['db']['dbname'] = 'cinder'
+default['bcpc']['cinder']['db']['max_overflow'] = 128
+default['bcpc']['cinder']['db']['max_pool_size'] = 64
 
 default['bcpc']['cinder']['debug'] = false
 default['bcpc']['cinder']['workers'] = nil
@@ -10,8 +13,6 @@ default['bcpc']['cinder']['allow_az_fallback'] = true
 default['bcpc']['cinder']['backend_native_threads_pool_size'] = nil
 default['bcpc']['cinder']['rbd_flatten_volume_from_snapshot'] = true
 default['bcpc']['cinder']['rbd_max_clone_depth'] = 5
-default['bcpc']['cinder']['database']['max_overflow'] = 128
-default['bcpc']['cinder']['database']['max_pool_size'] = 64
 default['bcpc']['cinder']['quota'] = {
   'volumes' => -1,
   'snapshots' => 10,

--- a/chef/cookbooks/bcpc/attributes/consul.rb
+++ b/chef/cookbooks/bcpc/attributes/consul.rb
@@ -22,12 +22,17 @@ default['bcpc']['consul']['config']['addresses']['dns'] = node['bcpc']['cloud'][
 default['bcpc']['consul']['config']['ports']['dns'] = 8600
 default['bcpc']['consul']['config']['recursors'] = [node['bcpc']['cloud']['vip']]
 
+# Load the mysql attribute file in order to populate mysql:port. Chef attribute
+# files are loaded alphabetically, and unless mysql:port is specified in the
+# environment it will be null when read below. Thus the explicit load.
+node.from_file(run_context.resolve_attribute('bcpc', 'mysql'))
+
 # Service definitions reference:
 # https://www.consul.io/docs/agent/services.html
 default['bcpc']['consul']['services'] = [
   {
     'name' => 'mysql',
-    'port' => 3306,
+    'port' => node['bcpc']['mysql']['port'],
     'enable_tag_override' => true,
     'tags' => ['mysql'],
     'check' => {

--- a/chef/cookbooks/bcpc/attributes/heat.rb
+++ b/chef/cookbooks/bcpc/attributes/heat.rb
@@ -4,10 +4,10 @@
 
 default['bcpc']['heat']['enabled'] = true
 
-# database
+# specify database and configure SQLAlchemy overflow/QueuePool sizes
 default['bcpc']['heat']['db']['dbname'] = 'heat'
-default['bcpc']['heat']['database']['max_overflow'] = 128
-default['bcpc']['heat']['database']['max_pool_size'] = 64
+default['bcpc']['heat']['db']['max_overflow'] = 128
+default['bcpc']['heat']['db']['max_pool_size'] = 64
 
 # workers parameters for heat-api and heat-engine set to number of CPUs
 # available by default. This provides an override.

--- a/chef/cookbooks/bcpc/attributes/keystone.rb
+++ b/chef/cookbooks/bcpc/attributes/keystone.rb
@@ -2,7 +2,10 @@
 # keystone
 ###############################################################################
 
-default['bcpc']['keystone']['db'] = 'keystone'
+# specify database and configure SQLAlchemy overflow/QueuePool sizes
+default['bcpc']['keystone']['db']['dbname'] = 'keystone'
+default['bcpc']['keystone']['db']['max_overflow'] = 128
+default['bcpc']['keystone']['db']['max_pool_size'] = 64
 
 # caching
 default['bcpc']['keystone']['enable_caching'] = true
@@ -16,9 +19,6 @@ default['bcpc']['keystone']['debug'] = false
 # Set the number of Keystone WSGI processes
 default['bcpc']['keystone']['workers'] = nil
 
-# configure SQLAlchemy overflow/QueuePool sizes
-default['bcpc']['keystone']['database']['max_overflow'] = 128
-default['bcpc']['keystone']['database']['max_pool_size'] = 64
 # The driver section below allows either 'sql' or 'ldap' (or 'templated' for catalog)
 # Note that not all drivers may support SQL/LDAP, only tinker if you know what you're getting into
 default['bcpc']['keystone']['drivers']['assignment'] = 'sql'

--- a/chef/cookbooks/bcpc/attributes/mysql.rb
+++ b/chef/cookbooks/bcpc/attributes/mysql.rb
@@ -8,7 +8,9 @@ default['bcpc']['mysql']['repo']['key'] = 'mysql/release.key'
 
 # fqdn of mysql server
 default['bcpc']['mysql']['host'] = 'primary.mysql.service.consul'
-default['bcpc']['mysql']['service_hostname'] = 'primary.mysql.service.consul'
+
+# port on which to accept incoming client connections
+default['bcpc']['mysql']['port'] = 3306
 
 default['bcpc']['mysql']['innodb_buffer_pool_instances'] = 16
 default['bcpc']['mysql']['innodb_buffer_pool_size'] = '128M'

--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -2,8 +2,10 @@
 # nova
 ###############################################################################
 
-# database
+# specify database and configure SQLAlchemy overflow/QueuePool sizes
 default['bcpc']['nova']['db']['dbname'] = 'nova'
+default['bcpc']['nova']['db']['max_overflow'] = 128
+default['bcpc']['nova']['db']['max_pool_size'] = 64
 
 # Nova debug toggle
 default['bcpc']['nova']['debug'] = false
@@ -44,10 +46,6 @@ default['bcpc']['nova']['max_concurrent_builds'] = 4
 # available by default. This provides an override.
 default['bcpc']['nova']['workers'] = nil
 default['bcpc']['placement']['workers'] = nil
-
-# configure SQLAlchemy overflow/QueuePool sizes
-default['bcpc']['nova']['database']['max_overflow'] = 128
-default['bcpc']['nova']['database']['max_pool_size'] = 64
 
 # set soft/hard ulimits in upstart unit file for nova-compute
 # as number of OSDs in cluster increases, soft limit needs to increase to avoid

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -26,6 +26,7 @@ mysqladmin = mysqladmin()
 #
 database = {
   'host' => node['bcpc']['mysql']['host'],
+  'port' => node['bcpc']['mysql']['port'],
   'dbname' => node['bcpc']['cinder']['db']['dbname'],
   'username' => config['cinder']['creds']['db']['username'],
   'password' => config['cinder']['creds']['db']['password'],

--- a/chef/cookbooks/bcpc/recipes/glance.rb
+++ b/chef/cookbooks/bcpc/recipes/glance.rb
@@ -24,6 +24,7 @@ mysqladmin = mysqladmin()
 #
 database = {
   'host' => node['bcpc']['mysql']['host'],
+  'port' => node['bcpc']['mysql']['port'],
   'dbname' => node['bcpc']['glance']['db']['dbname'],
   'username' => config['glance']['creds']['db']['username'],
   'password' => config['glance']['creds']['db']['password'],

--- a/chef/cookbooks/bcpc/recipes/heat.rb
+++ b/chef/cookbooks/bcpc/recipes/heat.rb
@@ -24,6 +24,7 @@ mysqladmin = mysqladmin()
 
 database = {
   'host' => node['bcpc']['mysql']['host'],
+  'port' => node['bcpc']['mysql']['port'],
   'dbname' => node['bcpc']['heat']['db']['dbname'],
   'username' => config['heat']['creds']['db']['username'],
   'password' => config['heat']['creds']['db']['password'],

--- a/chef/cookbooks/bcpc/recipes/keystone.rb
+++ b/chef/cookbooks/bcpc/recipes/keystone.rb
@@ -19,8 +19,12 @@ region = node['bcpc']['cloud']['region']
 config = data_bag_item(region, 'config')
 mysqladmin = mysqladmin()
 
+# hash used for database creation and access
+#
 database = {
-  'dbname' => node['bcpc']['keystone']['db'],
+  'host' => node['bcpc']['mysql']['host'],
+  'port' => node['bcpc']['mysql']['port'],
+  'dbname' => node['bcpc']['keystone']['db']['dbname'],
   'username' => config['keystone']['db']['username'],
   'password' => config['keystone']['db']['password'],
 }

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -29,6 +29,7 @@ mysqladmin = mysqladmin()
 #
 database = {
   'host' => node['bcpc']['mysql']['host'],
+  'port' => node['bcpc']['mysql']['port'],
   'dbname' => node['bcpc']['neutron']['db']['dbname'],
   'username' => config['neutron']['creds']['db']['username'],
   'password' => config['neutron']['creds']['db']['password'],

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -22,6 +22,7 @@ nova_compute_config = zone_config.nova_compute_config
 
 database = {
   'host' => node['bcpc']['mysql']['host'],
+  'port' => node['bcpc']['mysql']['port'],
   'dbname' => node['bcpc']['nova']['db']['dbname'],
   'username' => config['nova']['creds']['db']['username'],
   'password' => config['nova']['creds']['db']['password'],

--- a/chef/cookbooks/bcpc/recipes/nova-head.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-head.rb
@@ -26,6 +26,7 @@ mysqladmin = mysqladmin()
 #
 database = {
   'host' => node['bcpc']['mysql']['host'],
+  'port' => node['bcpc']['mysql']['port'],
   'dbname' => node['bcpc']['nova']['db']['dbname'],
   'username' => config['nova']['creds']['db']['username'],
   'password' => config['nova']['creds']['db']['password'],

--- a/chef/cookbooks/bcpc/recipes/powerdns.rb
+++ b/chef/cookbooks/bcpc/recipes/powerdns.rb
@@ -25,6 +25,7 @@ mysqladmin = mysqladmin()
 #
 database = {
   'host' => node['bcpc']['mysql']['host'],
+  'port' => node['bcpc']['mysql']['port'],
   'dbname' => node['bcpc']['powerdns']['db']['dbname'],
   'username' => config['powerdns']['creds']['db']['username'],
   'password' => config['powerdns']['creds']['db']['password'],

--- a/chef/cookbooks/bcpc/recipes/watcher.rb
+++ b/chef/cookbooks/bcpc/recipes/watcher.rb
@@ -24,6 +24,7 @@ mysqladmin = mysqladmin()
 
 database = {
   'host' => node['bcpc']['mysql']['host'],
+  'port' => node['bcpc']['mysql']['port'],
   'dbname' => node['bcpc']['watcher']['db']['dbname'],
   'username' => config['watcher']['creds']['db']['username'],
   'password' => config['watcher']['creds']['db']['password'],

--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -28,9 +28,9 @@ backend_native_threads_pool_size = <%= node['bcpc']['cinder']['backend_native_th
 
 <% end %>
 [database]
-connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}/#{@db['dbname']}" %>
-max_overflow = <%= node['bcpc']['cinder']['database']['max_overflow'] %>
-max_pool_size = <%= node['bcpc']['cinder']['database']['max_pool_size'] %>
+connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>
+max_overflow = <%= node['bcpc']['cinder']['db']['max_overflow'] %>
+max_pool_size = <%= node['bcpc']['cinder']['db']['max_pool_size'] %>
 idle_timeout = 3600
 
 [oslo_concurrency]

--- a/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
@@ -24,7 +24,7 @@ transport_url = rabbit://<%= @rmqnodes.map{|x| "#{@config['rabbit']['username']}
 image_member_quota = -1
 
 [database]
-connection = mysql+pymysql://<%= @db['username'] %>:<%= @db['password'] %>@<%= @db['host'] %>/<%= @db['dbname'] %>
+connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>
 max_pool_size=<%= node['bcpc']['glance']['db']['max_pool_size'] %>
 max_overflow=<%= node['bcpc']['glance']['db']['max_overflow'] %>
 

--- a/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
@@ -39,18 +39,18 @@ auth_uri = <%= "https://#{@node['bcpc']['cloud']['fqdn']}:5000/" %>
 # Deprecated group/name - [DEFAULT]/sql_connection
 # Deprecated group/name - [DATABASE]/sql_connection
 # Deprecated group/name - [sql]/connection
-connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{node['bcpc']['mysql']['host']}/heat" %>
+connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>
 
 # Maximum number of SQL connections to keep open in a pool. Setting a value of
 # 0 indicates no limit. (integer value)
 # Deprecated group/name - [DEFAULT]/sql_max_pool_size
 # Deprecated group/name - [DATABASE]/sql_max_pool_size
-max_pool_size = <%= node['bcpc']['heat']['database']['max_pool_size'] %>
+max_pool_size = <%= node['bcpc']['heat']['db']['max_pool_size'] %>
 
 # If set, use this value for max_overflow with SQLAlchemy. (integer value)
 # Deprecated group/name - [DEFAULT]/sql_max_overflow
 # Deprecated group/name - [DATABASE]/sqlalchemy_max_overflow
-max_overflow = <%= node['bcpc']['heat']['database']['max_overflow'] %>
+max_overflow = <%= node['bcpc']['heat']['db']['max_overflow'] %>
 
 
 [heat_api]

--- a/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
+++ b/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
@@ -155,8 +155,8 @@ SECURITY_GROUP_RULES = {
   'mysql': {
     'name': 'MYSQL',
     'ip_protocol': 'tcp',
-    'from_port': '3306',
-    'to_port': '3306',
+    'from_port': '<%= node['bcpc']['mysql']['port'] %>',
+    'to_port': '<%= node['bcpc']['mysql']['port'] %>',
   },
   'rdp': {
     'name': 'RDP',

--- a/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
@@ -25,9 +25,9 @@ cache_time = 3600
 driver = <%= node['bcpc']['keystone']['drivers']['credential'] %>
 
 [database]
-connection = mysql+pymysql://<%= @db['username'] %>:<%= @db['password'] %>@<%= @node["bcpc"]["mysql"]["service_hostname"] %>/<%= @db['dbname'] %>
-max_overflow = <%= node['bcpc']['keystone']['database']['max_overflow'] %>
-max_pool_size = <%= node['bcpc']['keystone']['database']['max_pool_size'] %>
+connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>
+max_overflow = <%= node['bcpc']['keystone']['db']['max_overflow'] %>
+max_pool_size = <%= node['bcpc']['keystone']['db']['max_pool_size'] %>
 
 [domain_config]
 driver = <%= node['bcpc']['keystone']['drivers']['domain_config'] %>

--- a/chef/cookbooks/bcpc/templates/default/mysql/wsrep.cnf.erb
+++ b/chef/cookbooks/bcpc/templates/default/mysql/wsrep.cnf.erb
@@ -77,7 +77,7 @@ query_cache_type=0
 # it will have (most likely) disastrous consequences on donor node
 bind-address=<%= node['service_ip'] %>
 max_connections=<%= node['bcpc']['mysql']['max_connections'] %>
-port=3306
+port=<%= node['bcpc']['mysql']['port'] %>
 
 # Defaults that most openstack bits are happy with
 collation-server = utf8_general_ci
@@ -126,7 +126,7 @@ wsrep_cluster_name="<%= node['bcpc']['cloud']['region'] %>"
 wsrep_node_address="<%= node['service_ip'] %>:4567"
 
 # Address for incoming client connections. Autodetect by default.
-wsrep_node_incoming_address="<%= node['service_ip'] %>:4567"
+wsrep_node_incoming_address="<%= node['service_ip'] %>:<%= node['bcpc']['mysql']['port'] %>"
 
 # How many threads will process writesets from other nodes
 wsrep_slave_threads=<%= node['bcpc']['mysql']['wsrep_slave_threads'] %>

--- a/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
@@ -27,7 +27,7 @@ etcd_cert_file = <%= node['bcpc']['etcd']['client-rw']['crt']['filepath'] %>
 etcd_key_file = <%= node['bcpc']['etcd']['client-rw']['key']['filepath'] %>
 
 [database]
-connection = mysql+pymysql://<%= "#{@db['username']}:#{@db['password']}@#{node['bcpc']['mysql']['host']}/#{@db['dbname']}" %>
+connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>
 max_pool_size = <%= node['bcpc']['neutron']['db']['max_pool_size'] %>
 max_overflow = <%= node['bcpc']['neutron']['db']['max_overflow'] %>
 

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -70,14 +70,14 @@ username = <%= @config['nova']['creds']['os']['username'] %>
 password = <%= @config['nova']['creds']['os']['password'] %>
 
 [api_database]
-connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{node['bcpc']['mysql']['host']}/nova_api" %>
-max_overflow=<%= node['bcpc']['nova']['database']['max_overflow'] %>
-max_pool_size=<%= node['bcpc']['nova']['database']['max_pool_size'] %>
+connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}_api" %>
+max_overflow=<%= node['bcpc']['nova']['db']['max_overflow'] %>
+max_pool_size=<%= node['bcpc']['nova']['db']['max_pool_size'] %>
 
 [database]
-connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{node['bcpc']['mysql']['host']}/nova" %>
-max_overflow = <%= node['bcpc']['nova']['database']['max_overflow'] %>
-max_pool_size = <%= node['bcpc']['nova']['database']['max_pool_size'] %>
+connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>
+max_overflow = <%= node['bcpc']['nova']['db']['max_overflow'] %>
+max_pool_size = <%= node['bcpc']['nova']['db']['max_pool_size'] %>
 
 [placement]
 os_region_name = <%= node['bcpc']['cloud']['region'] %>

--- a/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/powerdns/pdns.conf.erb
@@ -48,8 +48,8 @@ disable-axfr = yes
 launch = gmysql
 
 # gmysql parameters
-gmysql-host = <%= node['service_ip'] %>
-gmysql-port = 3306
+gmysql-host = <%= @db['host'] %>
+gmysql-port = <%= @db['port'] %>
 gmysql-dbname = <%= @db['dbname'] %>
 gmysql-user = <%= @db['username'] %>
 gmysql-password = <%= @db['password'] %>

--- a/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
@@ -6,7 +6,7 @@ transport_url = rabbit://<%= @rmqnodes.map{|n| "#{@config['rabbit']['username']}
 bind_host = <%= node['service_ip'] %>
 
 [database]
-connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{node['bcpc']['mysql']['host']}/watcher?charset=utf8" %>
+connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}?charset=utf8" %>
 
 [keystone_authtoken]
 auth_url = <%= "https://#{@node['bcpc']['cloud']['fqdn']}:35357/" %>


### PR DESCRIPTION
This commit also introduces the mysql port attribute, which until now
was hard coded to 3306.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
Make references to mysql variables (url, port, dname) more consistent.

**Testing performed**
Created a 3h3w BVE and ran various rally tests.
