### PR TITLE
Configure HW EDAC polling 

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -294,6 +294,11 @@ grub_cmdline_linux: []
 # system configuration
 ###############################################################################
 
+# Disable "correctable" MCE (Machine Check Error) and EDAC (Error Detection
+# and Correction) reporting. This relinquishes control of the kernel/OS
+# processing of correctable/soft error polling and reporting to the platform.
+hardware_edac_polling: false
+
 # Select desired I/O scheduler to be applied at startup (deadline, noop, cfq)
 hardware_io_scheduler: mq-deadline
 

--- a/ansible/playbooks/roles/common/tasks/configure-hardware.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-hardware.yml
@@ -1,0 +1,103 @@
+- name: Gather a list of hardware/virtualization facts
+  setup:
+    gather_subset:
+      - '!all'
+      - '!any'
+      - hardware
+      - virtual
+
+# IPMI module configuration and loading
+- name: Configure the kernel's IPMI module
+  block:
+    - name: Load ipmi_devintf kernel module
+      modprobe:
+        name: ipmi_devintf
+
+    - name: Ensure ipmi_devintf is loaded at boot
+      template:
+        src: system/modules-load.conf.j2
+        dest: /etc/modules-load.d/ipmi_devintf.conf
+        owner: root
+        group: root
+        mode: '0644'
+      vars:
+        kernel_module_name: ipmi_devintf
+  when: ansible_virtualization_role in ["NA", "host"]
+
+# Configure I/O scheduler algorithm
+- name: Configure disk scheduler algorithm
+  template:
+    src: udev/98-io-scheduler.rules.j2
+    dest: /etc/udev/rules.d/98-io-scheduler.rules
+    owner: root
+    group: root
+    mode: '0644'
+  register: udev_io_scheduler
+
+# Configure block device readahead
+- name: Configure block device readahead
+  template:
+    src: udev/99-readahead.rules.j2
+    dest: /etc/udev/rules.d/99-readahead.rules
+    owner: root
+    group: root
+    mode: '0644'
+  register: udev_readahead
+
+- name: Reload udevadm rules
+  command: udevadm control --reload-rules
+  when: udev_io_scheduler.changed or udev_readahead.changed  # noqa no-handler
+
+- name: Replay udev events
+  command: udevadm trigger
+  when: udev_io_scheduler.changed or udev_readahead.changed  # noqa no-handler
+
+# Control processor microcode application
+- name: Control processor microcode application
+  block:
+    - name: Check if AMD processor
+      command: grep -q AuthenticAMD /proc/cpuinfo
+      ignore_errors: true
+      register: is_amd
+      changed_when: false
+
+    - name: Install amd64-microcode package
+      apt:
+        name: amd64-microcode
+      when: is_amd is successful
+
+    - name: Configure amd64-microcode package
+      template:
+        src: amd64-microcode/default.j2
+        dest: /etc/default/amd64-microcode
+        owner: root
+        group: root
+        mode: '0644'
+      register: amd_microcode
+      when: is_amd is successful
+
+    - name: Check if Intel processor
+      command: grep -q GenuineIntel /proc/cpuinfo
+      ignore_errors: true
+      register: is_intel
+      changed_when: false
+
+    - name: Install intel-microcode package
+      apt:
+        name: intel-microcode
+      when: is_intel is successful
+
+    - name: Configure intel-microcode package
+      template:
+        src: intel-microcode/default.j2
+        dest: /etc/default/intel-microcode
+        owner: root
+        group: root
+        mode: '0644'
+      register: intel_microcode
+      when: is_intel is successful
+
+    - name: Update initramfs for all kernels
+      command: update-initramfs -uk all
+      when: amd_microcode.changed or intel_microcode.changed
+  when: ansible_virtualization_role in ["NA", "host"]

--- a/ansible/playbooks/roles/common/tasks/configure-hardware.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-hardware.yml
@@ -6,6 +6,59 @@
       - hardware
       - virtual
 
