### PR TITLE
Calico plugin should be installed prior to `neutron.conf` being rendered

### DIFF
--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -136,6 +136,12 @@ end
 # neutron package installation and service definition starts
 #
 package 'neutron-server'
+
+package 'calico-control' do
+  action :upgrade
+  notifies :restart, 'service[neutron-server]', :delayed
+end
+
 service 'neutron-server'
 
 service 'haproxy-neutron' do
@@ -209,10 +215,6 @@ end
 
 # configure neutron starts
 #
-package 'calico-control' do
-  action :upgrade
-  notifies :restart, 'service[neutron-server]', :delayed
-end
 
 template '/etc/neutron/neutron.conf' do
   source 'neutron/neutron.conf.erb'


### PR DESCRIPTION
Signed-off-by: David Comay <david.comay@gmail.com>

This fixes a race I introduced in #1807 and which I actually made worse in #1831 because I missed that `/etc/neutron/neutron.conf` was being rendered explicitly via a `notifies` when the Neutron database is created. The solution is to move the `package calico-control` back near the front of the file but to retain its own restart of `neutron-server` as a delayed action as figured out by @mihalis68 and @justinjpacheco.