### PR TITLE
Makefile: enable parallelized virtual tasks

### DIFF
--- a/virtual/Makefile
+++ b/virtual/Makefile
@@ -1,0 +1,35 @@
+create : create-virtual-network create-virtual-hosts
+destroy : destroy-virtual-network destroy-virtual-hosts
+
+create-virtual-hosts :
+
+	bin/create-virtual-environment.sh
+
+create-virtual-network :
+
+	bin/create-virtual-network.sh
+
+destroy-virtual-hosts :
+
+	bin/destroy-virtual-environment.sh
+
+destroy-virtual-network :
+
+	bin/destroy-virtual-network.sh
+
+###############################################################################
+# virtual environment helper targets
+###############################################################################
+
+vtunnel:
+
+	ssh_tunnel_conf=/tmp/ssh-config.$$$$ ;\
+	vagrant ssh-config r1n0 > $${ssh_tunnel_conf} ;\
+	ssh -f -N -F $${ssh_tunnel_conf} -L *:8443:10.65.0.254:443 -L *:6080:10.65.0.254:6080 r1n0 ;\
+	rm $${ssh_tunnel_conf} ;\
+	echo "\nOpenStack Dashboard available at: https://127.0.0.1:8443/horizon/\n"
+
+host ?= r1n1
+vssh:
+
+	vagrant ssh $(host) -c 'sudo -i'


### PR DESCRIPTION
This commit addresses two items: one of correctness/safety,
and one of build.

  1) Our top-level `Makefile` is authored in such a way
     that none of the tasks should be parallelized, lest
     significant changes to the `Makefile` are done such
     that it is made declartive wrt each steps' specific
     requirements, rather than presenting an ordered list
     of steps under the `all` target.  As is, anyone who
     issues a `make -j all` is in for a bad time. To
     prevent surprises, make use of `.NOTPARALLEL:`

  2) Split out the `virtual` targets into their own
     `Makefile`, and invoke it recursively such that it
     will not be subject to `.NOTPARALLEL:`.

This allows users to run e.g. `make destroy create all -j`,
and have the destroy/creation of virtual infrastructure
done in parallel without affecting the inherently serial
parts of the `Makefile`.  This improves build time of a
1h1w by ~4.6% in my lab.