### PR TITLE
netplan: Drop match: macaddress from configuration

### DIFF
--- a/ansible/playbooks/roles/common/templates/netplan/transit.yaml.j2
+++ b/ansible/playbooks/roles/common/templates/netplan/transit.yaml.j2
@@ -4,6 +4,4 @@ network:
     {{ item['name'] }}:
       addresses:
         - {{ item['ip'] }}
-      match:
-        macaddress: {{ item['mac'] }}
       mtu: {{ networking['mtu'] }}


### PR DESCRIPTION
Specifying the MAC address of the transit interfaces can
create operational hurdles when NICs are replaced. As
we use deterministic network interface names vis-a-vi
`systemd`, we do not need to also match on the MAC
address.