### PR TITLE
create-virtual-*: Parallelize spinups/reboots

### DIFF
--- a/virtual/bin/create-virtual-environment.sh
+++ b/virtual/bin/create-virtual-environment.sh
@@ -55,10 +55,7 @@ fi
 # bring up vagrant/virtualbox nodes
 (
     cd "${virtual_dir}"
-    vagrant up
-
-    # reload vms to load new kernel
-    vagrant reload
+    vagrant up --parallel
 
     # export ssh config file for ansible inventory parsing
     vagrant ssh-config > "${ssh_config_file}"
@@ -68,3 +65,7 @@ fi
 "${virtual_dir}/bin/generate-ansible-inventory.py" \
     --ssh-config "${ssh_config_file}" \
     --topology-config "${topology_file}" > "${ansible_dir}/inventory.yml"
+
+# reboot vms to load new kernel
+ansible -i "${ansible_dir}/inventory.yml" cloud -b -B 1 -P 0 -m shell -a "sleep 5 && reboot"
+ansible -i "${ansible_dir}/inventory.yml" cloud -m wait_for_connection -a "delay=15"

--- a/virtual/bin/create-virtual-network.sh
+++ b/virtual/bin/create-virtual-network.sh
@@ -28,5 +28,5 @@ fi
 # bring up network nodes
 (
     cd "${network_dir}"
-    vagrant up
+    vagrant up --parallel
 )


### PR DESCRIPTION
We previously used `vagrant reload` to turn all the VMs
one-by-one after they were provisioned with `vagrant up`.
Unfortunately, `vagrant reload` has no `--parallel` flag
as does `vagrant up`.

However, we have Ansible, and we generate an Ansible
playbook as part of the create-virtual-environment.sh
script, so just leverage that to do the reboots instead,
and do so in parallel.

Moreover, add `--parallel` to all `vagrant up` commands
to allow provisioners which respect this flag to come up
faster.

This improves build time of a 1h1w by ~1.8% in my lab.