### PR TITLE
ceph: Add option to disable progress module

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -106,3 +106,6 @@ default['bcpc']['ceph']['rbd_default_features'] = 33
 default['bcpc']['ceph']['mgr']['enabled'] = true
 default['bcpc']['ceph']['mon']['enabled'] = true
 default['bcpc']['ceph']['osd']['enabled'] = true
+
+# ceph mgr module configuration
+default['bcpc']['ceph']['module']['progress']['enabled'] = false

--- a/chef/cookbooks/bcpc/recipes/ceph-mgr.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-mgr.rb
@@ -36,3 +36,8 @@ execute 'create ceph mgr daemon' do
   command "ceph-deploy mgr create #{node['hostname']}"
   creates "/var/lib/ceph/mgr/ceph-#{node['hostname']}/done"
 end
+
+execute 'configure progress module' do
+  command "ceph progress #{node['bcpc']['ceph']['module']['progress']['enabled'] ? 'on' : 'off'}"
+  not_if "ceph config get mgr mgr/progress/enabled | grep -w #{node['bcpc']['ceph']['module']['progress']['enabled']}"
+end


### PR DESCRIPTION
Add a configurable option to (by default) disable the progress module.