### PR TITLE
Clean up unused apt urls 

### DIFF
--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -64,22 +64,6 @@ Vagrant.configure('2') do |config|
       # finish provisioner
       finish_args = []
 
-      if ENV.key?('BCC_APT_URL')
-        finish_args.append("--apt-url #{ENV['BCC_APT_URL']}")
-      end
-
-      if ENV.key?('BCC_APT_KEY_URL')
-        finish_args.append("--apt-key-url #{ENV['BCC_APT_KEY_URL']}")
-      end
-
-      if ENV.key?('http_proxy')
-        finish_args.append("--http-proxy #{ENV['http_proxy']}")
-      end
-
-      if ENV.key?('https_proxy')
-        finish_args.append("--https-proxy #{ENV['https_proxy']}")
-      end
-
       if hw_profile.key?('swap_gb')
         finish_args.append("--swap-size-gb #{hw_profile['swap_gb']}")
       end

--- a/virtual/Vagrantfile.libvirt
+++ b/virtual/Vagrantfile.libvirt
@@ -84,22 +84,6 @@ Vagrant.configure('2') do |config|
       # finish provisioner
       finish_args = []
 
-      if ENV.key?('BCC_APT_URL')
-        finish_args.append("--apt-url #{ENV['BCC_APT_URL']}")
-      end
-
-      if ENV.key?('BCC_APT_KEY_URL')
-        finish_args.append("--apt-key-url #{ENV['BCC_APT_KEY_URL']}")
-      end
-
-      if ENV.key?('http_proxy')
-        finish_args.append("--http-proxy #{ENV['http_proxy']}")
-      end
-
-      if ENV.key?('https_proxy')
-        finish_args.append("--https-proxy #{ENV['https_proxy']}")
-      end
-
       if hw_profile.key?('swap_gb')
         finish_args.append("--swap-size-gb #{hw_profile['swap_gb']}")
       end

--- a/virtual/provisioners/finish.sh
+++ b/virtual/provisioners/finish.sh
@@ -17,19 +17,11 @@
 set -xue
 set -o pipefail
 
-apt_key_url=''
-apt_url=''
-http_proxy=''
-https_proxy=''
 operations_user=''
 operations_user_ssh_pub_key=''
 swap_size_gb=''
 
 ARGUMENT_LIST=(
-    "apt-key-url"
-    "apt-url"
-    "http-proxy"
-    "https-proxy"
     "operations-user"
     "operations-user-ssh-pub-key"
     "swap-size-gb"
@@ -47,26 +39,6 @@ eval set --"$opts"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --apt-key-url)
-            export apt_key_url="$2"
-            shift 2
-            ;;
-
-        --apt-url)
-            export apt_url="$2"
-            shift 2
-            ;;
-
-        --http-proxy)
-            export http_proxy=$2
-            shift 2
-            ;;
-
-        --https-proxy)
-            export https_proxy=$2
-            shift 2
-            ;;
-
         --operations-user)
             export operations_user="$2"
             shift 2


### PR DESCRIPTION
Signed-off-by: Jing Geng <jgeng25@bloomberg.net>

Since we moved most provisioning steps to building a packer box, we no longer need the apt and http env vars when we provision the VMs. So I'm cleaning up these unused env vars. 
