### PR TITLE
`nova-api-metadata` can use a local `memcached` on the hypervisor

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -138,6 +138,7 @@ chef_roles:
     chef_type: role
     run_list:
       - role[node]
+      - recipe[bcpc::memcached]
       - recipe[bcpc::calico-work]
       - recipe[bcpc::nova-compute]
 

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -127,7 +127,11 @@ topics = <%= node['bcpc']['nova']['notifications']['topics'] %>
 [cache]
 enabled = true
 backend = oslo_cache.memcache_pool
+<% if @is_headnode -%>
 memcache_servers = <%= @headnodes.map{|n| "#{n['service_ip']}:11211" }.join(",") %>
+<% else %>
+memcache_servers = <%= "#{node['service_ip']}:11211" %>
+<% end %>
 
 [quota]
 <% node['bcpc']['nova'].fetch('quota',{}).fetch('default',{}).each do |resource, limit| %>


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

This proposed change adds `memcached` to worknodes and sets their configuration to use the local server for non-Keystone related objects, in particular Nova metadata. This is safe to do as `nova-api-metadata` when run directly on hypervisors should never be querying data except for their own instances.