### PR TITLE
chef: kill 'openstack <...> show | grep -w <...>'

### DIFF
--- a/chef/cookbooks/bcpc/recipes/flavors.rb
+++ b/chef/cookbooks/bcpc/recipes/flavors.rb
@@ -23,6 +23,17 @@ execute 'wait for flavors' do
   command 'openstack flavor list'
 end
 
+ruby_block "collect openstack flavor list" do
+  block do
+    Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
+    os_command = 'openstack flavor list --format json'
+    os_command_out = shell_out(os_command, :env => os_adminrc)
+    flavors_list = JSON.parse(os_command_out.stdout)
+    node.run_state['os_flavors'] = flavors_list.map{|f| f['Name']}
+  end
+  action :create
+end
+
 node['bcpc']['openstack']['flavors'].each do |flavor, spec|
   # skip over the boolean we use to enable/disable this recipe
   next if flavor == 'enabled'
@@ -34,6 +45,6 @@ node['bcpc']['openstack']['flavors'].each do |flavor, spec|
         --ram #{spec['ram']} \
         --disk #{spec['disk']}
     DOC
-    not_if "openstack flavor show #{flavor}"
+    not_if { node.run_state['os_flavors'].include? flavor }
   end
 end

--- a/chef/cookbooks/bcpc/recipes/glance.rb
+++ b/chef/cookbooks/bcpc/recipes/glance.rb
@@ -75,6 +75,27 @@ end
 #
 # create/configure glance openstack user ends
 
+ruby_block "collect openstack service and endpoints list" do
+  block do
+    Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
+    os_command = 'openstack service list --format json'
+    os_command_out = shell_out(os_command, :env => os_adminrc)
+    service_list = JSON.parse(os_command_out.stdout)
+
+    os_command = 'openstack endpoint list --format json'
+    os_command_out = shell_out(os_command, :env => os_adminrc)
+    endpoint_list = JSON.parse(os_command_out.stdout)
+
+    # build a hash of service_type => list of uris
+    groups = endpoint_list.group_by{|e| e['Service Type']}
+    endpoints = groups.map{|k,v| [k, v.map{|e| e['Interface']}]}.to_h
+
+    node.run_state['os_services'] = service_list.map{|s| s['Type']}
+    node.run_state['os_endpoints'] = endpoints
+  end
+  action :create
+end
+
 # create image service and endpoints starts
 #
 begin
@@ -91,7 +112,7 @@ begin
       openstack service create --name "#{name}" --description "#{desc}" #{type}
     DOC
 
-    not_if "openstack service list | grep #{type}"
+    not_if { node.run_state['os_services'].include? type }
   end
 
   %w(admin internal public).each do |uri|
@@ -104,7 +125,7 @@ begin
         openstack endpoint create --region #{region} #{type} #{uri} '#{url}'
       DOC
 
-      not_if "openstack endpoint list | grep #{type} | grep #{uri}"
+      not_if { node.run_state['os_endpoints'][type].include? uri rescue false }
     end
   end
 end

--- a/chef/cookbooks/bcpc/recipes/nova-head.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-head.rb
@@ -79,6 +79,27 @@ end
 #
 # create nova user ends
 
+ruby_block "collect openstack service and endpoints list" do
+  block do
+    Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
+    os_command = 'openstack service list --format json'
+    os_command_out = shell_out(os_command, :env => os_adminrc)
+    service_list = JSON.parse(os_command_out.stdout)
+
+    os_command = 'openstack endpoint list --format json'
+    os_command_out = shell_out(os_command, :env => os_adminrc)
+    endpoint_list = JSON.parse(os_command_out.stdout)
+
+    # build a hash of service_type => list of uris
+    groups = endpoint_list.group_by{|e| e['Service Type']}
+    endpoints = groups.map{|k,v| [k, v.map{|e| e['Interface']}]}.to_h
+
+    node.run_state['os_services'] = service_list.map{|s| s['Type']}
+    node.run_state['os_endpoints'] = endpoints
+  end
+  action :create
+end
+
 # create compute service and endpoints starts
 #
 begin
