### PR TITLE
Revert security group mysql port change

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
+++ b/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
@@ -155,8 +155,8 @@ SECURITY_GROUP_RULES = {
   'mysql': {
     'name': 'MYSQL',
     'ip_protocol': 'tcp',
-    'from_port': '<%= node['bcpc']['mysql']['port'] %>',
-    'to_port': '<%= node['bcpc']['mysql']['port'] %>',
+    'from_port': '3306',
+    'to_port': '3306',
   },
   'rdp': {
     'name': 'RDP',


### PR DESCRIPTION
Revert a recent change that tied the port in the 'MYSQL' security group
horizon is populated with, to the port used by the BCC mysql installation.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See above

**Testing performed**
Ran updated recipe on BVE.