### PR TITLE
Add support for Query Rules + add config option

### DIFF
--- a/chef/cookbooks/bcpc/attributes/proxysql.rb
+++ b/chef/cookbooks/bcpc/attributes/proxysql.rb
@@ -38,6 +38,7 @@ default['bcpc']['proxysql']['max_connections'] = 32768
 default['bcpc']['proxysql']['have_ssl'] = false
 default['bcpc']['proxysql']['use_tcp_keepalive'] = false
 default['bcpc']['proxysql']['wait_timeout'] = 28800000
+default['bcpc']['proxysql']['server_capabilities'] = 569899
 default['bcpc']['proxysql']['multiplexing'] = true
 default['bcpc']['proxysql']['free_connections_pct'] = 10
 default['bcpc']['proxysql']['long_query_time'] = 10000
@@ -108,3 +109,9 @@ default['bcpc']['proxysql']['mysql_users']['fast_forward'] = 1
 
 # The maximum number of allowable frontend connections for a specific user
 default['bcpc']['proxysql']['mysql_users']['max_connections'] = 32768
+
+# Query Rules
+
+# An array of rules, each containing a key=value pair, defining the query rules
+# ProxySQL will be configured with.
+default['bcpc']['proxysql']['query_rules'] = nil

--- a/chef/cookbooks/bcpc/recipes/proxysql.rb
+++ b/chef/cookbooks/bcpc/recipes/proxysql.rb
@@ -210,7 +210,8 @@ template '/etc/proxysql.cnf' do
     headnodes: headnodes(all: true),
     creds: config['proxysql']['creds'],
     backend: mysqlbackend,
-    mysql_users: config['mysql']['users']
+    mysql_users: config['mysql']['users'],
+    query_rules: node['bcpc']['proxysql']['query_rules']
   )
   notifies :start, 'service[proxysql conditional start]', :immediately
   notifies :run, 'bcpc_proxysql_reload[reload config]', :immediately

--- a/chef/cookbooks/bcpc/templates/default/proxysql/proxysql.cnf.erb
+++ b/chef/cookbooks/bcpc/templates/default/proxysql/proxysql.cnf.erb
@@ -175,6 +175,10 @@ mysql_variables=
 
     ############################ Backend Related ##############################
 
+    # The bitmask of MySQL capabilities (encoded as bits) with which the proxy
+    # will respond to clients connecting to it.
+    server_capabilities=<%= node['bcpc']['proxysql']['server_capabilities'] %>
+
     # Whether or not to allow multiple frontend connections to re-use the same
     # database backend connection.
     multiplexing=<%= node['bcpc']['proxysql']['multiplexing'] %>
@@ -402,4 +406,24 @@ proxysql_servers =
         weight=0
         comment="<%= node['hostname'] %>"
     },
+)
+
+###
+### Query Rules
+###
+
+# See https://proxysql.com/documentation/main-runtime/#mysql_query_rules for
+# more information.
+
+mysql_query_rules =
+(
+<% if !@query_rules.nil? %>
+  <% @query_rules.each do |r| %>
+    {
+    <% r[1].each do |p| %>
+        <%= p[0] %>=<%= p[1] %>
+    <% end %>
+    },
+  <% end %>
+<% end %>
 )


### PR DESCRIPTION
Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
Added changes to the automation to allow users to specify what query rules ProxySQL should be configured with.

**Testing performed**
Changes tested both in a local BVE and on a physical test cluster.

**Additional context**
Also made ProxySQL's `server_capabilities` parameter configurable. 
