### PR TITLE
Upgrade to Calico 3.15.5

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -167,8 +167,8 @@ assets_files:
     filename: etcd-v3.3.10-linux-amd64.tar.gz
 
   - name: calicoctl
-    url: https://github.com/projectcalico/calicoctl/releases/download/v3.15.4/calicoctl-linux-amd64
-    checksum: sha256:c2cbfaee6b56461453f0ef9bbf758ff792a1490f7e49ae18e4469653c9afc0f4
+    url: https://github.com/projectcalico/calicoctl/releases/download/v3.15.5/calicoctl-linux-amd64
+    checksum: sha256:f49e9e8d25108f7f22d5a51c756b2fe40cbe36347ad297e31a767376172f2845
     filename: calicoctl
 
   - name: consul

--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -12,4 +12,21 @@ default['bcpc']['calico']['calicoctl']['remote']['file'] = 'calicoctl'
 default['bcpc']['calico']['calicoctl']['remote']['source'] =
  "#{default['bcpc']['web_server']['url']}/calicoctl"
 default['bcpc']['calico']['calicoctl']['remote']['checksum'] =
- 'c2cbfaee6b56461453f0ef9bbf758ff792a1490f7e49ae18e4469653c9afc0f4'
+ 'f49e9e8d25108f7f22d5a51c756b2fe40cbe36347ad297e31a767376172f2845'
+
+# calico-felix
+default['bcpc']['calico']['felix']['failsafe']['inbound'] = [
+  'tcp:22',
+  'tcp:179',
+  'tcp:2379',
+  'tcp:2380',
+]
+
+default['bcpc']['calico']['felix']['failsafe']['outbound'] = [
+  'tcp:53',
+  'udp:53',
+  'udp:123',
+  'tcp:179',
+  'tcp:2379',
+  'tcp:2380',
+]

--- a/chef/cookbooks/bcpc/recipes/calico-felix.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-felix.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: calico-felix
 #
-# Copyright:: 2020 Bloomberg Finance L.P.
+# Copyright:: 2021 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,7 +40,9 @@ end
 template '/etc/calico/felix.cfg' do
   source 'calico/felix.cfg.erb'
   variables(
-    cert_type: cert_type
+    cert_type: cert_type,
+    failsafe_inbound: node['bcpc']['calico']['felix']['failsafe']['inbound'],
+    failsafe_outbound: node['bcpc']['calico']['felix']['failsafe']['outbound']
   )
   notifies :restart, 'service[calico-felix]', :immediately
 end

--- a/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
@@ -35,13 +35,13 @@ UsageReportingEnabled = false
 
 # UDP/TCP/SCTP protocol/port pairs that Felix will allow incoming traffic
 # to host endpoints on irrespective of the security policy.
-FailsafeInboundHostPorts = tcp:22,tcp:179,tcp:2379,tcp:2380
+FailsafeInboundHostPorts = <%= @failsafe_inbound.join(',') %>
 
 # UDP/TCP/SCTP protocol/port pairs that Felix will allow outgoing traffic
 # from host endpoints to irrespective of the security policy.
 # TCP 53 (DNS), UDP 53 (DNS), UDP 123 (NTP), TCP 179 (BGP),
 # TCP 2379 & 2380 (etcd)
-FailsafeOutboundHostPorts = tcp:53,udp:53,udp:123,tcp:179,tcp:2379,tcp:2380
+FailsafeOutboundHostPorts = <%= @failsafe_outbound.join(',') %>
 
 # IPv6 support for Felix
 Ipv6Support = false


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

Upgrades Calico to 3.15.5 which includes the following enhancement:

https://github.com/projectcalico/felix/pull/2721
https://github.com/projectcalico/felix/pull/2748

Tested by building a cluster, creating instances, and verifying the fail-safe enhancement by adding host endpoints and checking a source-specific fail-safe SSH inbound was successful for that source only. Also, manually verified the IP Tables chains (`cali-failsafe-in` & `cali-failsafe-out`) were as expected.