### PR TITLE
README.md: Add additional reqs for libvirt

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ make create all
 To create a libvirt build:
 
 ```shell
-sudo apt-get install build-essential libvirt-dev qemu-utils libguestfs-tools
+sudo apt-get install build-essential dnsmasq libguestfs-tools libvirt-dev pkg-config qemu-utils
 vagrant plugin install vagrant-libvirt vagrant-mutate
 vagrant box add bento/ubuntu-18.04 --box-version 202005.21.0 --provider virtualbox
 vagrant mutate bento/ubuntu-18.04 libvirt


### PR DESCRIPTION
At least with a clean 20.04 install, these packages were
also required to build a packer image and/or spin up a
libvirt box with vagrant.