### PR TITLE
Fix mgr election timer

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -20,9 +20,10 @@ osd scrub max interval = <%= @node['bcpc']['ceph']['osd_scrub_max_interval'] %>
 auth allow insecure global id reclaim = <%= node['bcpc']['ceph']['mon_auth_allow_insecure_global_id_reclaim'] %>
 mon compact on start = true
 mon cpu threads = <%= node['bcpc']['ceph']['mon_cpu_threads'] %>
+mon mgr beacon grace = <%= node['bcpc']['ceph']['mon_mgr_beacon_grace'] %>
+mgr tick period = <%= node['bcpc']['ceph']['mgr_tick_period'] %>
 
 [mgr]
-mon mgr beacon grace = <%= node['bcpc']['ceph']['mon_mgr_beacon_grace'] %>
 mgr stats period = <%= node['bcpc']['ceph']['mgr_stats_period'] %>
 mgr stats threshold = <%= node['bcpc']['ceph']['mgr_stats_threshold'] %>
 mgr tick period = <%= node['bcpc']['ceph']['mgr_tick_period'] %>


### PR DESCRIPTION
The mgr aims to beacon to the mons each `mgr_tick_period`
 seconds. If a beacon is not seen by the mons in the last
`mon_mgr_beacon_grace` seconds, then the mons mark the
currently acting mgr as failed and elect a new one in its
place.

In a previous commit, I had put the `mon_mgr_beacon_grace`
timer erroneously in the mgr section, but it's really a mon
section item as the mons are the ones which are looking for
mgr becaons and acting on a lack of response.

Moreover, after auditing the code to confirm this, I also
became aware that the mons *also* consider the mgr's tick
period when they themselves, the mons, see their own tick
period goes beyond that of the `mon_mgr_beacon_grace` less
the `mgr_tick_period`. In this case, they will reset the
mgr beacon timeoutos to avoid a potential false alarm.