### PR TITLE
Np consul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ all : \
 	configure-chef-nodes \
 	configure-web-server \
 	configure-common-node \
+	configure-consul-cluster \
 	run-chef-client \
 	reweight-ceph-osds \
 	add-cloud-images \
@@ -103,6 +104,12 @@ configure-common-node :
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/configure-common-node.yml \
 		--limit cloud
+
+configure-consul-cluster :
+
+	ansible-playbook -v \
+		-i ${inventory} ${playbooks}/site.yml \
+		-t configure-consul --limit headnodes
 
 run-chef-client : \
 	run-chef-client-bootstraps \

--- a/ansible/playbooks/consulnodes.yml
+++ b/ansible/playbooks/consulnodes.yml
@@ -1,0 +1,6 @@
+- hosts: headnodes
+  gather_facts: no
+  serial: "{{ step | default(ansible_play_batch | length) }}"
+  roles:
+    - common
+    - consul

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -5,13 +5,13 @@
 consul_filename: "\
   {% for asset in assets_files %}\
     {% if asset.name == 'consul' %}\
-      asset.filename\
+      {{ asset.filename }}\
     {% endif %}\
   {% endfor %}"
 consul_checksum: "\
   {% for asset in assets_files %}\
     {% if asset.name == 'consul' %}\
-      asset.checksum\
+      {{ asset.checksum }}\
     {% endif %}\
   {% endfor %}"
 

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -8,4 +8,5 @@ consul_checksum: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a75
 executable: /usr/local/sbin/consul
 config_directory: /etc/consul/conf.d
 config_data_directory: /var/lib/consul
-bcpc_scripts_directory: /usr/local/bcpc
+bcpc_scripts_directory: /usr/local/bcpc/bin
+service_ip: "{{ hostvars[inventory_hostname]['interfaces']['service']['ip'] }}"

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -8,7 +8,7 @@ consul_checksum: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a75
 executable: /usr/local/sbin/consul
 config_directory: /etc/consul/conf.d
 config_data_directory: /var/lib/consul
-bcpc_scripts_directory: /usr/local/bcpc/bin
+bcpc_directory: /usr/local/bcpc/bin
 chef_databags_config_directory: /chef/databags/config.json
 
 service_ip: "{{ hostvars[inventory_hostname]['interfaces']['service']['ip'] }}"
@@ -16,13 +16,27 @@ service_ip: "{{ hostvars[inventory_hostname]['interfaces']['service']['ip'] }}"
 client_address: 127.0.0.1
 consul_dns_port: 8600
 
-script_names:
-    - if_leader.j2
-    - if_primary_mysql.sh.j2
-    - if_not_primary_mysql.sh.j2
-    - if_primary_proxysql.sh.j2
-    - if_not_primary_proxysql.sh.j2
-    - proxysql-check-helper.j2
+scripts:
+  - if_leader.j2
+  - if_primary_mysql.sh.j2
+  - if_not_primary_mysql.sh.j2
+  - if_primary_proxysql.sh.j2
+  - if_not_primary_proxysql.sh.j2
+  - proxysql-check-helper.j2
+
+service_checks:
+  - dns-check
+  - haproxy-check
+  - mysql-check
+  - proxysql-check
+
+service_watches:
+  - cloud-ip-watch
+  - service-elect-watch
+  - service-watch
+  - service-elect-watch
+  - service-watch
+  - cloud-ip-watch
 
 services_interval: 10s
 services_timeout: 2s

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -1,0 +1,8 @@
+###############################################################################
+# consul files
+###############################################################################
+
+consul_filename: consul_1.7.2_linux_amd64.zip
+consul_checksum: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698
+
+executable: /usr/local/sbin/consul

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -9,7 +9,12 @@ executable: /usr/local/sbin/consul
 config_directory: /etc/consul/conf.d
 config_data_directory: /var/lib/consul
 bcpc_scripts_directory: /usr/local/bcpc/bin
+chef_databags_config_directory: /chef/databags/config.json
+
 service_ip: "{{ hostvars[inventory_hostname]['interfaces']['service']['ip'] }}"
+
+client_address: 127.0.0.1
+consul_dns_port: 8600
 
 script_names:
     - if_leader.j2

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -6,3 +6,5 @@ consul_filename: consul_1.7.2_linux_amd64.zip
 consul_checksum: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698
 
 executable: /usr/local/sbin/consul
+config_directory: /etc/consul/conf.d
+config_data_directory: /var/lib/consul

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -34,9 +34,6 @@ service_watches:
   - cloud-ip-watch
   - service-elect-watch
   - service-watch
-  - service-elect-watch
-  - service-watch
-  - cloud-ip-watch
 
 services_interval: 10s
 services_timeout: 2s

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -2,8 +2,18 @@
 # consul files
 ###############################################################################
 
-consul_filename: consul_1.7.2_linux_amd64.zip
-consul_checksum: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698
+consul_filename: "\
+  {% for asset in assets_files %}\
+    {% if asset.name == 'consul' %}\
+      asset.filename\
+    {% endif %}\
+  {% endfor %}"
+consul_checksum: "\
+  {% for asset in assets_files %}\
+    {% if asset.name == 'consul' %}\
+      asset.checksum\
+    {% endif %}\
+  {% endfor %}"
 
 executable: /usr/local/sbin/consul
 config_directory: /etc/consul/conf.d

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -10,3 +10,11 @@ config_directory: /etc/consul/conf.d
 config_data_directory: /var/lib/consul
 bcpc_scripts_directory: /usr/local/bcpc/bin
 service_ip: "{{ hostvars[inventory_hostname]['interfaces']['service']['ip'] }}"
+
+scripts_name:
+    - if_leader.j2
+    - if_primary_mysql.sh.j2
+    - if_not_primary_mysql.sh.j2
+    - if_primary_proxysql.sh.j2
+    - if_not_primary_proxysql.sh.j2
+    - proxysql-check-helper.j2

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -19,5 +19,9 @@ script_names:
     - if_not_primary_proxysql.sh.j2
     - proxysql-check-helper.j2
 
+services_interval: 10s
+services_timeout: 2s
+
 proxysql_admin_port: 6032
 proxysql_port: 6033
+myysql_port: 3306

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -18,3 +18,6 @@ script_names:
     - if_primary_proxysql.sh.j2
     - if_not_primary_proxysql.sh.j2
     - proxysql-check-helper.j2
+
+proxysql_admin_port: 6032
+proxysql_port: 6033

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -8,3 +8,4 @@ consul_checksum: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a75
 executable: /usr/local/sbin/consul
 config_directory: /etc/consul/conf.d
 config_data_directory: /var/lib/consul
+bcpc_scripts_directory: /usr/local/bcpc

--- a/ansible/playbooks/roles/consul/defaults/main.yml
+++ b/ansible/playbooks/roles/consul/defaults/main.yml
@@ -11,7 +11,7 @@ config_data_directory: /var/lib/consul
 bcpc_scripts_directory: /usr/local/bcpc/bin
 service_ip: "{{ hostvars[inventory_hostname]['interfaces']['service']['ip'] }}"
 
-scripts_name:
+script_names:
     - if_leader.j2
     - if_primary_mysql.sh.j2
     - if_not_primary_mysql.sh.j2

