### PR TITLE
memcached: Keep attributes in a common place

### DIFF
--- a/chef/cookbooks/bcpc/attributes/default.rb
+++ b/chef/cookbooks/bcpc/attributes/default.rb
@@ -69,15 +69,6 @@ default['bcpc']['metadata']['vendordata']['enabled'] = false
 # default['bcpc']['metadata']['vendordata']['driver'] = "nova.api.metadata.bcpc_metadata.BcpcMetadata"
 
 ###############################################################################
-# memcached
-###############################################################################
-
-# Enable memcached double verbose logging.
-default['bcpc']['memcached']['debug'] = false
-# Set number of memcached connections.
-default['bcpc']['memcached']['connections'] = 10240
-
-###############################################################################
 # virtualbox
 ###############################################################################
 

--- a/chef/cookbooks/bcpc/attributes/memcached.rb
+++ b/chef/cookbooks/bcpc/attributes/memcached.rb
@@ -2,6 +2,12 @@
 # Memcached
 ###############################################################################
 
+# Enable memcached double verbose logging.
+default['bcpc']['memcached']['debug'] = false
+
+# Set number of memcached connections.
+default['bcpc']['memcached']['connections'] = 10240
+
 # Specifies memcached maximum limit of RAM to use for item
 # storage (in megabytes). Note carefully that this isn't a global memory limit
 default['bcpc']['memcached']['memory'] = 64


### PR DESCRIPTION
Some memcached attributes were in a memcached-specific
file, while others were lumped in the default attribute
file.  Move them all to the same location for consistency.