### PR TITLE
cinder: Default rbd_exclusive_cinder_pool to true

### DIFF
--- a/chef/cookbooks/bcpc/attributes/cinder.rb
+++ b/chef/cookbooks/bcpc/attributes/cinder.rb
@@ -11,6 +11,7 @@ default['bcpc']['cinder']['debug'] = false
 default['bcpc']['cinder']['workers'] = nil
 default['bcpc']['cinder']['allow_az_fallback'] = true
 default['bcpc']['cinder']['backend_native_threads_pool_size'] = nil
+default['bcpc']['cinder']['rbd_exclusive_cinder_pool'] = true
 default['bcpc']['cinder']['rbd_flatten_volume_from_snapshot'] = true
 default['bcpc']['cinder']['rbd_max_clone_depth'] = 5
 default['bcpc']['cinder']['quota'] = {

--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -25,6 +25,7 @@ scheduler_default_filters = <%= @scheduler_default_filters.join(',') %>
 <% if !node['bcpc']['cinder']['backend_native_threads_pool_size'].nil? %>
 [backend_defaults]
 backend_native_threads_pool_size = <%= node['bcpc']['cinder']['backend_native_threads_pool_size'] %>
+rbd_exclusive_cinder_pool = <%= node['bcpc']['cinder']['rbd_exclusive_cinder_pool'] %>
 
 <% end %>
 [database]


### PR DESCRIPTION
As part of its periodic tasks, cinder polls each RBD
volume's size and accumulates a sum to report to the
cinder services. This is very inefficient.

Instead, if the Ceph pool(s) allocated to cinder are
guaranteed to be exclusively used by RBD volumes (and not
other Ceph objects), cinder can be told to just ask Ceph
for the size of the pool and be done with it.

This commit makes the necessary change, which is the
default in a future version of OpenStack/cinder anyways.