### PR TITLE
configure-chrony: fix IPv4/6 compatibility issue

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-chrony.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-chrony.yml
@@ -8,6 +8,12 @@
     dest: /etc/chrony/chrony.conf
   register: chrony
 
+- name: configure chrony defaults
+  template:
+    src: chrony/default.j2
+    dest: /etc/default/chrony
+  register: chrony_defaults
+
 - name: create systemd dependency work-around directory for chrony
   file:
     path: /etc/systemd/system/chrony.service.d
@@ -35,4 +41,4 @@
   systemd:
     name: chrony
     state: restarted
-  when: chrony.changed
+  when: chrony.changed or chrony_defaults.changed

--- a/ansible/playbooks/roles/common/templates/chrony/default.j2
+++ b/ansible/playbooks/roles/common/templates/chrony/default.j2
@@ -1,0 +1,10 @@
+# This is a configuration file for /etc/init.d/chrony and
+# /lib/systemd/system/chrony.service; it allows you to pass various options to
+# the chrony daemon without editing the init script or service file.
+
+# Options to pass to chrony.
+DAEMON_OPTS="{{ '-4' if not system_enable_ipv6 else '' }}"
+
+# Sync system clock in containers or without CAP_SYS_TIME (likely to fail)
+# See /usr/share/doc/chrony/README.container for details.
+SYNC_IN_CONTAINER="no"


### PR DESCRIPTION
When the chef-bcpc `system_enable_ipv6` attribute is set to
`False`, it may be the case that `chrony` still tries to
open `AF_INET6` sockets to connect to timeservers.

This will result in `chrony` failing to start with the
following logged to the system journal:
```
Jun 08 21:37:38 <hostname> chronyd[5708]: Could not open IPv6 command socket : Address family not supported by protocol
```

To avoid this, configure `chrony` to start with `-4` when
`system_enable_ipv6` is set to `False`.