### PR TITLE
Various improvements to the ProxySQL automation

### DIFF
--- a/chef/cookbooks/bcpc/attributes/proxysql.rb
+++ b/chef/cookbooks/bcpc/attributes/proxysql.rb
@@ -52,11 +52,18 @@ default['bcpc']['proxysql']['server_capabilities'] = 569899
 default['bcpc']['proxysql']['enable_client_deprecate_eof'] = false
 default['bcpc']['proxysql']['enable_server_deprecate_eof'] = false
 default['bcpc']['proxysql']['multiplexing'] = true
+default['bcpc']['proxysql']['connect_timeout_server'] = 1000
+default['bcpc']['proxysql']['connect_timeout_server_max'] = 10000
+default['bcpc']['proxysql']['connect_retries_on_failure'] = 10
+default['bcpc']['proxysql']['connect_retries_delay'] = 10
+default['bcpc']['proxysql']['shun_on_failures'] = 5
+default['bcpc']['proxysql']['shun_recovery_time_sec'] = 10
 default['bcpc']['proxysql']['free_connections_pct'] = 10
 default['bcpc']['proxysql']['long_query_time'] = 10000
 default['bcpc']['proxysql']['default_query_timeout'] = 86400000
 default['bcpc']['proxysql']['max_transaction_time'] = 14400000
 default['bcpc']['proxysql']['query_retries_on_failure'] = 1
+default['bcpc']['proxysql']['monitor_history'] = 3600000
 
 # Galera Hostgroup Variables
 
@@ -91,8 +98,9 @@ default['bcpc']['proxysql']['mysql_servers']['compression'] = 0
 # The maximum number of connections ProxySQL will establish to each backend
 default['bcpc']['proxysql']['mysql_servers']['max_connections'] = node['bcpc']['mysql']['max_connections']
 
-# If greater than 0 and a backend's replication lag surpasses the given
-# threshold it will be shunned until it catches up.
+# If greater than 0, and a backend's replication lag surpasses the given
+# threshold, it will be shunned until it catches up. This is set to 0
+# (disabled) in favor of max_transactions_behind.
 default['bcpc']['proxysql']['mysql_servers']['max_replication_lag'] = 0
 
 # Whether or not to enable SSL on ProxySQL-MySQL connections
@@ -117,7 +125,7 @@ default['bcpc']['proxysql']['mysql_users']['transaction_persistent'] = 0
 
 # If set queries bypass the query processing layer and are sent directly to the
 # backend server
-default['bcpc']['proxysql']['mysql_users']['fast_forward'] = 1
+default['bcpc']['proxysql']['mysql_users']['fast_forward'] = 0
 
 # The maximum number of allowable frontend connections for a specific user
 default['bcpc']['proxysql']['mysql_users']['max_connections'] = 32768

--- a/chef/cookbooks/bcpc/templates/default/consul/proxysql-check-helper.erb
+++ b/chef/cookbooks/bcpc/templates/default/consul/proxysql-check-helper.erb
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
+# Check connectivity to ProxySQL's admin interface
 mysqladmin status \
     --connect-timeout 10 \
     -u <%= @config['proxysql']['creds']['stats']['username'] %> \
@@ -21,3 +24,31 @@ mysqladmin status \
     -h localhost \
     --protocol=TCP \
     -P <%= node['bcpc']['proxysql']['admin_port'] %> 2> /dev/null
+
+set +e
+
+# Check connectivity via ProxySQL to a backend. Ideally this check will only
+# fail when all MySQL backends have encountered an issue, and thus switching
+# the primary will serve no purpose. However, as described in
+# https://github.com/sysown/proxysql/issues/3618, ProxySQL has at least one
+# bug that would require such a move.
+#
+# This check is forgiving because in a vast majority of cases ProxySQL will
+# handle backend failures just fine. It is designed to catch scenarios like
+# the one described in the bug report linked to above.
+MAX_ATTEMPTS=3
+ATTEMPTS=0
+while ! mysql -nNE \
+      --connect-timeout 10 \
+      -u root \
+      -p<%= @config['mysql']['users']['root']['password'] %> \
+      -h localhost \
+      --protocol=TCP \
+      -P <%= node['bcpc']['proxysql']['port'] %> \
+      -e "SELECT VERSION();" 2> /dev/null ; do
+    ((ATTEMPTS=ATTEMPTS+1))
+    if [ ${ATTEMPTS} -ge ${MAX_ATTEMPTS} ]; then
+        exit 1
+    fi
+    sleep 1
+done

--- a/chef/cookbooks/bcpc/templates/default/proxysql/proxysql.cnf.erb
+++ b/chef/cookbooks/bcpc/templates/default/proxysql/proxysql.cnf.erb
@@ -203,21 +203,32 @@ mysql_variables=
 
     # The delay (in milliseconds) before trying to reconnect after a failed
     # attempt to a backend MySQL server.
-    #connect_retries_delay=1
+    # NOTE: When changing, keep in mind values of other connect_* variables, as
+    # well as the values of shun_*.
+    connect_retries_delay=<%= node['bcpc']['proxysql']['connect_retries_delay'] %>
 
     # The number of times for which a reconnect should be attempted in case of
     # an error, timeout, or any other event that led to an unsuccessful
     # connection to a backend MySQL server.
-    #connect_retries_on_failure=10
+    connect_retries_on_failure=<%= node['bcpc']['proxysql']['connect_retries_on_failure'] %>
 
     # The timeout (in milliseconds) for a single attempt at connecting to a
     # backend server from the proxy.
-    #connect_timeout_server=1000
+    connect_timeout_server=<%= node['bcpc']['proxysql']['connect_timeout_server'] %>
 
     # The timeout for connecting to a backend server from the proxy. When this
     # timeout is reached, an error is returned to the client with code 9001 and
     # the message “Max connect timeout reached while reaching hostgroup…”.
-    #connect_timeout_server_max=10000
+    connect_timeout_server_max=<%= node['bcpc']['proxysql']['connect_timeout_server_max'] %>
+
+    # The maximum number of connection errors per second to a backend before
+    # it is temporarily SHUNNED.
+    shun_on_failures=<%= node['bcpc']['proxysql']['shun_on_failures'] %>
+
+    # The minimum amount of time ProxySQL will wait before attempting to place
+    # online a backend that was automatically SHUNNED.
+    # NOTE: Must be less than or equal to connect_timeout_server_max/1000.
+    shun_recovery_time_sec=<%= node['bcpc']['proxysql']['shun_recovery_time_sec'] %>
 
     # Percentage of open idle connections allowed from the total maximum number
     # of connections for a specific server in a hostgroup.
@@ -312,7 +323,7 @@ mysql_variables=
 
     # The duration for which the events for the checks made by the Monitor
     # module are kept (milliseconds).
-    #monitor_history=600000
+    monitor_history=<%= node['bcpc']['proxysql']['monitor_history'] %>
 
     ########################### Query Cache Related ###########################
 


### PR DESCRIPTION
- Allow in-place upgrades of ProxySQL
- When re-installing ProxySQL, back up the existing datadir
- Have consul switch the ProxySQL primary not only when ProxySQL is not
reachable, but also when a MySQL backend is not reachable via ProxySQL
- Expose several more ProxySQL configuration variables as chef attributes
- Increase the amount of time ProxySQL monitor logs are stored
- When uninstalling ProxySQL the process is never terminated; terminate
it at the end of a chef run
- Set fast_forward to false as default
- Updated comments

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See the description above.

**Testing performed**
Manual testing of additions on a local BVE + internal Jenkins pipeline.

**Additional context**
Add any other context about your contribution here.
