### PR TITLE
Pin decorator version due to change breaking rally

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -80,10 +80,15 @@ execute 'install rally in virtualenv' do
   environment env
   retries 3
   user 'rally'
+  # Installation notes:
+  # - 'pip' is pinned to avoid issues when installing `cryptography>3.4` as
+  #     part of `pycryptodome` etc.
+  # - 'decorator' is pinned due to https://bugs.launchpad.net/rally/+bug/1922707
   command <<-EOH
     virtualenv --no-download #{venv_dir} -p /usr/bin/python3
     . #{venv_dir}/bin/activate
     pip install 'pip>=19.1.1'
+    pip install 'decorator<=4.4.2'
     pip install rally-openstack==#{rally_openstack_version} rally==#{rally_version}
   EOH
   not_if "rally --version | grep rally-openstack | grep #{rally_openstack_version}"


### PR DESCRIPTION
Pin the 'decorator' package to a working version. Newer versions break
rally, as described
[here](https://bugs.launchpad.net/rally/+bug/1922707).

Can be reverted once the commit linked to above is merged and made
available.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See above.

**Testing performed**
Ran two jenkins pipelines (one on a vbox agent, one on libvirt agent) and rally tests pass once again.
