### PR TITLE
Provide basic support for AMD processors

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -23,13 +23,14 @@ chef_environment:
           - biosdevname=0
       nova:
         cpu_config:
-          cpu_mode: custom
-          cpu_model: qemu64
-          cpu_model_extra_flags:
-            - abm
-            - lahf_lm
-            - popcnt
-            - sse4a
+          AuthenticAMD:
+            cpu_mode: custom
+            cpu_model: qemu64
+            cpu_model_extra_flags: []
+          GenuineIntel:
+            cpu_mode: custom
+            cpu_model: qemu64
+            cpu_model_extra_flags: []
       ntp: "{{ ntp }}"
       openstack:
         flavors:

--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -31,9 +31,12 @@ default['bcpc']['nova']['notifications']['driver'] = 'messagingv2'
 default['bcpc']['nova']['notifications']['notify_on_state_change'] = 'vm_and_task_state'
 
 # CPU passthrough/masking configurations
-default['bcpc']['nova']['cpu_config']['cpu_mode'] = 'custom'
-default['bcpc']['nova']['cpu_config']['cpu_model'] = 'kvm64'
-default['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'] = []
+default['bcpc']['nova']['cpu_config']['AuthenticAMD']['cpu_mode'] = 'custom'
+default['bcpc']['nova']['cpu_config']['AuthenticAMD']['cpu_model'] = 'qemu64'
+default['bcpc']['nova']['cpu_config']['AuthenticAMD']['cpu_model_extra_flags'] = []
+default['bcpc']['nova']['cpu_config']['GenuineIntel']['cpu_mode'] = 'custom'
+default['bcpc']['nova']['cpu_config']['GenuineIntel']['cpu_model'] = 'qemu64'
+default['bcpc']['nova']['cpu_config']['GenuineIntel']['cpu_model_extra_flags'] = []
 
 # select from between this many equally optimal hosts when launching an instance
 default['bcpc']['nova']['scheduler_host_subset_size'] = 3

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: nova-compute
 #
-# Copyright:: 2020 Bloomberg Finance L.P.
+# Copyright:: 2021 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -196,6 +196,11 @@ template '/etc/nova/nova.conf' do
   notifies :restart, 'service[nova-api-metadata]', :immediately
 end
 
+flags = node['cpu']['0']['flags'] & %w(svm vmx)
+virt_type = flags.empty? ? 'qemu' : 'kvm'
+vendor_id = node['cpu']['0']['vendor_id']
+cpu_config = node['bcpc']['nova']['cpu_config'][vendor_id]
+
 template '/etc/nova/nova-compute.conf' do
   source 'nova/nova-compute.conf.erb'
   mode '0640'
@@ -203,7 +208,10 @@ template '/etc/nova/nova-compute.conf' do
   group 'nova'
 
   variables(
-    virt_type: node['cpu']['0']['flags'].include?('vmx') ? 'kvm' : 'qemu',
+    virt_type: virt_type,
+    cpu_mode: cpu_config['cpu_mode'],
+    cpu_model: cpu_config['cpu_model'],
+    cpu_model_extra_flag: cpu_config['cpu_model_extra_flags'],
     images_rbd_pool: nova_compute_config.ceph_pool,
     rbd_user: nova_compute_config.ceph_user,
     rbd_secret_uuid: nova_compute_config.libvirt_secret

--- a/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
@@ -3,7 +3,7 @@
 ###############################################################################
 
 # for an overview of all the available configuration options
-# go to: https://docs.openstack.org/glance/pike/configuration/glance_api.html
+# go to: https://docs.openstack.org/glance/rocky/configuration/glance_api.html
 #
 [DEFAULT]
 debug = <%= node['bcpc']['glance']['debug'] %>

--- a/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
@@ -1,5 +1,5 @@
-# for an overview of all the available configuration options for nova@pike
-# go to: https://docs.openstack.org/nova/pike/configuration/config.html
+# for an overview of all the available configuration options for nova@rocky
+# go to: https://docs.openstack.org/nova/rocky/configuration/config.html
 #
 [DEFAULT]
 compute_driver = libvirt.LibvirtDriver
@@ -15,13 +15,13 @@ rbd_secret_uuid = <%= @rbd_secret_uuid %>
 disk_cachemodes = "network=writeback"
 hw_disk_discard = unmap
 live_migration_uri = qemu+ssh://nova@%s/system
-<% unless node['bcpc']['nova']['cpu_config']['cpu_mode'].nil? %>
-cpu_mode = <%= node['bcpc']['nova']['cpu_config']['cpu_mode'] %>
+<% unless @cpu_mode.nil? %>
+cpu_mode = <%= @cpu_mode %>
 <% end -%>
-<% unless node['bcpc']['nova']['cpu_config']['cpu_model'].nil? %>
-cpu_model = <%= node['bcpc']['nova']['cpu_config']['cpu_model'] %>
+<% unless @cpu_model.nil? %>
+cpu_model = <%= @cpu_model %>
 <% end -%>
-<% unless node['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'].empty? %>
-cpu_model_extra_flags = <%= node['bcpc']['nova']['cpu_config']['cpu_model_extra_flags'].join(',') %>
+<% unless @cpu_model_extra_flag.empty? %>
+cpu_model_extra_flags = <%= @cpu_model_extra_flag.join(',') %>
 <% end -%>
 live_migration_permit_auto_converge = true

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -1,5 +1,5 @@
-# for an overview of all the available configuration options for nova@pike
-# go to: https://docs.openstack.org/nova/pike/configuration/config.html
+# for an overview of all the available configuration options for nova@rocky
+# go to: https://docs.openstack.org/nova/rocky/configuration/config.html
 #
 [DEFAULT]
 debug = false


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

These changes are a fairly straightforward extension to what we have now but allows customization based on the CPU vendor ID, currently either `AuthenticAMD` or `GenuineIntel`. By default, either vendor ID maps to a custom CPU model of `qemu64` with no additional flags added to the configuration. However if the hypervisor supports either the `svm` (AMD) or `vmx` (Intel) virtualization flag, then we set `virt_type` for the `nova-compute` configuration to use `kvm` instead of `qemu`.

It's expected that users would customize their AMD and/or Intel settings via the properties. As it is today, there's no way of specifying a *different* set of flags on a per-hypervisor basis via the Ansible inventory, for example. That's the subject of a future enhancement.

This has been tested in an upstream build as well as internal to Bloomberg configurations. It's also been tested in a nested configuration of running `chef-bcpc` on top of another `chef-bcpc` instance.