### PR TITLE
Pin the jinja2 package used by rally

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -84,11 +84,15 @@ execute 'install rally in virtualenv' do
   # - 'pip' is pinned to avoid issues when installing `cryptography>3.4` as
   #     part of `pycryptodome` etc.
   # - 'decorator' is pinned due to https://bugs.launchpad.net/rally/+bug/1922707
+  # - 'jinja2' is pinned due to a change in how 3.0.0+ handles variables set in
+  #     templates containing macros. This change breaks rally tasks used
+  #     internally by Bloomberg, which likely need to be fixed.
   command <<-EOH
     virtualenv --no-download #{venv_dir} -p /usr/bin/python3
     . #{venv_dir}/bin/activate
     pip install 'pip>=19.1.1'
     pip install 'decorator<=4.4.2'
+    pip install 'jinja2<3.0.0'
     pip install rally-openstack==#{rally_openstack_version} rally==#{rally_version}
   EOH
   not_if "rally --version | grep rally-openstack | grep #{rally_openstack_version}"


### PR DESCRIPTION
Custom rally tasks used by Bloomberg are failing with the latest 3.x.x
release. Once it is determined whether it is a problem with
customizations, core openstack-rally code or the jinja2 package itself
a relevant bug report will be filed.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See commit message.

**Testing performed**
Tested on internal Jenkins pipeline.