--- a/ansible/playbooks/roles/consul/defaults/proxysql.yml
+++ b/ansible/playbooks/roles/consul/defaults/proxysql.yml
@@ -1,0 +1,2 @@
+proxysql_admin_port: 6032
+proxysql_port: 6033

--- a/ansible/playbooks/roles/consul/defaults/proxysql.yml
+++ b/ansible/playbooks/roles/consul/defaults/proxysql.yml
@@ -1,2 +1,0 @@
-proxysql_admin_port: 6032
-proxysql_port: 6033

--- a/ansible/playbooks/roles/consul/files/dns-check
+++ b/ansible/playbooks/roles/consul/files/dns-check
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+unbound-control status || exit 1
+#pdns_control rping || exit 2

--- a/ansible/playbooks/roles/consul/files/haproxy-check
+++ b/ansible/playbooks/roles/consul/files/haproxy-check
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+killall -0 haproxy

--- a/ansible/playbooks/roles/consul/files/mysql-check
+++ b/ansible/playbooks/roles/consul/files/mysql-check
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2018, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+curl -I -q localhost:3307 2>/dev/null | grep 'HTTP/1.1 200'

--- a/ansible/playbooks/roles/consul/files/proxysql-check
+++ b/ansible/playbooks/roles/consul/files/proxysql-check
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2021, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+/usr/local/bcpc/bin/proxysql-check-helper

--- a/ansible/playbooks/roles/consul/handlers/main.yml
+++ b/ansible/playbooks/roles/consul/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: restart consul
+  import_tasks: restart_consul.yml
+
+- name: start consul
+  import_tasks: start_consul.yml

--- a/ansible/playbooks/roles/consul/handlers/main.yml
+++ b/ansible/playbooks/roles/consul/handlers/main.yml
@@ -3,3 +3,4 @@
 
 - name: start consul
   import_tasks: start_consul.yml
+  

--- a/ansible/playbooks/roles/consul/handlers/main.yml
+++ b/ansible/playbooks/roles/consul/handlers/main.yml
@@ -3,4 +3,3 @@
 
 - name: start consul
   import_tasks: start_consul.yml
-  

--- a/ansible/playbooks/roles/consul/handlers/restart_consul.yml
+++ b/ansible/playbooks/roles/consul/handlers/restart_consul.yml
@@ -1,0 +1,5 @@
+- name: restart consul
+  service:
+    name: consul
+    state: restarted
+  listen: 'restart consul'

--- a/ansible/playbooks/roles/consul/handlers/restart_consul.yml
+++ b/ansible/playbooks/roles/consul/handlers/restart_consul.yml
@@ -1,5 +1,5 @@
 - name: restart consul
-  service:
+  ansible.builtin.service:
     name: consul
     state: restarted
   listen: 'restart consul'

--- a/ansible/playbooks/roles/consul/handlers/restart_consul.yml
+++ b/ansible/playbooks/roles/consul/handlers/restart_consul.yml
@@ -1,5 +1,3 @@
 - name: restart consul
-  ansible.builtin.service:
-    name: consul
-    state: restarted
+  command: sudo systemctl restart consul.service
   listen: 'restart consul'

--- a/ansible/playbooks/roles/consul/handlers/start_consul.yml
+++ b/ansible/playbooks/roles/consul/handlers/start_consul.yml
@@ -1,0 +1,5 @@
+- name: start consul
+  service:
+    name: consul
+    state: started
+  listen: 'start consul'

--- a/ansible/playbooks/roles/consul/handlers/start_consul.yml
+++ b/ansible/playbooks/roles/consul/handlers/start_consul.yml
@@ -1,5 +1,5 @@
 - name: start consul
-  service:
+  ansible.builtin.service:
     name: consul
     state: started
   listen: 'start consul'

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -40,10 +40,6 @@
     mode: 0644
   notify: restart consul
 
-- name: read chef databags
-  set_fact:
-    chef_databags: "{{ lookup('file', (inventory_dir | dirname) + '{{ chef_databags_config_directory }}') }}"
-
 - name: copy consul scripts
   template:
     src: "{{ item }}"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -61,7 +61,7 @@
     owner: root
     group: root
     mode: 0755
-  loop: {{ service-checks }}
+  loop: "{{ service-checks }}"
   
 
 - name: configure consul config-services-watches

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -2,7 +2,6 @@
   tempfile:
     state: directory
     prefix: ansible-consul.
-    mode:
   register: temp_directory
 
 - name: unarchive consul

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -73,14 +73,14 @@
   loop: "{{ service_watches }}"
 
 - name: configure consul bootstrap config
+  set_fact:
+    bootstrap: 'true'
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     owner: root
     group: root
     mode: 0644
-  set_fact:
-    bootstrap: true
   run_once: yes
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
@@ -89,14 +89,14 @@
   notify: restart consul
 
 - name: configure consul servers config
+  set_fact:
+    bootstrap: 'false'
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     owner: root
     group: root
     mode: 0644
-  set_fact:
-    bootstrap: false
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -49,8 +49,6 @@
     src: "{{ item }}"
     dest: "{{ bcpc_scripts_directory }}"
     mode: 0644
-  vars_files:
-    - proxysql.yml
   loop: "{{ script_names }}"
 
 - name: reload systemd

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -44,6 +44,21 @@
   set_fact:
     chef_databags: "{{ lookup('file', (inventory_dir | dirname) + '/chef/databags/config.json') }}"
 
+- name: copy consul leader, mysql and proxysql check scripts
+  template:
+    src: "{{ item.j2 }}"
+    dest: "{{ bcpc_scripts_directory }}"
+    owner: root
+    group: root
+    mode: 0775
+  loop:
+    - if_leader
+    - if_primary_mysql.sh
+    - if_not_primary_mysql.sh
+    - if_primary_proxysql.sh
+    - if_not_primary_proxysql.sh
+    - proxysql-check-helper
+
 - name: reload systemd
   systemd:
     service: consul.service

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -49,8 +49,9 @@
     src: "{{ item }}"
     dest: "{{ bcpc_scripts_directory }}"
     mode: 0644
-  loop:
-    - "{{ scripts_name }}"
+  vars_files:
+    - proxysql.yml
+  loop: "{{ script_names }}"
 
 - name: reload systemd
   systemd:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -61,7 +61,7 @@
     owner: root
     group: root
     mode: 0755
-  loop: "{{ service-checks }}"
+  loop: "{{ service_checks }}"
   
 
 - name: configure consul config-services-watches

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -29,7 +29,7 @@
   loop:
     - "{{ config_directory }}"
     - "{{ config_data_directory }}"
-    - "{{ bcpc_scripts_directory }}"
+    - "{{ bcpc_directory }}"
 
 - name: create consul service file systemd
   template:
@@ -47,11 +47,22 @@
 - name: copy consul scripts
   template:
     src: "{{ item }}"
-    dest: "{{ bcpc_scripts_directory }}/{{ item.split('.j2')[0] }}"
+    dest: "{{ bcpc_directory }}/{{ item.split('.j2')[0] }}"
     owner: root
     group: root
     mode: 0755
   loop: "{{ script_names }}"
+  notify: restart consul
+
+- name: copy consul services checks
+  copy:
+    src: "{{ item }}"
+    dest: "{{ bcpc_directory }}"
+    owner: root
+    group: root
+    mode: 0755
+  loop: {{ service-checks }}
+  
 
 - name: configure consul config-services-watches
   template:
