### PR TITLE
Lower time it takes before a down OSD is marked out

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -64,7 +64,7 @@ default['bcpc']['ceph']['tcmalloc_max_total_thread_cache_bytes'] = '128MB'
 # Set the max open fds at the OS level
 default['bcpc']['ceph']['max_open_files'] = 2048
 
-# Set tunables for ceph osd reovery
+# Set tunables for Ceph OSD recovery
 default['bcpc']['ceph']['paxos_propose_interval'] = 1
 default['bcpc']['ceph']['osd_recovery_max_active'] = 1
 default['bcpc']['ceph']['osd_recovery_threads'] = 2
@@ -77,6 +77,7 @@ default['bcpc']['ceph']['osd_deep_scrub_interval'] = 2592000
 default['bcpc']['ceph']['osd_scrub_max_interval'] = 604800
 default['bcpc']['ceph']['osd_scrub_sleep'] = 0.05
 default['bcpc']['ceph']['osd_memory_target'] = 9663676416
+default['bcpc']['ceph']['mon_osd_down_out_interval'] = 300
 
 # BlueStore tuning
 default['bcpc']['ceph']['bluestore_rocksdb_options'] = [

--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -10,6 +10,7 @@ max open files = <%= node['bcpc']['ceph']['max_open_files'] %>
 rbd default features = <%= node['bcpc']['ceph']['rbd_default_features'] %>
 osd crush initial weight = <%= node['bcpc']['ceph']['osd_crush_initial_weight'] %>
 admin socket mode = 0775
+mon osd down out interval = <%= node['bcpc']['ceph']['mon_osd_down_out_interval'] %>
 
 # settings to throttle OSD scrubbing visible to both mgrs and OSDs
 osd deep scrub interval = <%= @node['bcpc']['ceph']['osd_deep_scrub_interval'] %>
@@ -18,7 +19,7 @@ osd scrub max interval = <%= @node['bcpc']['ceph']['osd_scrub_max_interval'] %>
 [mon]
 auth allow insecure global id reclaim = <%= node['bcpc']['ceph']['mon_auth_allow_insecure_global_id_reclaim'] %>
 mon compact on start = true
-mon_cpu_threads = <%= node['bcpc']['ceph']['mon_cpu_threads'] %>
+mon cpu threads = <%= node['bcpc']['ceph']['mon_cpu_threads'] %>
 
 [mgr]
 mon mgr beacon grace = <%= node['bcpc']['ceph']['mon_mgr_beacon_grace'] %>


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

This was tested by running the relevant recipe and then verifying that an OSD was marked out 300 seconds after it was marked down.

This also makes the `mon cpu threads` parameter rendered in a consistent manner with all of the other parameters in `ceph.conf`. I also verified on the resulting storage headnode that the configuration value was as expected (16).