### PR TITLE
playbooks/common: Fix configure-system invocation

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -1,3 +1,8 @@
+# Define Ansible virtualization facts
+- name: Define Ansible virtualization facts
+  setup:
+    gather_subset: "!all,!min,virtual"
+
 # IPMI module configuration and loading
 - name: Configure the kernel's IPMI module
   block:


### PR DESCRIPTION
configure-system now requires the `virtual` facts to be
present in order to run.