### PR TITLE
ansible: Default to HWE kernel configuration

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -279,7 +279,7 @@ hardware_cpu_load_microcode: true
 # If pin_version is false, track linux-{{ variant }} upstream
 # For example, linux-{{ generic-hwe-18.04 }}
 kernel_pin_version: false
-kernel_variant: generic
+kernel_variant: generic-hwe-18.04-edge
 kernel_version: ''
 
 # Use this to *add* more reserved ports; i.e. modify value of


### PR DESCRIPTION
We now install the HWE kernel by default as part of the
packer/virtual builds, so we should make this the default
in Ansible.

Failing to do so results in kernel-utilities, such as
`bpftool`, `perf`, etc. being unavailable.  This issue has
manifested itself already as a Calico issue, as
`calico-felix` needs `bpftool` but it was not being
installed.