### PR TITLE
Vagrant box build fix

### DIFF
--- a/virtual/packer/bin/create-packer-box.sh
+++ b/virtual/packer/bin/create-packer-box.sh
@@ -56,6 +56,12 @@ if [ -z "$base_box_exists" ]; then
     fi
 fi
 
+# prevent vagrant-libvirt from failing if there's scrapnel lying around
+if [ "$VAGRANT_DEFAULT_PROVIDER" == "libvirt" ]; then
+    virsh destroy output-vagrant_source || true
+    virsh undefine output-vagrant_source || true
+    virsh vol-delete --pool default output-vagrant_source.img || true
+fi
 
 # create the packer box
 # Use the script path to find the packer directory

--- a/virtual/packer/bin/destroy-packer-box.sh
+++ b/virtual/packer/bin/destroy-packer-box.sh
@@ -34,9 +34,16 @@ if [ -n "$output_box_exists" ]; then
     if [ "$VAGRANT_DEFAULT_PROVIDER" == "libvirt" ]; then
         virsh vol-delete \
             --pool default \
-            "${OUTPUT_PACKER_BOX_NAME}_vagrant_box_image_0.img"
+            "${OUTPUT_PACKER_BOX_NAME}_vagrant_box_image_0_box.img" || true
         virsh pool-refresh default
     fi
+fi
+
+# cleanup any scrapnel vagrant-libvirt may have left lying around
+if [ "$VAGRANT_DEFAULT_PROVIDER" == "libvirt" ]; then
+    virsh destroy output-vagrant_source || true
+    virsh undefine output-vagrant_source || true
+    virsh vol-delete --pool default output-vagrant_source.img || true
 fi
 
 # Remove the output directory from packer build 


### PR DESCRIPTION
`packer` can leave artifacts in `libvirt` that prevent box
builds from succeeding in some cases, without leaving an
appropriate error message.

Perform some pre-flight activities to increase the success
rate of box builds.