+# EDAC controller configuration
+- name: Enumerate a list of supported EDAC modules
+  block:
+    - name: Get the current kernel release
+      command: uname -r
+      register: kernel_uname
+      changed_when: false
+
+    - name: Find a list of modules
+      find:
+        paths:
+          - "/lib/modules/{{ kernel_uname['stdout'].strip() }}/kernel/drivers/edac"
+        file_type: file
+        use_regex: yes
+        patterns:
+          - "^\\w+\\.ko$"
+      register: edac_kos
+
+    - name: Set a fact with the list of modules
+      set_fact:
+        kernel_edac_modules: "{{ edac_kos['files']
+                               | map(attribute='path')
+                               | map('basename')
+                               | map('regex_replace', '\\.ko$', '')
+                               | list }}"
+
+- name: Disable EDAC controllers
+  block:
+    - name: Unload kernel modules for EDAC
+      modprobe:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ kernel_edac_modules }}"
+
+    - name: Ensure EDAC modules are blacklisted
+      template:
+        src: hardware/edac.conf.j2
+        dest: /etc/modprobe.d/edac.conf
+        owner: root
+        group: root
+        mode: '0644'
+      vars:
+        modules: "{{ kernel_edac_modules }}"
+  when: not hardware_edac_polling
+
+- name: Enable EDAC controllers
+  block:
+    - name: Ensure EDAC modules are not blacklisted
+      file:
+        path: /etc/modprobe.d/edac.conf
+        state: absent
+  when: hardware_edac_polling
+
 # IPMI module configuration and loading
 - name: Configure the kernel's IPMI module
   block:

--- a/ansible/playbooks/roles/common/tasks/configure-node.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-node.yml
@@ -6,6 +6,10 @@
   become: true
   tags: [never,configure-system]
 
+- import_tasks: configure-hardware.yml
+  become: true
+  tags: [never,configure-hardware]
+
 - import_tasks: configure-volumes.yml
   become: true
   tags: [never,configure-volumes]

--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -3,24 +3,6 @@
   setup:
     gather_subset: "!all,!min,virtual"
 
-# IPMI module configuration and loading
-- name: Configure the kernel's IPMI module
-  block:
-    - name: Load ipmi_devintf kernel module
-      modprobe:
-        name: ipmi_devintf
-
-    - name: Ensure ipmi_devintf is loaded at boot
-      template:
-        src: system/modules-load.conf.j2
-        dest: /etc/modules-load.d/ipmi_devintf.conf
-        owner: root
-        group: root
-        mode: '0644'
-      vars:
-        kernel_module_name: ipmi_devintf
-  when: ansible_virtualization_role in ["NA", "host"]
-
 # ip_conntrack module configuration and loading
 - name: Configure ip_conntrack kernel module when loaded
   template:
@@ -73,26 +55,6 @@
   command: update-grub
   when: grub_defaults.changed  # noqa no-handler
 
-# Ensure elevator changes are effective
-- name: Gather a list of hardware/block devices
-  setup:
-    gather_subset:
-      - '!all'
-      - '!any'
-      - hardware
-
-- name: Check current block device I/O scheduler settings
-  shell: "grep -E '( |^){{ hardware_io_scheduler }}( |$)' /sys/block/{{ item }}/queue/scheduler"
-  with_items: "{{ ansible_facts.devices | select('match', '^sd') | list }}"
-  register: block_device_schedulers
-  failed_when: block_device_schedulers.rc == 0
-  ignore_errors: true
-  changed_when: false
-
-- name: Apply I/O scheduler settings to block devices
-  shell: "echo {{ hardware_io_scheduler }} > /sys/block/{{ item.item }}/queue/scheduler"
-  when: item is failed
-  with_items: "{{ block_device_schedulers.results }}"
 
 # Configure sysctl parameters
 - name: Configure sysctl parameters
@@ -107,34 +69,6 @@
 - name: Reload sysctl settings
   command: sysctl -p /etc/sysctl.d/70-bcpc.conf
   when: sysctl_bcpc.changed  # noqa no-handler
