### PR TITLE
Set keys stored in memcached to expire in 24 hours

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
@@ -12,6 +12,7 @@ driver = <%= node['bcpc']['keystone']['drivers']['assignment'] %>
 [cache]
 enabled = <%= node['bcpc']['keystone']['enable_caching'] %>
 backend = oslo_cache.memcache_pool
+backend_argument = memcached_expire_time:86400
 memcache_servers = <%= @headnodes.map{ |h| "#{h['service_ip']}:11211" }.join(',') %>
 memcache_dead_retry = 60
 memcache_socket_timeout = 1

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -127,6 +127,7 @@ topics = <%= node['bcpc']['nova']['notifications']['topics'] %>
 [cache]
 enabled = true
 backend = oslo_cache.memcache_pool
+backend_argument = memcached_expire_time:86400
 memcache_servers = <%= @headnodes.map{|n| "#{n['service_ip']}:11211" }.join(",") %>
 
 [quota]


### PR DESCRIPTION
Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
Change the default expiration time of key/value pairs set on memcached via dogpile.cache from 0 (never expire) to 24 hours.

**Testing performed**
Created a 3h3w BVE with the changes and ran simple rally tests against it. All tests passed and no non-expiring keys were found in memcached afterwards.

**Additional context**
OpenStack services store values in memcached via both oslo.cache (a wrapper for dogpile.cache) and directly via a memcached client. When using oslo.cache we currently specify the default expiration time for keys as understood by dogpile.cache, but the backing keys created by said library in memcached are set to never expire. Thus values that were last used over a month ago can still be present in memcached because, although dogpile.cache recognizes them as expired, it never removed them from the backing store.

This results in the number of values stored by memcached growing continuously until it reaches the maximum amount of memory allocated for it, after which it evicts LRU entries as needed.

This change sets the memcached_expire_time dogpile.cache backend parameter to a high value (24 hours) and therefore limits the amount of time a dogpile.cache key/value pair is stored on memcached without being updated. dogpile.cache is never configured to store values for longer than a few minutes so this would ensure that valid values (as understood by dogpile.cache) are not evicted earlier than expected. This would also ensure that we only store a days worth of stale cache entries, reduce load on the memcached crawler (fewer entries to scan), remove the need to periodically restart memcached due to large memory usage, and free-up tens of gigabytes of RAM on headnodes.
