### PR TITLE
added message-ttl for versioned nova notifications

### DIFF
--- a/chef/cookbooks/bcpc/attributes/rabbitmq.rb
+++ b/chef/cookbooks/bcpc/attributes/rabbitmq.rb
@@ -19,3 +19,7 @@ default['bcpc']['rabbitmq']['ulimit']['nofile'] = 4096
 
 # Heartbeat timeout to detect dead RabbitMQ brokers
 default['bcpc']['rabbitmq']['heartbeat'] = 60
+
+# TTL for messages on the Nova (versioned) notifications queue that is consumed
+# by Watcher
+default['bcpc']['rabbitmq']['message_ttl']['watcher'] = 10 * 60 * 1000 # 10 minutes

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -165,3 +165,11 @@ novncproxy_base_url = <%= "https://#{node['bcpc']['cloud']['fqdn']}:6080/vnc_aut
 [notifications]
 notification_format = <%= node['bcpc']['nova']['notifications']['format'] %>
 notify_on_state_change = <%= node['bcpc']['nova']['notifications']['notify_on_state_change'] %>
+<% if node['bcpc']['nova']['notifications']['format'] != 'unversioned' %>
+# The default value for 'versioned_notifications_topics' is
+# 'versioned_notifications'. However, we are changing it to
+# 'watcher_notifications' as Watcher is the only consumer for these
+# notifications at this time, and Watcher does not clean up the queue after
+# consuming the messages as it uses 'pool' option from oslo_messaging.
+versioned_notifications_topics = watcher_notifications
+<% end %>

--- a/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
@@ -23,7 +23,7 @@ auth_type = password
 lock_path = /var/lock/watcher
 
 [oslo_messaging_notifications]
-ver = messagingv2
+driver = messagingv2
 
 [watcher_clients_auth]
 auth_url = <%= "https://#{@node['bcpc']['cloud']['fqdn']}:35357/" %>
@@ -36,3 +36,11 @@ auth_uri = <%= "https://#{@node['bcpc']['cloud']['fqdn']}:5000/" %>
 memcached_servers = <%= @headnodes.map{ |n| "#{n['service_ip']}:11211" }.join(',') %>
 auth_type = password
 
+<% if node['bcpc']['nova']['notifications']['format'] != 'unversioned' %>
+[watcher_decision_engine]
+# The default value for 'notifications_topics' is
+# 'nova.versioned_notifications,watcher.watcher_notifications'. However, we are
+# changing it to match the queue name for versioned messages that we have
+# configured in nova config file.
+notification_topics = nova.watcher_notifications,watcher.watcher_notifications
+<% end %>


### PR DESCRIPTION
Signed-off-by: Ajay Tikoo <atikoo@bloomberg.net>

**Description of changes**
Watcher relies on versioned notifications for keeping its cluster data model in
sync between periodic rebuilds. However, with versioned notifications
enabled, they remain in the rabbitmq queue as they are not consumed by
anything (though Watcher is using these messages, it may be requeing
them). In order to avoid the queues to grow indefinitely, we need to set a
`message-ttl` for the notification queues for versioned nova notifications.
The TTL has been set to 10 minutes, but can be changed in the attributes file.

**Testing performed**
These changes have been validated to be working as expected in the lab
environment