-
-# Configure I/O scheduler algorithm
-- name: Configure disk scheduler algorithm
-  template:
-    src: udev/98-io-scheduler.rules.j2
-    dest: /etc/udev/rules.d/98-io-scheduler.rules
-    owner: root
-    group: root
-    mode: '0644'
-  register: udev_io_scheduler
-
-# Configure block device readahead
-- name: Configure block device readahead
-  template:
-    src: udev/99-readahead.rules.j2
-    dest: /etc/udev/rules.d/99-readahead.rules
-    owner: root
-    group: root
-    mode: '0644'
-  register: udev_readahead
-
-- name: Reload udevadm rules
-  command: udevadm control --reload-rules
-  when: udev_io_scheduler.changed or udev_readahead.changed  # noqa no-handler
-
-- name: Replay udev events
-  command: udevadm trigger
-  when: udev_io_scheduler.changed or udev_readahead.changed  # noqa no-handler
 
 # Configure /etc/updatedb.conf
 - name: Configure /etc/updatedb.conf
@@ -253,53 +187,3 @@
 - name: Install kexec-tools
   apt:
     name: kexec-tools
-
-# Control processor microcode application
-- name: Control processor microcode application
-  block:
-    - name: Check if AMD processor
-      command: grep -q AuthenticAMD /proc/cpuinfo
-      ignore_errors: true
-      register: is_amd
-      changed_when: false
-
-    - name: Install amd64-microcode package
-      apt:
-        name: amd64-microcode
-      when: is_amd is successful
-
-    - name: Configure amd64-microcode package
-      template:
-        src: amd64-microcode/default.j2
-        dest: /etc/default/amd64-microcode
-        owner: root
-        group: root
-        mode: '0644'
-      register: amd_microcode
-      when: is_amd is successful
-
-    - name: Check if Intel processor
-      command: grep -q GenuineIntel /proc/cpuinfo
-      ignore_errors: true
-      register: is_intel
-      changed_when: false
-
-    - name: Install intel-microcode package
-      apt:
-        name: intel-microcode
-      when: is_intel is successful
-
-    - name: Configure intel-microcode package
-      template:
-        src: intel-microcode/default.j2
-        dest: /etc/default/intel-microcode
-        owner: root
-        group: root
-        mode: '0644'
-      register: intel_microcode
-      when: is_intel is successful
-
-    - name: Update initramfs for all kernels
-      command: update-initramfs -uk all
-      when: amd_microcode.changed or intel_microcode.changed
-  when: ansible_virtualization_role in ["NA", "host"]

--- a/ansible/playbooks/roles/common/templates/grub/default.j2
+++ b/ansible/playbooks/roles/common/templates/grub/default.j2
@@ -17,9 +17,10 @@ GRUB_HIDDEN_TIMEOUT_QUIET=true
 GRUB_TIMEOUT=0
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="vga=normal nomodeset 3 console=tty0 console=tty1"
+{% set ignore_ce = 'mce=ignore_ce' if not hardware_edac_polling else '' -%}
 {% set ipv6_cmdline = 'ipv6.disable=1' if not system_enable_ipv6 else '' -%}
 {% set nvme_core_cmdline = 'nvme_core.multipath=' + ('1' if hardware_nvme_multipath else '0') -%}
-GRUB_CMDLINE_LINUX="{{ ' '.join([ipv6_cmdline, nvme_core_cmdline] + grub_cmdline_linux) }}"
+GRUB_CMDLINE_LINUX="{{ ' '.join([ignore_ce, ipv6_cmdline, nvme_core_cmdline] + grub_cmdline_linux) }}"
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs
 # This works with Linux (no patch required) and with any kernel that obtains

--- a/ansible/playbooks/roles/common/templates/hardware/edac.conf.j2
+++ b/ansible/playbooks/roles/common/templates/hardware/edac.conf.j2
@@ -1,0 +1,3 @@
+{% for module in modules %}
+blacklist {{ module }}
+{% endfor %}


### PR DESCRIPTION
Configure polling of MCA banks and use of EDAC controllers.

Optionally disable polling/EDAC by default, as most server
platforms have BMCs (Baseboard Management Controllers)
managing hardware status out-of-band.