@@ -64,6 +75,7 @@
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}
     - {src: 'config.json.j2', dest: '{{ config_directory }}/config.json'}
+  notify: restart consul
 
 - name: reload systemd
   systemd:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -47,9 +47,19 @@
 - name: copy consul scripts
   template:
     src: "{{ item }}"
-    dest: "{{ bcpc_scripts_directory }}"
-    mode: 0644
+    dest: "{{ bcpc_scripts_directory }}/{{ item.split('.j2')[0] }}"
+    owner: root
+    group: root
+    mode: 0755
   loop: "{{ script_names }}"
+
+- name: copy consul services config
+  template:
+    src: services.json.j2
+    dest: "{{ config_directory }}/services.json"
+    owner: root
+    group: root
+    mode: 0755
 
 - name: reload systemd
   systemd:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -44,7 +44,7 @@
   set_fact:
     chef_databags: "{{ lookup('file', (inventory_dir | dirname) + '/chef/databags/config.json') }}"
 
-- name: copy consul leader, mysql and proxysql check scripts
+- name: copy consul scripts
   template:
     src: "{{ item.j2 }}"
     dest: "{{ bcpc_scripts_directory }}"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -64,7 +64,7 @@
   loop: "{{ service_checks }}"
 
 - name: copy consul services watches
-  copy:
+  template:
     src: "{{ item }}"
     dest: "{{ bcpc_directory }}"
     owner: root

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -2,6 +2,7 @@
   tempfile:
     state: directory
     prefix: ansible-consul.
+    mode:
   register: temp_directory
 
 - name: unarchive consul

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -72,25 +72,7 @@
     mode: 0755
   loop: "{{ service_watches }}"
 
-- name: configure consul bootstrap config
-  set_fact:
-    bootstrap_val: 'true'
-  template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    owner: root
-    group: root
-    mode: 0644
-  run_once: yes
-  loop:
-    - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
-    - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}
-    - {src: 'config.json.j2', dest: '{{ config_directory }}/config.json'}
-  notify: restart consul
-
 - name: configure consul servers config
-  set_fact:
-    bootstrap_val: 'false'
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -9,11 +9,22 @@
     src: "{{ assets_download_dir }}/{{ consul_filename }}"
     dest: "{{ temp_directory.path }}/"
     creates: "{{ temp_directory.path }}/consul"
+    mode: 0755
 
 - name: install consul
   copy:
     src: "{{ temp_directory.path }}/consul"
     dest: "{{ executable }}"
+    remote_src: yes
     mode: 0755
-  notify:
-    - restart consul
+  notify: restart consul
+
+- name: Daemon reload systemd in case the binaries upgraded
+  systemd:
+    daemon_reload: yes
+  become: true
+
+- name: Cleanup
+  file:
+    path: "{{ temp_directory.path }}"
+    state: "absent"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -62,7 +62,15 @@
     group: root
     mode: 0755
   loop: "{{ service_checks }}"
-  
+
+- name: copy consul services watches
+  copy:
+    src: "{{ item }}"
+    dest: "{{ bcpc_directory }}"
+    owner: root
+    group: root
+    mode: 0755
+  loop: "{{ service_watches }}"
 
 - name: configure consul config-services-watches
   template:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -79,6 +79,7 @@
     owner: root
     group: root
     mode: 0644
+  bootstrap: true
   run_once: yes
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
@@ -93,6 +94,7 @@
     owner: root
     group: root
     mode: 0644
+  bootstrap: false
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -9,3 +9,11 @@
     src: "{{ assets_download_dir }}/{{ consul_filename }}"
     dest: "{{ temp_directory.path }}/"
     creates: "{{ temp_directory.path }}/consul"
+
+- name: install consul
+  copy:
+    src: "{{ install_temp.path }}/consul"
+    dest: "{{ executable }}"
+    mode: 0755
+  notify:
+    - restart consul

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -79,7 +79,8 @@
     owner: root
     group: root
     mode: 0644
-  bootstrap: true
+  set_fact:
+    bootstrap: true
   run_once: yes
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
@@ -94,7 +95,8 @@
     owner: root
     group: root
     mode: 0644
-  bootstrap: false
+  set_fact:
+    bootstrap: false
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -74,7 +74,7 @@
 
 - name: configure consul bootstrap config
   set_fact:
-    bootstrap: 'true'
+    bootstrap_val: 'true'
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -90,7 +90,7 @@
 
 - name: configure consul servers config
   set_fact:
-    bootstrap: 'false'
+    bootstrap_val: 'false'
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -30,7 +30,6 @@
     - "{{ config_directory }}"
     - "{{ config_data_directory }}"
     - "{{ bcpc_scripts_directory }}"
-    - "{{ bcpc_scripts_directory }}/bin"
 
 - name: create consul service file systemd
   template:
@@ -40,6 +39,14 @@
     group: root
     mode: 0644
   notify: restart consul
+
+- name: read the Chef databags
+  set_fact:
+    chef_databags: "{{ lookup('file', (inventory_dir | dirname) + '/chef/databags/config.json') }}"
+
+- name: "print chef data bags"
+  debug:
+    msg: "chef data bags are {{ chef_databags }}"
 
 - name: reload systemd
   systemd:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -79,12 +79,12 @@
     owner: root
     group: root
     mode: 0644
+  run_once: yes
+  consul_bootstrap: inventory_hostname
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}
     - {src: 'config.json.j2', dest: '{{ config_directory }}/config.json'}
-  run_once: yes
-  consul_bootstrap: inventory_hostname
   notify: restart consul
 
 - name: configure consul servers config-services-watches

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -53,13 +53,16 @@
     mode: 0755
   loop: "{{ script_names }}"
 
-- name: copy consul services config
+- name: copy consul services and watches config
   template:
-    src: services.json.j2
-    dest: "{{ config_directory }}/services.json"
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
     owner: root
     group: root
     mode: 0755
+  loop:
+    - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
+    - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}
 
 - name: reload systemd
   systemd:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -1,4 +1,4 @@
-- name: create temp directory
+- name: create temp download directory
   tempfile:
     state: directory
     prefix: ansible-consul.
@@ -19,7 +19,7 @@
     mode: 0755
   notify: restart consul
 
-- name: create config directories
+- name: create consul config directories
   file:
     path: "{{ item }}"
     state: directory
@@ -40,9 +40,9 @@
     mode: 0644
   notify: restart consul
 
-- name: read the Chef databags
+- name: read chef databags
   set_fact:
-    chef_databags: "{{ lookup('file', (inventory_dir | dirname) + '/chef/databags/config.json') }}"
+    chef_databags: "{{ lookup('file', (inventory_dir | dirname) + '{{ chef_databags_config_directory }}') }}"
 
 - name: copy consul scripts
   template:
@@ -53,7 +53,7 @@
     mode: 0755
   loop: "{{ script_names }}"
 
-- name: configure consul services and watches
+- name: configure consul config-services-watches
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -72,7 +72,7 @@
     daemon_reload: yes
   notify: restart consul
 
