### PR TITLE
Send the Retry-After header in 429 responses

### DIFF
--- a/chef/cookbooks/bcpc/attributes/haproxy.rb
+++ b/chef/cookbooks/bcpc/attributes/haproxy.rb
@@ -57,3 +57,6 @@ default['bcpc']['haproxy']['qos']['exemptions'] = []
 
 # SLO link returned in 429 responses
 default['bcpc']['haproxy']['qos']['slo_url'] = nil
+
+# The value of the Retry-After header specified in 429 responses
+default['bcpc']['haproxy']['qos']['retry_after'] = 5

--- a/chef/cookbooks/bcpc/templates/default/haproxy/429.http.erb
+++ b/chef/cookbooks/bcpc/templates/default/haproxy/429.http.erb
@@ -2,6 +2,7 @@ HTTP/1.0 429 Too Many Requests
 Cache-Control: no-cache
 Connection: close
 Content-Type: text/html
+Retry-After: <%= node['bcpc']['haproxy']['qos']['retry_after'] %>
 
 <html><body><h1>429 Too Many Requests</h1>
 You have executed too many requests and have been rate limited. Please see the service SLO<% if not node['bcpc']['haproxy']['qos']['slo_url'].nil? %> at <%= node['bcpc']['haproxy']['qos']['slo_url'] %><% end %> for more information.


### PR DESCRIPTION
Gophercloud as of
[this](https://github.com/gophercloud/utils/pull/144/files) PR provides
a default retry function that reads the Retry-After header in the 429
response to determine until when it should sleep before retrying the API
call. The number of retries performed can easily be specified by end
users (see
[this](https://github.com/terraform-provider-openstack/terraform-provider-openstack/pull/1159/files)
PR to Terraform's terraform-provider-openstack provider).

The issue is the default retry function does not execute if the
Retry-After header is not specified, even though the relevant RFC states
that the header *may* or may not be specified. End clients of BCC using
terraform and the corresponding terraform-provider-openstack provider
cannot easily define their own retry function. An
[issue](https://github.com/gophercloud/utils/issues/155) has been
created in gophercloud/util to fix this, but in the meanwhile this
header must be specified in order for the retry functionality to work.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
Added the Retry-After header to 429 responses.

**Testing performed**
Tested on an internal test cluster.

**Additional context**
See commit description.
