### PR TITLE
Do not install recommended packages

### DIFF
--- a/chef/cookbooks/bcpc/recipes/etcd3gw.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd3gw.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: etcd3gw
 #
-# Copyright:: 2019 Bloomberg Finance L.P.
+# Copyright:: 2021 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package 'python-futurist'
+package %w(
+  python-futurist
+  python-setuptools
+)
 
 target = node['bcpc']['etcd3gw']['remote_file']['file']
 save_path = "#{Chef::Config[:file_cache_path]}/#{target}"

--- a/virtual/packer/packer_box_provision.sh
+++ b/virtual/packer/packer_box_provision.sh
@@ -50,6 +50,8 @@ deb ${apt_url} bionic-updates main restricted universe multiverse
 EOF
     fi
 
+    echo 'APT::Install-Recommends "false";' \
+	 >> /etc/apt/apt.conf.d/99no-install-recommends
     apt-get update
 }
 


### PR DESCRIPTION

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
- tell apt never install apt recommended packages right in the packer box
- add python-setuptools to common packages (needed for etcd3gtw recipe

**Testing performed**
Builds clean most of the time. Some large builds require chefing the first head node be restarted due to an apparent race condition where neutron-server restarts in chef/cookbooks/bcpc/recipes/neutron-head.rb sometimes fail. That will be the subject of a separate PR

**Additional context**
Part of an effort to strip down BCC cluster member nodes to their mimimal essential packages to reduce the "surface area"to look at when reviewing CVEs and similar.