-- name: cleanup
+- name: cleanup temp download directory
   file:
     path: "{{ temp_directory.path }}"
     state: "absent"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -72,7 +72,22 @@
     mode: 0755
   loop: "{{ service_watches }}"
 
-- name: configure consul config-services-watches
+- name: configure consul bootstrap config-services-watches
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: 0644
+  loop:
+    - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
+    - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}
+    - {src: 'config.json.j2', dest: '{{ config_directory }}/config.json'}
+  run_once: yes
+  consul_bootstrap: inventory_hostname
+  notify: restart consul
+
+- name: configure consul servers config-services-watches
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -84,6 +99,7 @@
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}
     - {src: 'config.json.j2', dest: '{{ config_directory }}/config.json'}
   notify: restart consul
+  when: inventory_hostname != consul_bootstrap
 
 - name: reload systemd
   systemd:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -59,7 +59,7 @@
     dest: "{{ item.dest }}"
     owner: root
     group: root
-    mode: 0755
+    mode: 0644
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -12,7 +12,7 @@
 
 - name: install consul
   copy:
-    src: "{{ itemp_directory.path }}/consul"
+    src: "{{ temp_directory.path }}/consul"
     dest: "{{ executable }}"
     mode: 0755
   notify:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -53,7 +53,7 @@
     mode: 0755
   loop: "{{ script_names }}"
 
-- name: copy consul services and watches config
+- name: configure consul services and watches
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -63,6 +63,7 @@
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}
+    - {src: 'config.json.j2', dest: '{{ config_directory }}/config.json'}
 
 - name: reload systemd
   systemd:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -10,7 +10,7 @@
     state: present
 
 - name: unarchive consul
-  copy:
+  unarchive:
     src: "{{ assets_download_dir }}/{{ consul_filename }}"
     dest: "{{ temp_directory.path }}/"
     creates: "{{ temp_directory.path }}/consul"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -79,7 +79,7 @@
     owner: root
     group: root
     mode: 0644
-  bootstrap: true
+  bootstrap: "true"
   run_once: yes
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
@@ -94,7 +94,7 @@
     owner: root
     group: root
     mode: 0644
-  bootstrap: false
+  bootstrap: "false"
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -4,8 +4,13 @@
     prefix: ansible-consul.
   register: temp_directory
 
+- name: Install unzip
+  ansible.builtin.package:
+    name: unzip
+    state: present
+
 - name: unarchive consul
-  unarchive:
+  copy:
     src: "{{ assets_download_dir }}/{{ consul_filename }}"
     dest: "{{ temp_directory.path }}/"
     creates: "{{ temp_directory.path }}/consul"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -7,5 +7,5 @@
 - name: unarchive consul
   unarchive:
     src: "{{ assets_download_dir }}/{{ consul_filename }}"
-    dest: "{{ itemp_directory.path }}/"
+    dest: "{{ temp_directory.path }}/"
     creates: "{{ temp_directory.path }}/consul"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -72,7 +72,7 @@
     mode: 0755
   loop: "{{ service_watches }}"
 
-- name: configure consul bootstrap config-services-watches
+- name: configure consul bootstrap config
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -87,7 +87,7 @@
     - {src: 'config.json.j2', dest: '{{ config_directory }}/config.json'}
   notify: restart consul
 
-- name: configure consul servers config-services-watches
+- name: configure consul servers config
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -80,7 +80,6 @@
     group: root
     mode: 0644
   run_once: yes
-  consul_bootstrap: inventory_hostname
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}
@@ -99,7 +98,6 @@
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}
     - {src: 'config.json.j2', dest: '{{ config_directory }}/config.json'}
   notify: restart consul
-  when: inventory_hostname != consul_bootstrap
 
 - name: reload systemd
   systemd:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -1,0 +1,11 @@
+- name: create temp directory
+  tempfile:
+    state: directory
+    prefix: ansible-consul.
+  register: temp_directory
+
+- name: unarchive consul
+  unarchive:
+    src: "{{ assets_download_dir }}/{{ consul_filename }}"
+    dest: "{{ itemp_directory.path }}/"
+    creates: "{{ temp_directory.path }}/consul"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -51,7 +51,7 @@
     owner: root
     group: root
     mode: 0755
-  loop: "{{ script_names }}"
+  loop: "{{ scripts }}"
   notify: restart consul
 
 - name: copy consul services checks

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -46,18 +46,11 @@
 
 - name: copy consul scripts
   template:
-    src: "{{ item.j2 }}"
+    src: "{{ item }}"
     dest: "{{ bcpc_scripts_directory }}"
-    owner: root
-    group: root
-    mode: 0775
+    mode: 0644
   loop:
-    - if_leader
-    - if_primary_mysql.sh
-    - if_not_primary_mysql.sh
-    - if_primary_proxysql.sh
-    - if_not_primary_proxysql.sh
-    - proxysql-check-helper
+    - "{{ scripts_name }}"
 
 - name: reload systemd
   systemd:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -4,11 +4,6 @@
     prefix: ansible-consul.
   register: temp_directory
 
-- name: Install unzip
-  ansible.builtin.package:
-    name: unzip
-    state: present
-
 - name: unarchive consul
   unarchive:
     src: "{{ assets_download_dir }}/{{ consul_filename }}"

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -79,7 +79,7 @@
     owner: root
     group: root
     mode: 0644
-  bootstrap: "true"
+  bootstrap: true
   run_once: yes
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
@@ -94,7 +94,7 @@
     owner: root
     group: root
     mode: 0644
-  bootstrap: "false"
+  bootstrap: false
   loop:
     - {src: 'services.json.j2', dest: '{{ config_directory }}/services.json'}
     - {src: 'watches.json.j2', dest: '{{ config_directory }}/watches.json'}

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -12,7 +12,7 @@
 
 - name: install consul
   copy:
-    src: "{{ install_temp.path }}/consul"
+    src: "{{ itemp_directory.path }}/consul"
     dest: "{{ executable }}"
     mode: 0755
   notify:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -27,13 +27,23 @@
     group: root
     mode: 0775
   loop:
-    - {{ config_directory }}
-    - {{ config_data_directory }}
+    - "{{ config_directory }}"
+    - "{{ config_data_directory }}"
+
+- name: create consul service file systemd
+  template:
+    src: consul.service.j2
+    dest: /etc/systemd/system/consul.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart consul
 
 - name: reload systemd
   systemd:
-    daemon_reload: yes
-  become: true
+    service: consul.service
+    enabled: true
+  notify: restart consul
 
 - name: cleanup
   file:

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -44,10 +44,6 @@
   set_fact:
     chef_databags: "{{ lookup('file', (inventory_dir | dirname) + '/chef/databags/config.json') }}"
 
-- name: "print chef data bags"
-  debug:
-    msg: "chef data bags are {{ chef_databags }}"
-
 - name: reload systemd
   systemd:
     service: consul.service

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -29,6 +29,8 @@
   loop:
     - "{{ config_directory }}"
     - "{{ config_data_directory }}"
+    - "{{ bcpc_scripts_directory }}"
+    - "{{ bcpc_scripts_directory }}/bin"
 
 - name: create consul service file systemd
   template:
@@ -36,13 +38,14 @@
     dest: /etc/systemd/system/consul.service
     owner: root
     group: root
