### PR TITLE
Asset downloads are properly retried

### DIFF
--- a/ansible/playbooks/roles/localhost/tasks/download-asset.yml
+++ b/ansible/playbooks/roles/localhost/tasks/download-asset.yml
@@ -4,11 +4,13 @@
   when: item.environment is defined
 
 - name: "download: {{ item.name }}"
-  retries: 5
-  delay: 10
   get_url:
     url: "{{ item.url }}"
     checksum: "{{ item.checksum }}"
     dest: "{{ assets_download_dir }}/{{ item.filename }}"
     validate_certs: "{{ validate_certs | default(true) }}"
   environment: "{{ local_environment | default({}) }}"
+  retries: 5
+  delay: 10
+  register: result
+  until: result is succeeded


### PR DESCRIPTION
Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
Asset downloads were not being properly retried because the task statement was missing the `until` clause, which tells ansible when to stop retrying.

**Testing performed**
Manual testing on a BVE was performed as well as on an internal Jenkins pipeline.

**Additional context**
Checked remaining ansible code to ensure the same mistake was not made elsewhere and it was not. See [this](https://github.com/bloomberg/chef-bcpc/blob/master/ansible/playbooks/roles/common/tasks/configure-bgp.yml#L49) for the only other place we use the `retries` command.
