### PR TITLE
Revert "ceph: Add option to disable progress module"

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -106,6 +106,3 @@ default['bcpc']['ceph']['rbd_default_features'] = 33
 default['bcpc']['ceph']['mgr']['enabled'] = true
 default['bcpc']['ceph']['mon']['enabled'] = true
 default['bcpc']['ceph']['osd']['enabled'] = true
-
-# ceph mgr module configuration
-default['bcpc']['ceph']['module']['progress']['enabled'] = false

--- a/chef/cookbooks/bcpc/recipes/ceph-mgr.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-mgr.rb
@@ -36,8 +36,3 @@ execute 'create ceph mgr daemon' do
   command "ceph-deploy mgr create #{node['hostname']}"
   creates "/var/lib/ceph/mgr/ceph-#{node['hostname']}/done"
 end
-
-execute 'configure progress module' do
-  command "ceph progress #{node['bcpc']['ceph']['module']['progress']['enabled'] ? 'on' : 'off'}"
-  not_if "ceph config get mgr mgr/progress/enabled | grep -w #{node['bcpc']['ceph']['module']['progress']['enabled']}"
-end


### PR DESCRIPTION
This reverts commit a2fe25ddd3067a0ee4ffd3f6dc21d8ac1bfd3d58
as it was causing clean cluster build issues.