-    mode: '0644'
+    mode: 0644
   notify: restart consul
 
 - name: reload systemd
   systemd:
     service: consul.service
     enabled: true
+    daemon_reload: yes
   notify: restart consul
 
 - name: cleanup

--- a/ansible/playbooks/roles/consul/tasks/install-consul.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-consul.yml
@@ -19,12 +19,23 @@
     mode: 0755
   notify: restart consul
 
-- name: Daemon reload systemd in case the binaries upgraded
+- name: create config directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0775
+  loop:
+    - {{ config_directory }}
+    - {{ config_data_directory }}
+
+- name: reload systemd
   systemd:
     daemon_reload: yes
   become: true
 
-- name: Cleanup
+- name: cleanup
   file:
     path: "{{ temp_directory.path }}"
     state: "absent"

--- a/ansible/playbooks/roles/consul/tasks/install-required-packages.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-required-packages.yml
@@ -1,0 +1,4 @@
+- name: Install unzip
+  ansible.builtin.package:
+    name: unzip
+    state: present

--- a/ansible/playbooks/roles/consul/tasks/install-required-packages.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-required-packages.yml
@@ -2,4 +2,3 @@
   ansible.builtin.package:
     name: unzip
     state: present
-    

--- a/ansible/playbooks/roles/consul/tasks/install-required-packages.yml
+++ b/ansible/playbooks/roles/consul/tasks/install-required-packages.yml
@@ -2,3 +2,4 @@
   ansible.builtin.package:
     name: unzip
     state: present
+    

--- a/ansible/playbooks/roles/consul/tasks/main.yml
+++ b/ansible/playbooks/roles/consul/tasks/main.yml
@@ -5,3 +5,4 @@
 - import_tasks: install-consul.yml
   become: true
   tags: [never,configure-consul]
+  

--- a/ansible/playbooks/roles/consul/tasks/main.yml
+++ b/ansible/playbooks/roles/consul/tasks/main.yml
@@ -1,0 +1,3 @@
+- import_tasks: install-consul.yml
+  become: true
+  tags: [never,configure-consul]

--- a/ansible/playbooks/roles/consul/tasks/main.yml
+++ b/ansible/playbooks/roles/consul/tasks/main.yml
@@ -1,3 +1,7 @@
+- import_tasks: install-required-packages.yml
+  become: true
+  tags: [never,configure-consul]
+
 - import_tasks: install-consul.yml
   become: true
   tags: [never,configure-consul]

--- a/ansible/playbooks/roles/consul/tasks/main.yml
+++ b/ansible/playbooks/roles/consul/tasks/main.yml
@@ -5,4 +5,3 @@
 - import_tasks: install-consul.yml
   become: true
   tags: [never,configure-consul]
-  

