### PR TITLE
Replace injecting ansible-core with ansible.

### DIFF
--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -17,7 +17,7 @@ function install_linters_linux {
     for pkg in bashate flake8 ansible-lint; do
         pipx install --force "${pkg}"
     done
-    pipx inject ansible-lint ansible-core
+    pipx inject ansible-lint ansible
     sudo gem install cookstyle
 }
 


### PR DESCRIPTION
There were reports of linters failing due to `ansible` version mismatch, [like this one](https://github.com/bloomberg/chef-bcpc/runs/4170534527?check_suite_focus=true) and [this one](https://github.com/bloomberg/chef-bcpc/runs/4181008568?check_suite_focus=true). It appears that there is a mismatch between the version of `ansible-lint` and `ansible` (python libs). This PR injects `ansible` into the `ansible-lint` pipx venv to prevent a mismatch.

**Testing performed**
Ran [this PR check](https://github.com/psipika/chef-bcpc/runs/4189660449?check_suite_focus=true).

Signed-off-by: Piotr Sipika <psipika@bloomberg.net>
