### PR TITLE
Delay neutron restart upon installing calico-control

### DIFF
--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -211,7 +211,7 @@ end
 #
 package 'calico-control' do
   action :upgrade
-  notifies :restart, 'service[neutron-server]', :immediately
+  notifies :restart, 'service[neutron-server]', :delayed
 end
 
 template '/etc/neutron/neutron.conf' do


### PR DESCRIPTION
We have been seeing neutron-server.rb fail in larger builds from time to time, especially on faster machines. The neutron service is not ready to start just after calico control is installed and the restart is not useful at that time anyway.

**Describe your changes**
Work by @justinjpacheco to narrow down a fix : just adjust the restart upon installing calico-control package to be delayed.

**Testing performed**
Justin tested multiple large scale builds with a multi-pod leaf/spine, 3h3w3r openstack topology, all succeeded cleanly. I repeated this once more on a minimal openstack cluster (1h1w) and again clean.

