### PR TITLE
Install `cpu-checker` on all node types

### DIFF
--- a/chef/cookbooks/bcpc/recipes/common-packages.rb
+++ b/chef/cookbooks/bcpc/recipes/common-packages.rb
@@ -47,6 +47,7 @@ package %w(
   vim
   ksh
   bash-completion
+  cpu-checker
 )
 
 cookbook_file '/etc/screenrc' do

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -35,7 +35,6 @@ database = {
 package %w(
   ceph
   nova-compute
-  cpu-checker
   libvirt-daemon-driver-storage-rbd
   nova-api-metadata
   ovmf


### PR DESCRIPTION
Having the `cpu-checker` on all node types is useful for determining the state of their (potential) virtualization use.