--- a/ansible/playbooks/roles/consul/templates/cloud-ip-watch
+++ b/ansible/playbooks/roles/consul/templates/cloud-ip-watch
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright 2021, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SERVICE="$1"
+
+remove_cloud_ip() {
+    /sbin/ip address delete \
+      {{ cloud_ip }}/32 dev lo
+}
+
+add_cloud_ip() {
+    /sbin/ip address add \
+      {{ cloud_ip }}/32 dev lo
+}
+
+self_ip="{{ hostvars[inventory_hostname]['interfaces']['service']['ip'] }}"
+leader=$(curl -qs http://localhost:8500/v1/status/leader | jq -r '.')
+if [ "${self_ip}" != "${leader%:8300}" ]; then
+    remove_cloud_ip
+    exit 0
+fi
+
+status="$(cat)"
+self="{{ inventory_hostname }}"
+echo "$status" > "/tmp/${SERVICE}-handler.log"
+echo "$status" | jq ".[] |
+select((.Node==\"$self\") and (.CheckID==\"service:${SERVICE}\")) | .Status" |
+  grep -q passing
+if [ $? -eq 0 ]; then
+    add_cloud_ip
+else
+    remove_cloud_ip
+fi
+exit 0

--- a/ansible/playbooks/roles/consul/templates/config.json.j2
+++ b/ansible/playbooks/roles/consul/templates/config.json.j2
@@ -17,7 +17,7 @@
   "recursors": [
     "{{ cloud_ip }}"
   ],
-  "bootstrap": false,
+  "bootstrap_expect": {{ ansible_play_hosts | length }},
   "retry_join": [
   {% for host in groups['headnodes']|difference([inventory_hostname]) %}
   "{{ hostvars[host]['interfaces']['service']['ip'] }}"{{ "," if not loop.last }}

--- a/ansible/playbooks/roles/consul/templates/config.json.j2
+++ b/ansible/playbooks/roles/consul/templates/config.json.j2
@@ -1,0 +1,26 @@
+{
+  "datacenter": "{{ cloud_region }}",
+  "client_addr": "127.0.0.1",
+  "advertise_addr": "{{ hostvars[inventory_hostname]['interfaces']['service']['ip'] }}",
+  "data_dir": "{{ config_data_directory }}",
+  "disable_update_check": true,
+  "enable_script_checks": true,
+  "server": false,
+  "log_level": "INFO",
+  "node_name": "{{ inventory_hostname }}",
+  "addresses": {
+    "dns": "{{ cloud_ip }}"
+  },
+  "ports": {
+    "dns": 8600
+  },
+  "recursors": [
+    "{{ cloud_ip }}"
+  ],
+  "bootstrap": false,
+  "retry_join": [
+  {% for host in groups['headnodes']|difference([inventory_hostname]) %}
+  "{{ hostvars[host]['interfaces']['service']['ip'] }}"{{ "," if not loop.last }}
+  {% endfor %}
+  ]
+}

--- a/ansible/playbooks/roles/consul/templates/config.json.j2
+++ b/ansible/playbooks/roles/consul/templates/config.json.j2
@@ -17,7 +17,7 @@
   "recursors": [
     "{{ cloud_ip }}"
   ],
-  "bootstrap": {{ bootstrap }},
+  "bootstrap": {{ bootstrap_val }},
   "retry_join": [
   {% for host in groups['headnodes']|difference([inventory_hostname]) %}
   "{{ hostvars[host]['interfaces']['service']['ip'] }}"{{ "," if not loop.last }}

--- a/ansible/playbooks/roles/consul/templates/config.json.j2
+++ b/ansible/playbooks/roles/consul/templates/config.json.j2
@@ -17,7 +17,7 @@
   "recursors": [
     "{{ cloud_ip }}"
   ],
-  "bootstrap": false,
+  "bootstrap": {{ bootstrap }},
   "retry_join": [
   {% for host in groups['headnodes']|difference([inventory_hostname]) %}
   "{{ hostvars[host]['interfaces']['service']['ip'] }}"{{ "," if not loop.last }}

--- a/ansible/playbooks/roles/consul/templates/config.json.j2
+++ b/ansible/playbooks/roles/consul/templates/config.json.j2
@@ -5,7 +5,7 @@
   "data_dir": "{{ config_data_directory }}",
   "disable_update_check": true,
   "enable_script_checks": true,
-  "server": false,
+  "server": true,
   "log_level": "INFO",
   "node_name": "{{ inventory_hostname }}",
   "addresses": {

--- a/ansible/playbooks/roles/consul/templates/config.json.j2
+++ b/ansible/playbooks/roles/consul/templates/config.json.j2
@@ -17,7 +17,7 @@
   "recursors": [
     "{{ cloud_ip }}"
   ],
-  "bootstrap": {{ bootstrap_val }},
+  "bootstrap": false,
   "retry_join": [
   {% for host in groups['headnodes']|difference([inventory_hostname]) %}
   "{{ hostvars[host]['interfaces']['service']['ip'] }}"{{ "," if not loop.last }}

--- a/ansible/playbooks/roles/consul/templates/config.json.j2
+++ b/ansible/playbooks/roles/consul/templates/config.json.j2
@@ -1,6 +1,6 @@
 {
   "datacenter": "{{ cloud_region }}",
-  "client_addr": "127.0.0.1",
+  "client_addr": "{{ client_address }}",
   "advertise_addr": "{{ hostvars[inventory_hostname]['interfaces']['service']['ip'] }}",
   "data_dir": "{{ config_data_directory }}",
   "disable_update_check": true,
@@ -12,7 +12,7 @@
     "dns": "{{ cloud_ip }}"
   },
   "ports": {
-    "dns": 8600
+    "dns": {{ consul_dns_port }}
   },
   "recursors": [
     "{{ cloud_ip }}"

--- a/ansible/playbooks/roles/consul/templates/consul.service.j2
+++ b/ansible/playbooks/roles/consul/templates/consul.service.j2
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 Type=simple
 Restart=on-failure
-ExecStart="{{ executable }}" agent $OPTIONS -config-dir="{{ config_directory }}"
+ExecStart={{ executable }} agent $OPTIONS -config-dir={{ config_directory }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 StandardOutput=journal

--- a/ansible/playbooks/roles/consul/templates/consul.service.j2
+++ b/ansible/playbooks/roles/consul/templates/consul.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=consul agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+Restart=on-failure
+ExecStart="{{ executable }}" agent $OPTIONS -config-dir="{{ config_directory }}"
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=consul
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/playbooks/roles/consul/templates/if_leader.j2
+++ b/ansible/playbooks/roles/consul/templates/if_leader.j2
@@ -1,0 +1,7 @@
+set -e
+
+self_ip="{{ service_ip }}"
+leader=$(curl -qs http://localhost:8500/v1/status/leader | jq -r '.')
+if [ "${self_ip}" == "${leader%:8300}" ]; then
+    $*
+fi

--- a/ansible/playbooks/roles/consul/templates/if_not_primary_mysql.sh.j2
+++ b/ansible/playbooks/roles/consul/templates/if_not_primary_mysql.sh.j2
@@ -1,3 +1,3 @@
-if ! host primary.mysql.service.consul | awk '{print $NF}' | grep -e "{{ service_ip }}" > /dev/null; then
+if ! host primary.mysql.service.consul | awk '{print $NF}' | grep -e "^{{ service_ip }}$" > /dev/null; then
     $*
 fi

--- a/ansible/playbooks/roles/consul/templates/if_not_primary_mysql.sh.j2
+++ b/ansible/playbooks/roles/consul/templates/if_not_primary_mysql.sh.j2
@@ -1,0 +1,3 @@
+if ! host primary.mysql.service.consul | awk '{print $NF}' | grep -e "{{ service_ip }}" > /dev/null; then
+    $*
+fi

--- a/ansible/playbooks/roles/consul/templates/if_not_primary_proxysql.sh.j2
+++ b/ansible/playbooks/roles/consul/templates/if_not_primary_proxysql.sh.j2
@@ -1,0 +1,3 @@
+if ! host primary.proxysql.service.consul | awk '{print $NF}' | grep -e "{{ service_ip }}" > /dev/null; then
+    $*
+fi

--- a/ansible/playbooks/roles/consul/templates/if_not_primary_proxysql.sh.j2
+++ b/ansible/playbooks/roles/consul/templates/if_not_primary_proxysql.sh.j2
@@ -1,3 +1,3 @@
-if ! host primary.proxysql.service.consul | awk '{print $NF}' | grep -e "{{ service_ip }}" > /dev/null; then
+if ! host primary.proxysql.service.consul | awk '{print $NF}' | grep -e "^{{ service_ip }}$" > /dev/null; then
     $*
 fi

--- a/ansible/playbooks/roles/consul/templates/if_primary_mysql.sh.j2
+++ b/ansible/playbooks/roles/consul/templates/if_primary_mysql.sh.j2
@@ -1,0 +1,3 @@
+if host primary.mysql.service.consul | awk '{print $NF}' | grep -e "{{ service_ip }}" > /dev/null; then
+    $*
+fi

--- a/ansible/playbooks/roles/consul/templates/if_primary_mysql.sh.j2
+++ b/ansible/playbooks/roles/consul/templates/if_primary_mysql.sh.j2
@@ -1,3 +1,3 @@
-if host primary.mysql.service.consul | awk '{print $NF}' | grep -e "{{ service_ip }}" > /dev/null; then
+if host primary.mysql.service.consul | awk '{print $NF}' | grep -e "^{{ service_ip }}$" > /dev/null; then
     $*
 fi

--- a/ansible/playbooks/roles/consul/templates/if_primary_proxysql.sh.j2
+++ b/ansible/playbooks/roles/consul/templates/if_primary_proxysql.sh.j2
@@ -1,0 +1,3 @@
+if host primary.proxysql.service.consul | awk '{print $NF}' | grep -e "{{ service_ip }}" > /dev/null; then
+    $*
+fi

--- a/ansible/playbooks/roles/consul/templates/if_primary_proxysql.sh.j2
+++ b/ansible/playbooks/roles/consul/templates/if_primary_proxysql.sh.j2
@@ -1,3 +1,3 @@
-if host primary.proxysql.service.consul | awk '{print $NF}' | grep -e "{{ service_ip }}" > /dev/null; then
+if host primary.proxysql.service.consul | awk '{print $NF}' | grep -e "^{{ service_ip }}$" > /dev/null; then
     $*
 fi

--- a/ansible/playbooks/roles/consul/templates/proxysql-check-helper.j2
+++ b/ansible/playbooks/roles/consul/templates/proxysql-check-helper.j2
@@ -1,0 +1,40 @@
+set -e
+
+# Check connectivity to ProxySQL's admin interface
+mysqladmin status \
+    --connect-timeout 10 \
+    -u "{{ chef_databags['proxysql']['creds']['stats']['username'] }}" \
+    -p "{{ chef_databags['proxysql']['creds']['stats']['password'] }}" \
+    -h localhost \
+    --protocol=TCP \
+    -P "{{ proxysql_admin_port }}" 2> /dev/null
+
+set +e
+
+# Check connectivity via ProxySQL to a backend. Ideally this check will only
+# fail when all MySQL backends have encountered an issue, and thus switching
+# the primary will serve no purpose. However, as described in
+# https://github.com/sysown/proxysql/issues/3618, ProxySQL has at least one
+# bug that would require such a move.
+#
+# This check is forgiving because in a vast majority of cases ProxySQL will
+# handle backend failures just fine. It is designed to catch scenarios like
+# the one described in the bug report linked to above.
+MAX_ATTEMPTS=3
+ATTEMPTS=0
+while ! mysql -nNE \
+      --connect-timeout 10 \
+      -u root \
+      -p "{{ chef_databags['mysql']['users']['root']['password'] }}" \
+      -h localhost \
+      --protocol=TCP \
+      -P "{{ proxysql_port }}" \
+      -e "SELECT VERSION();" 2> /dev/null ; do
+    ((ATTEMPTS=ATTEMPTS+1))
+    if [ ${ATTEMPTS} -ge ${MAX_ATTEMPTS} ]; then
+        exit 1
+    fi
+    sleep 1
+done
+© 2021 GitHub, Inc.
+Terms

--- a/ansible/playbooks/roles/consul/templates/proxysql-check-helper.j2
+++ b/ansible/playbooks/roles/consul/templates/proxysql-check-helper.j2
@@ -3,11 +3,11 @@ set -e
 # Check connectivity to ProxySQL's admin interface
 mysqladmin status \
     --connect-timeout 10 \
-    -u "{{ chef_databags['proxysql']['creds']['stats']['username'] }}" \
-    -p "{{ chef_databags['proxysql']['creds']['stats']['password'] }}" \
+    -u {{ chef_databags['proxysql']['creds']['stats']['username'] }} \
+    -p{{ chef_databags['proxysql']['creds']['stats']['password'] }} \
     -h localhost \
     --protocol=TCP \
-    -P "{{ proxysql_admin_port }}" 2> /dev/null
+    -P {{ proxysql_admin_port }} 2> /dev/null
 
 set +e
 
@@ -25,10 +25,10 @@ ATTEMPTS=0
 while ! mysql -nNE \
       --connect-timeout 10 \
       -u root \
-      -p "{{ chef_databags['mysql']['users']['root']['password'] }}" \
+      -p{{ chef_databags['mysql']['users']['root']['password'] }} \
       -h localhost \
       --protocol=TCP \
-      -P "{{ proxysql_port }}" \
+      -P {{ proxysql_port }} \
       -e "SELECT VERSION();" 2> /dev/null ; do
     ((ATTEMPTS=ATTEMPTS+1))
     if [ ${ATTEMPTS} -ge ${MAX_ATTEMPTS} ]; then

--- a/ansible/playbooks/roles/consul/templates/proxysql-check-helper.j2
+++ b/ansible/playbooks/roles/consul/templates/proxysql-check-helper.j2
@@ -3,8 +3,8 @@ set -e
 # Check connectivity to ProxySQL's admin interface
 mysqladmin status \
     --connect-timeout 10 \
-    -u {{ chef_databags['proxysql']['creds']['stats']['username'] }} \
-    -p{{ chef_databags['proxysql']['creds']['stats']['password'] }} \
+    -u {{ chef_databags[1]['proxysql']['creds']['stats']['username'] }} \
+    -p{{ chef_databags[1]['proxysql']['creds']['stats']['password'] }} \
     -h localhost \
     --protocol=TCP \
     -P {{ proxysql_admin_port }} 2> /dev/null
@@ -25,7 +25,7 @@ ATTEMPTS=0
 while ! mysql -nNE \
       --connect-timeout 10 \
       -u root \
-      -p{{ chef_databags['mysql']['users']['root']['password'] }} \
+      -p{{ chef_databags[1]['mysql']['users']['root']['password'] }} \
       -h localhost \
       --protocol=TCP \
       -P {{ proxysql_port }} \

--- a/ansible/playbooks/roles/consul/templates/service-elect-watch
+++ b/ansible/playbooks/roles/consul/templates/service-elect-watch
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright 2021, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SERVICE="$1"
+
+status="$(cat)"
+CURL="curl -q -s"
+self="{{ inventory_hostname }}"
+
+SESSION=$($CURL "http://{{ client_address }}:8500/v1/kv/${SERVICE}/leader?consistent" | grep -E -i -o "[0-9a-z]{8}-([0-9a-z]{4}-){3}[0-9a-z]{12}")
+
+# Find out if I am holding onto lock
+LOCK_HOLDER=$($CURL "http://{{ client_address }}:8500/v1/session/info/$SESSION" | jq -r ".[] | .Node")
+if [ "$LOCK_HOLDER" == "$self" ]; then
+  LEADER=true
+fi
+
+echo "$status" | jq ".[] | select((.Node==\"$self\") and (.CheckID==\"service:${SERVICE}\")) | .Status" | grep -q passing
+if [ $? -eq 0 ]; then
+  if [ "$SESSION" == "" ]; then
+    # There is no leader, attempt to lock
+    SESSION=$($CURL -X PUT -d "{\"Name\": \"${SERVICE}\"}" "http://{{ client_address }}:8500/v1/session/create?consistent" | grep -E -i -o "[0-9a-z]{8}-([0-9a-z]{4}-){3}[0-9a-z]{12}")
+    # If lock is acquired, mark myself as leader
+    $CURL -X PUT -d "{\"Name\": \"${SERVICE}\"}" "http://{{ client_address }}:8500/v1/kv/${SERVICE}/leader?consistent&acquire=$SESSION" && LEADER=true
+  fi
+else
+  # Failed check, so release lock if I am leader
+  if [ "$LEADER" == "true" ]; then
+    $CURL -X PUT "http://{{ client_address }}:8500/v1/kv/${SERVICE}/leader?release=$SESSION"
+    LEADER=false
+  fi
+fi
+
+# Update service tag
+if [ "$LEADER" == "true" ]; then
+  payload=$(cat {{ config_directory }}/services.json | jq -M -c "to_entries | .[] | if .key==\"service\" then .value else .value[] | select(.name==\"${SERVICE}\") end | .tags += [\"primary\"]")
+  $CURL -X PUT -d "$payload" http://{{ client_address }}:8500/v1/agent/service/register
+else
+  payload=$(cat {{ config_directory }}/services.json | jq -M -c "to_entries | .[] | if .key==\"service\" then .value else .value[] | select(.name==\"${SERVICE}\") end")
+  $CURL -X PUT -d "$payload" http://{{ client_address }}:8500/v1/agent/service/register
+fi

--- a/ansible/playbooks/roles/consul/templates/service-watch
+++ b/ansible/playbooks/roles/consul/templates/service-watch
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2021, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SERVICE="$1"
+
+status="$(cat)"
+self="{{ inventory_hostname }}"
+echo "$status" > "/tmp/${SERVICE}-handler.log"
+echo "$status" | jq ".[] | select((.Node==\"$self\") and (.CheckID==\"service:${SERVICE}\")) | .Status" | grep -q passing
+if [ $? -eq 0 ]; then
+  curl -X PUT "http://{{ client_address }}:8500/v1/agent/service/maintenance/${SERVICE}?enable=false"
+else
+  curl -X PUT "http://{{ client_address }}:8500/v1/agent/service/maintenance/${SERVICE}?enable=true&reason=failed+check"
+fi

--- a/ansible/playbooks/roles/consul/templates/services.json.j2
+++ b/ansible/playbooks/roles/consul/templates/services.json.j2
@@ -10,7 +10,7 @@
       "check": {
         "name": "mysql",
         "args": [
-          "{{ bcpc_scripts_directory }}/mysql-check"
+          "{{ bcpc_directory }}/mysql-check"
         ],
         "interval": "{{ services_interval }}",
         "timeout": "{{ services_timeout }}"
@@ -26,7 +26,7 @@
       "check": {
         "name": "proxysql",
         "args": [
-          "{{ bcpc_scripts_directory }}/proxysql-check"
+          "{{ bcpc_directory }}/proxysql-check"
         ],
         "interval": "{{ services_interval }}",
         "timeout": "{{ services_timeout }}"
@@ -37,7 +37,7 @@
       "check": {
         "name": "haproxy",
         "args": [
-          "{{ bcpc_scripts_directory }}/haproxy-check"
+          "{{ bcpc_directory }}/haproxy-check"
         ],
         "interval": "{{ services_interval }}",
         "timeout": "{{ services_timeout }}"
@@ -48,7 +48,7 @@
       "check": {
         "name": "dns",
         "args": [
-          "{{ bcpc_scripts_directory }}/dns-check"
+          "{{ bcpc_directory }}/dns-check"
         ],
         "interval": "{{ services_interval }}",
         "timeout": "{{ services_timeout }}"

--- a/ansible/playbooks/roles/consul/templates/services.json.j2
+++ b/ansible/playbooks/roles/consul/templates/services.json.j2
@@ -1,0 +1,58 @@
+{
+  "services": [
+    {
+      "name": "mysql",
+      "port": {{ myysql_port }},
+      "enable_tag_override": true,
+      "tags": [
+        "mysql"
+      ],
+      "check": {
+        "name": "mysql",
+        "args": [
+          "{{ bcpc_scripts_directory }}/mysql-check"
+        ],
+        "interval": "{{ services_interval }}",
+        "timeout": "{{ services_timeout }}"
+      }
+    },
+    {
+      "name": "proxysql",
+      "port": {{ proxysql_port }},
+      "enable_tag_override": true,
+      "tags": [
+        "proxysql"
+      ],
+      "check": {
+        "name": "proxysql",
+        "args": [
+          "{{ bcpc_scripts_directory }}/proxysql-check"
+        ],
+        "interval": "{{ services_interval }}",
+        "timeout": "{{ services_timeout }}"
+      }
+    },
+    {
+      "name": "haproxy",
+      "check": {
+        "name": "haproxy",
+        "args": [
+          "{{ bcpc_scripts_directory }}/haproxy-check"
+        ],
+        "interval": "{{ services_interval }}",
+        "timeout": "{{ services_timeout }}"
+      }
+    },
+    {
+      "name": "dns",
+      "check": {
+        "name": "dns",
+        "args": [
+          "{{ bcpc_scripts_directory }}/dns-check"
+        ],
+        "interval": "{{ services_interval }}",
+        "timeout": "{{ services_timeout }}"
+      }
+    }
+  ]
+}

--- a/ansible/playbooks/roles/consul/templates/watches.json.j2
+++ b/ansible/playbooks/roles/consul/templates/watches.json.j2
@@ -36,7 +36,7 @@
       "service": "proxysql",
       "type": "checks",
       "args": [
-        {{ bcpc_scripts_directory }}/service-watch",
+        "{{ bcpc_scripts_directory }}/service-watch",
         "proxysql"
       ]
     },

--- a/ansible/playbooks/roles/consul/templates/watches.json.j2
+++ b/ansible/playbooks/roles/consul/templates/watches.json.j2
@@ -1,0 +1,52 @@
+{
+  "watches": [
+    {
+      "service": "haproxy",
+      "type": "checks",
+      "args": [
+        "{{ bcpc_scripts_directory }}/cloud-ip-watch",
+        "haproxy"
+      ]
+    },
+    {
+      "service": "mysql",
+      "type": "checks",
+      "args": [
+        "{{ bcpc_scripts_directory }}/service-elect-watch",
+        "mysql"
+      ]
+    },
+    {
+      "service": "mysql",
+      "type": "checks",
+      "args": [
+        "{{ bcpc_scripts_directory }}/service-watch",
+        "mysql"
+      ]
+    },
+    {
+      "service": "proxysql",
+      "type": "checks",
+      "args": [
+        "{{ bcpc_scripts_directory }}/service-elect-watch",
+        "proxysql"
+      ]
+    },
+    {
+      "service": "proxysql",
+      "type": "checks",
+      "args": [
+        {{ bcpc_scripts_directory }}/service-watch",
+        "proxysql"
+      ]
+    },
+    {
+      "service": "dns",
+      "type": "checks",
+      "args": [
+        "{{ bcpc_scripts_directory }}/cloud-ip-watch",
+        "dns"
+      ]
+    }
+  ]
+}

--- a/ansible/playbooks/roles/consul/templates/watches.json.j2
+++ b/ansible/playbooks/roles/consul/templates/watches.json.j2
@@ -4,7 +4,7 @@
       "service": "haproxy",
       "type": "checks",
       "args": [
-        "{{ bcpc_scripts_directory }}/cloud-ip-watch",
+        "{{ bcpc_directory }}/cloud-ip-watch",
         "haproxy"
       ]
     },
@@ -12,7 +12,7 @@
       "service": "mysql",
       "type": "checks",
       "args": [
-        "{{ bcpc_scripts_directory }}/service-elect-watch",
+        "{{ bcpc_directory }}/service-elect-watch",
         "mysql"
       ]
     },
@@ -20,7 +20,7 @@
       "service": "mysql",
       "type": "checks",
       "args": [
-        "{{ bcpc_scripts_directory }}/service-watch",
+        "{{ bcpc_directory }}/service-watch",
         "mysql"
       ]
     },
@@ -28,7 +28,7 @@
       "service": "proxysql",
       "type": "checks",
       "args": [
-        "{{ bcpc_scripts_directory }}/service-elect-watch",
+        "{{ bcpc_directory }}/service-elect-watch",
         "proxysql"
       ]
     },
@@ -36,7 +36,7 @@
       "service": "proxysql",
       "type": "checks",
       "args": [
-        "{{ bcpc_scripts_directory }}/service-watch",
+        "{{ bcpc_directory }}/service-watch",
         "proxysql"
       ]
     },
@@ -44,7 +44,7 @@
       "service": "dns",
       "type": "checks",
       "args": [
-        "{{ bcpc_scripts_directory }}/cloud-ip-watch",
+        "{{ bcpc_directory }}/cloud-ip-watch",
         "dns"
       ]
     }

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -6,5 +6,4 @@
 - import_playbook: storageheadnodes.yml
 - import_playbook: worknodes.yml
 - import_playbook: storagenodes.yml
-- import_playbook: storagenodes.yml
 - import_playbook: consulnodes.yml

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -6,3 +6,5 @@
 - import_playbook: storageheadnodes.yml
 - import_playbook: worknodes.yml
 - import_playbook: storagenodes.yml
+- import_playbook: storagenodes.yml
+- import_playbook: consulnodes.yml


### PR DESCRIPTION
Adding consul role to replace consul chef recipes, attributes, and templates.
Currently only conul-package is being added to ansible.
recipes:
- consul-package.rb
- consul.rb

attributes:
- consul.rb

templates:
- cloud-ip-watch.erb
- consul.service.erb
- if_leader.erb
- if_not_primary_mysql.sh.erb
- if_not_primary_proxysql.sh.erb
- if_primary_mysql.sh.erb
- if_primary_proxysql.sh.erb
- proxysql-check-helper.erb
- service-default.erb
- service-elect-watch.erb
- service-watch.erb