### PR TITLE
added metadata cache expiration support

### DIFF
--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -66,7 +66,8 @@ default['bcpc']['nova']['resume_guests_state_on_host_boot'] = false
 default['bcpc']['nova']['default_log_levels'] = nil
 
 # The loopback address matches what Calico's Felix defaults to for metadata
-default['bcpc']['nova']['metadata_listen'] = '127.0.0.1'
+default['bcpc']['nova']['metadata']['listen'] = '127.0.0.1'
+default['bcpc']['nova']['metadata']['cache_expiration'] = 60
 
 # Nova scheduler default filters
 default['bcpc']['nova']['scheduler_default_filters'] = %w(

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -37,7 +37,8 @@ osapi_compute_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% end %>
 <% else %>
 enabled_apis = metadata
-metadata_listen = <%= node['bcpc']['nova']['metadata_listen'] %>
+metadata_cache_expiration = <%= node['bcpc']['nova']['metadata']['cache_expiration'] %>
+metadata_listen = <%= node['bcpc']['nova']['metadata']['listen'] %>
 <% if node['bcpc']['nova']['workers'] %>
 metadata_workers = <%= node['bcpc']['nova']['workers'] %>
 <% else %>


### PR DESCRIPTION
  - attribute is 60 seconds by default
  - updated the metadata_listen param to match the cache_expiration hash
    structure format

Signed-off-by: Justin Pacheco <jpacheco39@bloomberg.net>