### PR TITLE
Update databag generation script for watcher

### DIFF
--- a/virtual/bin/lib/bcc_chef_databags.py
+++ b/virtual/bin/lib/bcc_chef_databags.py
@@ -499,6 +499,18 @@ class BCCChefDatabags:
                 'key': self.api_ssl.key(),
                 'crt': self.api_ssl.crt(),
                 'intermediate': None
+            },
+            'watcher': {
+                'creds': {
+                    'db': {
+                        'username': 'watcher',
+                        'password': self.generate_string()
+                    },
+                    'os': {
+                        'username': 'watcher',
+                        'password': self.generate_string()
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Watcher credentials are now also generated by the databag generation
script.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See above

**Testing performed**
Changes used when generating databags for a cluster.

**Additional context**
None
