### PR TITLE
Add a stubnodes Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ headnodes = $$(ansible headnodes -i ${inventory} --list | tail -n +2 | wc -l)
 rmqnodes = $$(ansible rmqnodes -i ${inventory} --list | tail -n +2 | wc -l)
 storagenodes = \
         $$(ansible storagenodes -i ${inventory} --list | tail -n +2 | wc -l)
+stubnodes = $$(ansible stubnodes -i ${inventory} --list | tail -n +2 | wc -l)
 
 all : \
 	sync-assets \
@@ -98,7 +99,8 @@ run-chef-client : \
 	run-chef-client-rmqnodes \
 	run-chef-client-headnodes \
 	run-chef-client-worknodes \
-	run-chef-client-storagenodes
+	run-chef-client-storagenodes \
+	run-chef-client-stubnodes
 
 run-chef-client-bootstraps :
 
@@ -148,6 +150,14 @@ run-chef-client-storagenodes :
 		ansible-playbook -v \
 			-i ${inventory} ${playbooks}/site.yml \
 			-t chef-client --limit storagenodes; \
+	fi
+
+run-chef-client-stubnodes :
+
+	@if [ "${stubnodes}" -gt 0 ]; then \
+		ansible-playbook -v \
+			-i ${inventory} ${playbooks}/site.yml \
+			-t chef-client --limit stubnodes; \
 	fi
 
 reweight-ceph-osds:


### PR DESCRIPTION
Until now chef recipes were not run during a `make all`; this fixes that
oversight.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See above.

**Testing performed**
Successfully ran `run-chef-client-stubnodes` on our internal test cluster.

**Additional context**
Until now chef recipes for stub nodes were not executed as part of `make all`. This fixes that by adding the `run-chef-client-stubnodes` target, which is invoked during a `make all`. So far chef recipes for stub nodes were executed via calls to ansible, bypassing the makefile.
