### PR TITLE
add custom neutron notification queue support

### DIFF
--- a/chef/cookbooks/bcpc/attributes/neutron.rb
+++ b/chef/cookbooks/bcpc/attributes/neutron.rb
@@ -45,3 +45,7 @@ default['bcpc']['neutron']['calico']['num_port_status_threads'] = nil
 default['bcpc']['neutron']['calico']['etcd_compaction_period_mins'] = nil
 default['bcpc']['neutron']['calico']['etcd_compaction_min_revisions'] = nil
 default['bcpc']['neutron']['calico']['project_name_cache_max'] = nil
+
+# notifications
+default['bcpc']['neutron']['notifications']['enabled'] = false
+default['bcpc']['neutron']['notifications']['topics'] = []

--- a/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
@@ -68,6 +68,16 @@ password = <%= @config['nova']['creds']['os']['password'] %>
 [oslo_concurrency]
 lock_path = $state_path/lock
 
+<% if node['bcpc']['neutron']['notifications']['enabled'] %>
+[oslo_messaging_notifications]
+driver = messagingv2
+<% node['bcpc']['neutron']['notifications']['topics'].each do |t|  %>
+topics = <%= t %>
+<% end %>
+#retry = -1
+#transport_url = <DEFAULT's transport_url>
+<% end %>
+
 [quotas]
 <% node['bcpc']['neutron']['quota'].fetch('default',{}).each do |resource, limit| %>
 <%= "#{resource} = #{limit}" %>


### PR DESCRIPTION
  - additional neutron notification queues can now be published to with
     neutron specific event information
