### PR TITLE
Rename ansible_ssh_user to ansible_user

### DIFF
--- a/virtual/files/ansible/vars/virtual.yml
+++ b/virtual/files/ansible/vars/virtual.yml
@@ -6,7 +6,7 @@ root_dir: "{{ inventory_dir | dirname }}"
 virtual_dir: "{{ root_dir }}/virtual"
 virtual_ssh_dir: "{{ virtual_dir }}/files/ssh"
 ansible_ssh_private_key_file: "{{ virtual_ssh_dir }}/id_ed25519"
-ansible_ssh_user: operations
+ansible_user: operations
 operator_authorized_key: >
   {{ lookup('file', ansible_ssh_private_key_file + '.pub') }}
 ansible_ssh_common_args: >


### PR DESCRIPTION
The variable ansible_ssh_user has been deprecated since Ansible 2.0 and
no longer works as expected in the newest version of Ansible.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See commit description.

**Testing performed**
Internal jenkins pipeline passes. Older versions of ansible (e.g. 2.10.8) still work.

**Additional context**
N/A
