### PR TITLE
increased retry timeout for watcher's vm migration

### DIFF
--- a/chef/cookbooks/bcpc/files/default/watcher/conf/__init__.py
+++ b/chef/cookbooks/bcpc/files/default/watcher/conf/__init__.py
@@ -1,0 +1,62 @@
+# -*- encoding: utf-8 -*-
+# Copyright (c) 2016 b<>com
+# Copyright (c) 2016 Intel Corp
+#
+# Authors: Vincent FRANCOISE <vincent.francoise@b-com.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oslo_config import cfg
+
+from watcher.conf import api
+from watcher.conf import applier
+from watcher.conf import ceilometer_client
+from watcher.conf import cinder_client
+from watcher.conf import clients_auth
+from watcher.conf import collector
+from watcher.conf import db
+from watcher.conf import decision_engine
+from watcher.conf import exception
+from watcher.conf import glance_client
+from watcher.conf import gnocchi_client
+from watcher.conf import ironic_client
+from watcher.conf import monasca_client
+from watcher.conf import neutron_client
+from watcher.conf import nova_client
+from watcher.conf import nova_helper
+from watcher.conf import paths
+from watcher.conf import planner
+from watcher.conf import service
+
+CONF = cfg.CONF
+
+service.register_opts(CONF)
+api.register_opts(CONF)
+paths.register_opts(CONF)
+exception.register_opts(CONF)
+db.register_opts(CONF)
+planner.register_opts(CONF)
+applier.register_opts(CONF)
+decision_engine.register_opts(CONF)
+monasca_client.register_opts(CONF)
+nova_client.register_opts(CONF)
+nova_helper.register_opts(CONF)
+glance_client.register_opts(CONF)
+gnocchi_client.register_opts(CONF)
+cinder_client.register_opts(CONF)
+ceilometer_client.register_opts(CONF)
+neutron_client.register_opts(CONF)
+clients_auth.register_opts(CONF)
+ironic_client.register_opts(CONF)
+collector.register_opts(CONF)

--- a/chef/cookbooks/bcpc/files/default/watcher/conf/nova_helper.py
+++ b/chef/cookbooks/bcpc/files/default/watcher/conf/nova_helper.py
@@ -1,0 +1,42 @@
+# -*- encoding: utf-8 -*-
+# Copyright (c) 2021 Bloomberg LP
+#
+# Authors: Ajay Tikoo <atikoo@bloomberg.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oslo_config import cfg
+
+nova_helper = cfg.OptGroup(name='nova_helper',
+                           title='Configuration Options for nova_helper module')
+
+NOVA_HELPER_OPTS = [
+    cfg.IntOpt('instance_migration_timeout',
+               default='120',
+               min=120,
+               help='Number of seconds to wait for migration to complete'),
+    cfg.IntOpt('instance_migration_poll_interval',
+               default='1',
+               min=1,
+               help='Number of seconds to wait between migration status checks'),
+]
+
+
+def register_opts(conf):
+    conf.register_group(nova_helper)
+    conf.register_opts(NOVA_HELPER_OPTS, group=nova_helper)
+
+
+def list_opts():
+    return [('nova_helper', NOVA_HELPER_OPTS)]

--- a/chef/cookbooks/bcpc/recipes/watcher.rb
+++ b/chef/cookbooks/bcpc/recipes/watcher.rb
@@ -19,6 +19,7 @@ return unless node['bcpc']['watcher']['enabled']
 
 region = node['bcpc']['cloud']['region']
 config = data_bag_item(region, 'config')
+config_options = node['bcpc']['watcher']
 
 mysqladmin = mysqladmin()
 psqladmin = psqladmin()
@@ -130,8 +131,37 @@ watcher_processes = if !node['bcpc']['watcher']['api_workers'].nil?
                       node['bcpc']['openstack']['services']['workers']
                     end
 
+# install patched conf/nova_helper.py
+# added configuration options for nova instance migration times
+cookbook_file '/usr/lib/python2.7/dist-packages/watcher/conf/nova_helper.py' do
+  source 'watcher/conf/nova_helper.py'
+  notifies :run, 'execute[pycompile-nova-helper-conf]', :immediately
+  notifies :restart, 'service[watcher-applier]', :delayed
+  notifies :restart, 'service[watcher-decision-engine]', :delayed
+end
+
+execute 'pycompile-nova-helper-conf' do
+  action :nothing
+  command 'pycompile /usr/lib/python2.7/dist-packages/watcher/conf/nova_helper.py'
+end
+
+# install patched conf/__init__.py
+# implements configuration options for nova instance migration times
+cookbook_file '/usr/lib/python2.7/dist-packages/watcher/conf/__init__.py' do
+  source 'watcher/conf/__init__.py'
+  notifies :run, 'execute[pycompile-conf-init-file]', :immediately
+  notifies :restart, 'service[watcher-applier]', :delayed
+  notifies :restart, 'service[watcher-decision-engine]', :delayed
+end
+
+execute 'pycompile-conf-init-file' do
+  action :nothing
+  command 'pycompile /usr/lib/python2.7/dist-packages/watcher/conf/__init__.py'
+end
+
 # install patched nova_helper.py
-# implements these fixes:
+# uses configurtion options for nova instance migration times, and implements
+# the following bug fixes:
 # 1. https://review.opendev.org/c/openstack/watcher/+/610905
 # 2. https://review.opendev.org/c/openstack/watcher/+/615819
 cookbook_file '/usr/lib/python2.7/dist-packages/watcher/common/nova_helper.py' do
@@ -225,6 +255,7 @@ template '/etc/watcher/watcher.conf' do
     db: database,
     os: openstack,
     config: config,
+    config_options: config_options,
     is_headnode: headnode?,
     headnodes: headnodes(all: true),
     rmqnodes: rmqnodes(all: true),

--- a/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
@@ -36,6 +36,12 @@ auth_uri = <%= "https://#{@node['bcpc']['cloud']['fqdn']}:5000/" %>
 memcached_servers = <%= @headnodes.map{ |n| "#{n['service_ip']}:11211" }.join(',') %>
 auth_type = password
 
+<% if @config_options.has_key? 'nova_helper' %>
+[nova_helper]
+instance_migration_timeout = <%= @config_options['nova_helper']['instance_migration']['timeout'] %>
+instance_migration_poll_interval = <%= @config_options['nova_helper']['instance_migration']['poll_interval'] %>
+<% end %>
+
 <% if node['bcpc']['nova']['notifications']['format'] != 'unversioned' %>
 [watcher_decision_engine]
 # The default value for 'notifications_topics' is


### PR DESCRIPTION
**Describe your changes**
When migrating an instance, Watcher polls to check the status of the migrating instance for 120 seconds. If migration does not complete (or fail) within this time, Watcher considers that the migration failed, does not try to migrate any pending instances, and marks the action plan as failed. In a large production environment, it generally takes longer time for a migration to complete. In order to avoid Watcher failing a migration prematurely, this change makes the timeout and poll interval a configurable parameter, which defaults to the same values as are right now hard coded in the code (120 seconds and 1 second respectively). In environments where it normally takes longer to live migrate instances, Watcher can be configured with higher timeouts so that it will not consider a migration failed unless it actually fails or takes longer than the configured time to migrate.

Changes in the patched files:
1. **conf/__init__.py**: the changes to this file are two additional lines, one importing nova_helper from watcher.conf, and other registering its config options.
2. **conf/nova_helper.py**: this is a new file, which implements the configuration items for nova_helper.

**Testing performed**
Testing has been performed in the virtual lab environment.