### PR TITLE
Cleanup of some unnecessary files in the Packer box

### DIFF
--- a/virtual/packer/config.json
+++ b/virtual/packer/config.json
@@ -5,6 +5,7 @@
       "environment_vars": [
         "BCC_APT_KEY_URL={{user `bcc_apt_key_url`}}",
         "BCC_APT_URL={{user `bcc_apt_url`}}",
+        "BCC_BASE_BOX_PROVIDER={{user `base_box_provider`}}",
         "BCC_KERNEL_VERSION={{user `kernel_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",

--- a/virtual/packer/packer_box_provision.sh
+++ b/virtual/packer/packer_box_provision.sh
@@ -51,7 +51,7 @@ EOF
     fi
 
     echo 'APT::Install-Recommends "false";' \
-	 >> /etc/apt/apt.conf.d/99no-install-recommends
+         >> /etc/apt/apt.conf.d/99no-install-recommends
     apt-get update
 }
 
@@ -79,8 +79,9 @@ function configure_linux_kernel {
 
 function cleanup_image {
     # autoremoving packages and cleaning apt data
-    apt-get -y --purge autoremove;
-    apt-get -y clean;
+    apt-get -y --purge autoremove
+    apt-get -y clean
+    apt-get -y purge libfakeroot
 
     # remove /var/cache
     find /var/cache -type f -exec rm -rf {} \;
@@ -101,6 +102,14 @@ function cleanup_image {
     # clear the history so our install isn't there
     rm -f /root/.wget-hsts
     export HISTSIZE=0
+
+    # remove VirtualBox Guest Additions when libvirt is in use
+    if [ "${BCC_BASE_BOX_PROVIDER}" == "libvirt" ]; then
+        systemctl disable vboxadd
+        systemctl disable vboxadd-service
+        systemctl reset-failed
+        rm -rf /opt/VBoxGuestAdditions-*
+    fi
 }
 
 function download_debs {


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

There are some files left in the built Packer box that can cause warnings in VMs based on it. In particular:

* There are orphaned configuration files left from `libfakeroot` (inherited from the base box)

* When using `libvirt`, the presence of the VirtualBox guest additions cause `systemctl --failed` to report failed services