### PR TITLE
On error, leave VM created during Packer build for analysis

### DIFF
--- a/virtual/packer/bin/create-packer-box.sh
+++ b/virtual/packer/bin/create-packer-box.sh
@@ -75,6 +75,7 @@ lower_packer_ver=$(printf '%s\n' "$required_packer_ver" "$current_packer_ver" \
 if [ "$lower_packer_ver" = "$required_packer_ver" ]; then
     VAGRANT_VAGRANTFILE=Vagrantfile packer build \
                         --force \
+                        --on-error=abort \
                         --var-file=variables.json \
                         "config.json"
     cd "output-vagrant"


### PR DESCRIPTION
Signed-off-by: David Comay <david.comay@gmail.com>

This change will leave around the `source` VM created during the Packer build process when an error occurs so that it can be examined to determine the cause of the failure.