### PR TITLE
Break out nova worker attributes

### DIFF
--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -51,7 +51,8 @@ default['bcpc']['nova']['max_concurrent_builds'] = 4
 
 # "workers" parameters in nova are set to number of CPUs
 # available by default. This provides an override.
-default['bcpc']['nova']['workers'] = nil
+default['bcpc']['nova']['metadata']['workers'] = nil
+default['bcpc']['nova']['osapi_workers'] = nil
 default['bcpc']['placement']['workers'] = nil
 
 # set soft/hard ulimits in upstart unit file for nova-compute

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -31,8 +31,8 @@ transport_url = rabbit://<%= @rmqnodes.map{|n| "#{@config['rabbit']['username']}
 osapi_compute_link_prefix = <%= "https://#{node["bcpc"]['cloud']["fqdn"]}:8774" %>
 enabled_apis = osapi_compute
 osapi_compute_listen = <%= node['service_ip'] %>
-<% if node['bcpc']['nova']['workers'] %>
-osapi_compute_workers = <%= node['bcpc']['nova']['workers'] %>
+<% if node['bcpc']['nova']['osapi_workers'] %>
+osapi_compute_workers = <%= node['bcpc']['nova']['osapi_workers'] %>
 <% else %>
 osapi_compute_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% end %>
@@ -40,8 +40,8 @@ osapi_compute_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 enabled_apis = metadata
 metadata_cache_expiration = <%= node['bcpc']['nova']['metadata']['cache_expiration'] %>
 metadata_listen = <%= node['bcpc']['nova']['metadata']['listen'] %>
-<% if node['bcpc']['nova']['workers'] %>
-metadata_workers = <%= node['bcpc']['nova']['workers'] %>
+<% if node['bcpc']['nova']['metadata']['workers'] %>
+metadata_workers = <%= node['bcpc']['nova']['metadata']['workers'] %>
 <% else %>
 metadata_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% end %>


### PR DESCRIPTION
Allow the setting of the number of nova-api-metadata and osapi_compute
workers independently of one another.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See description.

**Testing performed**
Tested on a physical test cluster.
