### PR TITLE
Add galaxy rules to skip list.

### DIFF
--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -21,7 +21,7 @@ function main {
     find . -name "*.sh" -exec bashate -e E006 {} \;
     find . -name "*.py" \
          ! -path "./chef/cookbooks/bcpc/files/default/*" -exec flake8 {} \;
-    ansible-lint -x var-naming ansible/
+    ansible-lint -x var-naming -x meta-no-info -x meta-no-tags ansible/
     cookstyle --version && cookstyle .
 }
 


### PR DESCRIPTION
Signed-off-by: Piotr Sipika <psipika@bloomberg.net>

`ansible-lint` maintainers assume certain rulesets are used more broadly than they possibly are.
As an example, [this issue](https://github.com/ansible-community/ansible-lint/issues/818) indicates that the `galaxy` set of rules is to be used.

At present, `chef-bcpc` does not employ these rules and there are no plans to do so in the near future.
This PR includes explicit exclusion of `meta-no-info` and `meta-no-tags` rules from the `galaxy` set.

More info on the rules and tags can be found [here](https://ansible-lint.readthedocs.io/en/latest/rules.html#using-tags-to-include-rules).

Tested [on my fork](https://github.com/psipika/chef-bcpc/runs/4855922174?check_suite_focus=true).
