### PR TITLE
Hard-pin version of ansible to match ansible-lint.

### DIFF
--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -17,7 +17,7 @@ function install_linters_linux {
     for pkg in bashate flake8 ansible-lint==5.2.1; do
         pipx install --force "${pkg}"
     done
-    pipx inject ansible-lint ansible-core==2.11.6
+    pipx inject ansible-lint ansible==5.1.0
     sudo gem install cookstyle
 }
 


### PR DESCRIPTION
Signed-off-by: Piotr Sipika <psipika@bloomberg.net>

Making sure to use `ansible` with the right version vs `ansible-core`...

**Testing performed**
[Successful run here](https://github.com/psipika/chef-bcpc/runs/4692458781?check_suite_focus=true)