@@ -95,7 +116,7 @@ begin
       openstack service create --name "#{name}" --description "#{desc}" #{type}
     DOC
 
-    not_if "openstack service list | grep #{type}"
+    not_if { node.run_state['os_services'].include? type }
   end
 
   %w(admin internal public).each do |uri|
@@ -108,7 +129,7 @@ begin
         openstack endpoint create --region #{region} #{type} #{uri} '#{url}'
       DOC
 
-      not_if "openstack endpoint list | grep #{type} | grep #{uri}"
+      not_if { node.run_state['os_endpoints'][type].include? uri rescue false }
     end
   end
 end
@@ -176,7 +197,7 @@ begin
         --name "#{name}" --description "#{desc}" #{type}
     DOC
 
-    not_if "openstack service list | grep #{type}"
+    not_if { node.run_state['os_services'].include? type }
   end
 
   %w(admin internal public).each do |uri|
@@ -190,7 +211,7 @@ begin
           --region #{region} #{type} #{uri} '#{url}'
       DOC
 
-      not_if "openstack endpoint list | grep #{type} | grep #{uri}"
+      not_if { node.run_state['os_endpoints'][type].include? uri rescue false }
     end
   end
 end

--- a/chef/cookbooks/bcpc/recipes/watcher.rb
+++ b/chef/cookbooks/bcpc/recipes/watcher.rb
@@ -73,6 +73,27 @@ execute "add #{openstack['role']} role to #{openstack['username']} user" do
   DOC
 end
 
+ruby_block "collect openstack service and endpoints list" do
+  block do
+    Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
+    os_command = 'openstack service list --format json'
+    os_command_out = shell_out(os_command, :env => os_adminrc)
+    service_list = JSON.parse(os_command_out.stdout)
+
+    os_command = 'openstack endpoint list --format json'
+    os_command_out = shell_out(os_command, :env => os_adminrc)
+    endpoint_list = JSON.parse(os_command_out.stdout)
+
+    # build a hash of service_type => list of uris
+    groups = endpoint_list.group_by{|e| e['Service Type']}
+    endpoints = groups.map{|k,v| [k, v.map{|e| e['Interface']}]}.to_h
+
+    node.run_state['os_services'] = service_list.map{|s| s['Type']}
+    node.run_state['os_endpoints'] = endpoints
+  end
+  action :create
+end
+
 # create infra-optim service and endpoints
 begin
   type = 'infra-optim'
@@ -85,7 +106,7 @@ begin
     command <<-DOC
       openstack service create --name "#{name}" --description "#{desc}" #{type}
     DOC
-    not_if "openstack service list | grep #{type}"
+    not_if { node.run_state['os_services'].include? type }
   end
 
   %w(admin internal public).each do |uri|
@@ -95,7 +116,7 @@ begin
       command <<-DOC
         openstack endpoint create --region #{region} #{type} #{uri} '#{url}'
       DOC
-      not_if "openstack endpoint list | grep #{type} | grep #{uri}"
+      not_if { node.run_state['os_endpoints'][type].include? uri rescue false }
     end
   end
 end


### PR DESCRIPTION
For services/endpoints/objects that we provision with Chef,
we first do a scan using a 'openstack ... | grep ...'
check.

There are two problems with this:
  1) We are not setting pipefail, so if the OpenStack API
     mucks up during the left side of the pipe, the grep
     will still return success as if no object was found.
     We will then run the 'create' command, which will
     create a duplicate object if that command manages to
     go through.  This could cause a temporary outage
     as a result of a Chef run, that an operator may not
     at first realize.

  2) We tend to have cases where we run multiple `show`
     commands and fire up the `openstack` tool multiple
     times.  Instead, just list out all objects and do
     the filtering on the client/Chef side, as it's a
     lot faster -- especially with things like flavors.
     quotas, etc. where we have lots of them under CM.

This improves build time of a 1h1w by ~2% in my lab.