### PR TITLE
etcd3gw: Install all requirements

### DIFF
--- a/chef/cookbooks/bcpc/recipes/etcd3gw.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd3gw.rb
@@ -17,7 +17,12 @@
 
 package %w(
   python-futurist
+  python-pbr
+  python-requests
   python-setuptools
+  python-six
+  python-urllib3
+  python-wheel
 )
 
 target = node['bcpc']['etcd3gw']['remote_file']['file']


### PR DESCRIPTION
The etcd3gw package tries to install a wheel, and some
package which was implicitly depending on wheel no longer
does.  This causes the setuptools bdist_wheel step to
fail.

Specify all requirements for etcd3gw ahead of time and
install them via apt to avoid this scenario.