### PR TITLE
Use python3 for inventory generation

### DIFF
--- a/virtual/bin/generate-ansible-inventory.py
+++ b/virtual/bin/generate-ansible-inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Copyright 2020, Bloomberg Finance L.P.


### PR DESCRIPTION
Ubuntu Focal/Debian Bullseye no longer provide python2
(or it is not packaged as part of a default package), and
use of Python2 is deprecated.