### PR TITLE
Expand infra tests and make them more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ to provide the best out-of-the-box experience.
 
 ### Local Build
 
-* Review `virtual/topology/topology.yml` for the topology you will build and
-make changes as required, e.g. assign more or less RAM based on your topology
-and your build environment. Other topologies exist in the same directory.
+* Choose the topology and hardware configuration of your cluster. You can
+choose from existing configurations in `virtual/topology`, or build your own.
+[hardware.yml](virtual/topology/hardware.yml) and
+[topology.yml](virtual/topology/topology.yml) are used by default. To view a
+list of tested topologies and hardware configurations please see
+[virtual/README](virtual/README.md).
 * To make changes to the virtual topology without dirtying the tree, copy the
 [hardware.yml](virtual/topology/hardware.yml) and
 [topology.yml](virtual/topology/topology.yml) to files named

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,6 +1,9 @@
 [pytest]
 addopts = --strict
 markers =
-    worknodes
-    headnodes
     bootstraps
+    headnodes
+    rmqnodes
+    worknodes
+    storagenodes
+    stubnodes

--- a/tests/test_cinder.py
+++ b/tests/test_cinder.py
@@ -25,8 +25,11 @@ def test_services(host, name):
     assert s.is_running
     assert s.is_enabled
 
-
+@pytest.mark.bootstraps
+@pytest.mark.rmqnodes
 @pytest.mark.worknodes
+@pytest.mark.storagenodes
+@pytest.mark.stubnodes
 @pytest.mark.parametrize("name", [
     ("cinder-volume"),
     ("cinder-scheduler"),

--- a/tests/test_glance.py
+++ b/tests/test_glance.py
@@ -23,3 +23,15 @@ def test_services_head(host, name):
     s = host.service(name)
     assert s.is_running
     assert s.is_enabled
+
+@pytest.mark.bootstraps
+@pytest.mark.rmqnodes
+@pytest.mark.worknodes
+@pytest.mark.storagenodes
+@pytest.mark.stubnodes
+@pytest.mark.parametrize("name", [
+    ("glance-api"),
+])
+def test_services_not_installed(host, name):
+    s = host.package(name)
+    assert not s.is_installed

--- a/tests/test_nova.py
+++ b/tests/test_nova.py
@@ -25,7 +25,25 @@ import pytest
     pytest.param("nova-compute", marks=pytest.mark.worknodes),
     pytest.param("nova-api-metadata", marks=pytest.mark.worknodes),
 ])
-def test_services_head(host, name):
+def test_services(host, name):
     s = host.service(name)
     assert s.is_running
     assert s.is_enabled
+
+@pytest.mark.bootstraps
+@pytest.mark.rmqnodes
+@pytest.mark.storagenodes
+@pytest.mark.stubnodes
+@pytest.mark.parametrize("name", [
+    ("nova-api"),
+    ("nova-scheduler"),
+    ("nova-consoleauth"),
+    ("nova-conductor"),
+    ("nova-novncproxy"),
+    ("nova-scheduler"),
+    ("nova-compute"),
+    ("nova-api-metadata"),
+])
+def test_services_not_installed(host, name):
+    s = host.package(name)
+    assert not s.is_installed

--- a/virtual/README.md
+++ b/virtual/README.md
@@ -4,12 +4,32 @@ The virtual directory contains everything needed in order to build a virtual
 cluster using either VirtualBox or libvirt. A single *network-vm* may be used
 instead of the full leaf-spine architecture described [here](network/README.md)
 by specifying the environmental variable `BCC_DEPLOY_NETWORK_VM=true`.
-Additional information can be found [here](../README.md).
+Instructions on how how build a virtual cluster can be found
+[here](../README.md).
 
-A short description of important directories and files can be found below.
+## Directories
 
 - bin: Various scripts used during the creation and tearing down of the
     specified virtual environment.
 - network: See the [README](network/README.md).
 - topology: Defines the hardware configuration and topology of the virtual
     environment to be created.
+
+## Tested Configurations
+
+The Bloomberg chef-bcpc team periodically tests various cluster configurations
+as part of their internal CI/CD process. The following table details those
+configurations, as well as certain details regarding the tests. Note, however,
+that these tests are **not** performed on a pure chef-bcpc cluster but instead
+on a cluster comprised of a combination of chef-bcpc and various closed-source
+components internal to Bloomberg, so your millage may vary.
+
+| Topology | Hardware Configuration | Network VM | Branch | Frequency |
+|---|---|---|---|---|
+| [1h1w](topology/1h1w.yml) | [hardware](topology/hardware.yml) | Yes | development | daily |
+| [3h3w](topology/3h3w.yml) | [hardware](topology/hardware.yml) | Yes | development | daily |
+| [3h3w3r](topology/3h3w3r.yml) | [hardware](topology/hardware.yml) | Yes | development | weekly |
+| [3h3w3r](topology/3h3w3r.yml) | [hardware](topology/hardware.yml) | Yes | master | weekly |
+
+Periodic testing of the pure chef-bcpc component is planned. And as always,
+contributions from the community are also very welcome.


### PR DESCRIPTION
- allow testing of bootstraps, rmqnodes, storagenodes and stubnodes
- both negative and positive tests are performed for all currently
tested services
- rmq service is tested for headnodes iff the relevant chef runlist is
present

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
Improved and expanded the infra tests.

**Testing performed**
Ran the infra tests against a 1h1w, 3h3w and 3h3w3r.

**Additional context**
Before this infra tests would fail when run against a 3h3h3r because they assumed that head nodes always run the rabbitmq service. While addressing this I decided to make the existing code a bit more consistent.
