### PR TITLE
add availability zone anti-affinity.

### DIFF
--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -107,3 +107,8 @@ default['bcpc']['nova']['db-archive']['cron_day'] = '*'
 default['bcpc']['nova']['db-archive']['cron_weekday'] = '6'
 default['bcpc']['nova']['db-archive']['cron_hour'] = '4'
 default['bcpc']['nova']['db-archive']['cron_minute'] = '0'
+
+# Anti-affinity availability zone scheduler filter
+default['bcpc']['nova']['scheduler']['filter']['anti_affinity_availability_zone']['enabled'] = false
+default['bcpc']['nova']['scheduler']['filter']['anti_affinity_availability_zone']['name'] = 'AntiAffinityAvailabilityZoneFilter'
+default['bcpc']['nova']['scheduler']['filter']['anti_affinity_availability_zone']['filterPath'] = 'nova.scheduler.filters.anti_affinity_availability_zone_filter.AntiAffinityAvailabilityZoneFilter'

--- a/chef/cookbooks/bcpc/files/default/nova/anti_affinity_availability_zone_filter.py
+++ b/chef/cookbooks/bcpc/files/default/nova/anti_affinity_availability_zone_filter.py
@@ -1,0 +1,80 @@
+# Copyright 2012, Piston Cloud Computing, Inc.
+# Copyright 2012, OpenStack Foundation
+# Copyright 2021, Bloomberg L.P.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from nova import availability_zones
+from nova import context
+from nova.scheduler import filters
+from oslo_log import log as logging
+from oslo_utils import strutils
+
+LOG = logging.getLogger(__name__)
+
+
+class _AntiAffinityAvailabilityZoneFilter(filters.BaseHostFilter):
+    """Checks the availability zone of the host if the
+    availability_zone_anti_affinity is set to true.
+    If the host is from a different zone than zones in the server group
+    it returns true, otherwise returns false."""
+
+    # a variable which is checked for all scheduler filters during a rebuild
+    # for each filter.
+    RUN_ON_REBUILD = False
+
+    def host_passes(self, host_state, spec_obj):
+        # Only invoke the filter if 'anti-affinity' and scheduler
+        # hint anti_affinity_policy = availability_zone is configured
+        instance_group = spec_obj.instance_group
+        policy = instance_group.policy if instance_group else None
+        az_hint = spec_obj.get_scheduler_hint('anti_affinity_policy', None)
+        # if the policy is not anti-affinity and anti_affinity_policy scheduler
+        # hint is not availability_zone then return true and don't apply filter
+        if self.policy_name != policy or az_hint != 'availability_zone':
+            return True
+        # Move operations like resize can check the same source compute node
+        # where the instance is. That case, AntiAffinityAvailabilityZoneFilter
+        # must not return the source as a non-possible destination.
+        if spec_obj.instance_uuid in host_state.instances.keys():
+            return True
+        # list of hosts of non-deleted instances in the server group
+        hosts_group_members = (
+            spec_obj.instance_group.hosts if spec_obj.instance_group else [])
+        # set of availability zones of the instances in the server group
+        instance_group_availability_zones = set()
+        host_availability_zone = availability_zones.get_host_availability_zone(
+            context.get_admin_context(), host_state.host)
+        for host in hosts_group_members:
+            instance_group_availability_zones.add(
+                availability_zones.get_host_availability_zone(
+                    context.get_admin_context(), host))
+        # Very old request specs don't have a full InstanceGroup with the UUID
+        group_uuid = (instance_group.uuid
+                      if instance_group and 'uuid' in instance_group
+                      else 'n/a')
+        LOG.debug("Anti-affinity-AZ-filter: check if the host %(host)s in AZ "
+                  "%(host_az)s is not in the same set of AZs in server group "
+                  "%(group_uuid)s",
+                  {'host': host_state.host,
+                   'host_az': host_availability_zone,
+                   'group_uuid': group_uuid})
+        return host_availability_zone not in instance_group_availability_zones
+
+
+class AntiAffinityAvailabilityZoneFilter(_AntiAffinityAvailabilityZoneFilter):
+    def __init__(self):
+        self.policy_name = 'anti-affinity'
+        super(AntiAffinityAvailabilityZoneFilter, self).__init__()

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -140,11 +140,13 @@ driver = filter_scheduler
 workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% end%>
 
-[filter_scheduler]
-available_filters = nova.scheduler.filters.all_filters
-enabled_filters = <%= node['bcpc']['nova']['scheduler_default_filters'].join(',') %>
-
 <% if @is_headnode -%>
+[filter_scheduler]
+<% @available_filters.each do |available_filter| %>
+available_filters = <%= available_filter %>
+<% end %>
+enabled_filters = <%= @enabled_filters.join(',') %>
+
 [vnc]
 enabled = true
 server_listen = <%= node['service_ip'] %>


### PR DESCRIPTION
add availability zone anti affinity scheduler filter

Changes

- Checks for a flag in nova attributes, if set the AZ anti-affinity filter is added.
- add the path and filter name to the nova.conf
- copy and compiles the filter.
- restart the nova-scheduler.

Testing performed
- Running BVE
   applied with enabled false that passed correctly and availability zone anti-affinity did not apply.
   applied with enabled true that availability zone anti-affinity applied, compiled and services restarted. the nova.conf was 
   changed and the services restarted.
- Fresh BVE
   I tested with a fresh build with the changes and enabled set to false. The build was successful and nova.conf changes 
   were correct and the affinity filter was not installed.
   I tested a fresh build with 3h3w and two AZs one with one host and one with two hosts. The attribute was enabled true. 
   Tested the functionality of the filter and its application. I was success.
