### PR TITLE
mysql: Wait for Consul to elect a mysql primary

### DIFF
--- a/chef/cookbooks/bcpc/recipes/mysql.rb
+++ b/chef/cookbooks/bcpc/recipes/mysql.rb
@@ -114,3 +114,8 @@ template '/etc/xinetd.d/mysqlchk' do
   )
   notifies :restart, 'service[xinetd]', :immediately
 end
+
+execute 'wait for consul to elect the primary mysql host' do
+  retries 30
+  command 'getent hosts primary.mysql.service.consul'
+end


### PR DESCRIPTION
The MySQL recipe does not wait for Consul to elect a
database primary, and the next recipe to currently execute
(powerdns) tries to make use of the database host.  This
causes a race condition that has now begun to enumerate
more frequently... so wait for Consul to elect the primary
MySQL host as part of the MySQL recipe.