### PR TITLE
added ceph installation booleans

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -66,3 +66,8 @@ default['bcpc']['ceph']['bluestore_cache_size_ssd'] = 10737418240
 # deep-flatten. Other values (in particular, exclusive-lock) may prevent
 # instances from being able to access their root file system after a crash.
 default['bcpc']['ceph']['rbd_default_features'] = 33
+
+# ceph mgr,mon,osd service installation flags
+default['bcpc']['ceph']['mgr']['enabled'] = true
+default['bcpc']['ceph']['mon']['enabled'] = true
+default['bcpc']['ceph']['osd']['enabled'] = true

--- a/chef/cookbooks/bcpc/recipes/ceph-mgr.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-mgr.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: ceph-mgr
 #
-# Copyright:: 2019 Bloomberg Finance L.P.
+# Copyright:: 2021 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+return unless node['bcpc']['ceph']['mgr']['enabled']
+
+include_recipe 'bcpc::ceph-packages'
 
 region = node['bcpc']['cloud']['region']
 config = data_bag_item(region, 'config')

--- a/chef/cookbooks/bcpc/recipes/ceph-mon.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-mon.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: ceph-mon
 #
-# Copyright:: 2020 Bloomberg Finance L.P.
+# Copyright:: 2021 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+return unless node['bcpc']['ceph']['mon']['enabled']
 
 include_recipe 'bcpc::ceph-packages'
 

--- a/chef/cookbooks/bcpc/recipes/ceph-osd.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-osd.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: ceph-osd
 #
-# Copyright:: 2020 Bloomberg Finance L.P.
+# Copyright:: 2021 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+return unless node['bcpc']['ceph']['osd']['enabled']
 
 include_recipe 'bcpc::ceph-packages'
 


### PR DESCRIPTION
  - added a ceph mgr,mon and osd "enabled" flag to control recipe
    execution

Signed-off-by: Justin Pacheco <jpacheco39@bloomberg.net>
