### PR TITLE
Create venv for linter execution to bypass `pipx`

### DIFF
--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -13,11 +13,13 @@ function main {
 #
 
 function install_linters_linux {
+    echo "${PWD}"
+    env
     python3 -m venv linter_venv
     cd linter_venv && . bin/activate
 
     sudo apt-get install -y shellcheck
-    for pkg in bashate flake8 ansible ansible-lint ansible; do
+    for pkg in bashate flake8 ansible-lint ansible; do
         pip install --force "${pkg}"
     done
 

--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -14,7 +14,7 @@ function main {
 
 function install_linters_linux {
     python3 -m venv /tmp/linter_venv
-    cd /tmp/linter_venv && . bin/activate
+    cd /tmp/linter_venv && source bin/activate
 
     sudo apt-get install -y shellcheck
     pip install --force bashate flake8 ansible-lint ansible

--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -13,15 +13,11 @@ function main {
 #
 
 function install_linters_linux {
-    echo "${PWD}"
-    env
-    python3 -m venv linter_venv
-    cd linter_venv && . bin/activate
+    python3 -m venv /tmp/linter_venv
+    cd /tmp/linter_venv && . bin/activate
 
     sudo apt-get install -y shellcheck
-    for pkg in bashate flake8 ansible-lint ansible; do
-        pip install --force "${pkg}"
-    done
+    pip install --force bashate flake8 ansible-lint ansible
 
     sudo gem install cookstyle
 }

--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -14,6 +14,7 @@ function main {
 
 function install_linters_linux {
     python3 -m venv /tmp/linter_venv
+    # shellcheck disable=SC1091
     cd /tmp/linter_venv && source bin/activate
 
     sudo apt-get install -y shellcheck

--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -13,11 +13,14 @@ function main {
 #
 
 function install_linters_linux {
+    python3 -m venv linter_venv
+    cd linter_venv && . bin/activate
+
     sudo apt-get install -y shellcheck
-    for pkg in bashate flake8 ansible-lint==5.3.2; do
-        pipx install --force "${pkg}"
+    for pkg in bashate flake8 ansible ansible-lint ansible; do
+        pip install --force "${pkg}"
     done
-    pipx inject ansible-lint ansible==5.2.0
+
     sudo gem install cookstyle
 }
 

--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -17,6 +17,7 @@
 set -ev
 
 function main {
+    cd linter_venv && . bin/activate
     find . -name "*.sh" -exec shellcheck {} \;
     find . -name "*.sh" -exec bashate -e E006 {} \;
     find . -name "*.py" \

--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -18,6 +18,8 @@ set -ev
 
 function main {
     cd linter_venv && . bin/activate
+    echo ${PWD}
+    exit 0
     find . -name "*.sh" -exec shellcheck {} \;
     find . -name "*.sh" -exec bashate -e E006 {} \;
     find . -name "*.py" \

--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -17,6 +17,7 @@
 set -ev
 
 function main {
+    # shellcheck disable=SC1091
     cd /tmp/linter_venv && source bin/activate
 
     find "${GITHUB_WORKSPACE}" -name "*.sh" -exec shellcheck {} \;

--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -22,8 +22,11 @@ function main {
     find "${GITHUB_WORKSPACE}" -name "*.sh" -exec shellcheck {} \;
     find "${GITHUB_WORKSPACE}" -name "*.sh" -exec bashate -e E006 {} \;
     find "${GITHUB_WORKSPACE}" -name "*.py" \
-         ! -path "${GITHUB_WORKSPACE}/chef/cookbooks/bcpc/files/default/*" -exec flake8 {} \;
-    ansible-lint -x var-naming -x meta-no-info -x meta-no-tags "${GITHUB_WORKSPACE}/ansible/"
+         ! -path "${GITHUB_WORKSPACE}/chef/cookbooks/bcpc/files/default/*" \
+         -exec flake8 {} \;
+    ansible-lint -x var-naming \
+                 -x meta-no-info \
+                 -x meta-no-tags "${GITHUB_WORKSPACE}/ansible/"
     cookstyle --version && cookstyle "${GITHUB_WORKSPACE}"
 }
 

--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -17,15 +17,14 @@
 set -ev
 
 function main {
-    cd linter_venv && . bin/activate
-    echo ${PWD}
-    exit 0
-    find . -name "*.sh" -exec shellcheck {} \;
-    find . -name "*.sh" -exec bashate -e E006 {} \;
-    find . -name "*.py" \
+    cd /tmp/linter_venv && . bin/activate
+
+    find "${GITHUB_WORKSPACE}" -name "*.sh" -exec shellcheck {} \;
+    find "${GITHUB_WORKSPACE}" -name "*.sh" -exec bashate -e E006 {} \;
+    find "${GITHUB_WORKSPACE}" -name "*.py" \
          ! -path "./chef/cookbooks/bcpc/files/default/*" -exec flake8 {} \;
-    ansible-lint -x var-naming -x meta-no-info -x meta-no-tags ansible/
-    cookstyle --version && cookstyle .
+    ansible-lint -x var-naming -x meta-no-info -x meta-no-tags "${GITHUB_WORKSPACE}/ansible/"
+    cookstyle --version && cookstyle "${GITHUB_WORKSPACE}"
 }
 
 main

--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -17,12 +17,12 @@
 set -ev
 
 function main {
-    cd /tmp/linter_venv && . bin/activate
+    cd /tmp/linter_venv && source bin/activate
 
     find "${GITHUB_WORKSPACE}" -name "*.sh" -exec shellcheck {} \;
     find "${GITHUB_WORKSPACE}" -name "*.sh" -exec bashate -e E006 {} \;
     find "${GITHUB_WORKSPACE}" -name "*.py" \
-         ! -path "./chef/cookbooks/bcpc/files/default/*" -exec flake8 {} \;
+         ! -path "${GITHUB_WORKSPACE}/chef/cookbooks/bcpc/files/default/*" -exec flake8 {} \;
     ansible-lint -x var-naming -x meta-no-info -x meta-no-tags "${GITHUB_WORKSPACE}/ansible/"
     cookstyle --version && cookstyle "${GITHUB_WORKSPACE}"
 }

--- a/virtual/packer/bin/download-packer-box.sh
+++ b/virtual/packer/bin/download-packer-box.sh
@@ -37,14 +37,18 @@ fi
 
 #download base box from s3 storage
 if [ "$S3_CONFIG_FILE" == "null" ]; then
-    s3cmd get --force "${DOWNLOAD_BUCKET}/${DOWNLOAD_PACKER_BOX}" "${packer_dir}/download/${DOWNLOAD_PACKER_BOX}"
+    s3cmd get \
+          --force "${DOWNLOAD_BUCKET}/${DOWNLOAD_PACKER_BOX}" \
+          "${packer_dir}/download/${DOWNLOAD_PACKER_BOX}"
 else
-    s3cmd -c "${S3_CONFIG_FILE}" get --force "${DOWNLOAD_BUCKET}/${DOWNLOAD_PACKER_BOX}" "${packer_dir}/download/${DOWNLOAD_PACKER_BOX}"
+    s3cmd -c "${S3_CONFIG_FILE}" get \
+          --force "${DOWNLOAD_BUCKET}/${DOWNLOAD_PACKER_BOX}" \
+          "${packer_dir}/download/${DOWNLOAD_PACKER_BOX}"
 fi
 
 # add the downloaded box as the output box in vagrant
 VAGRANT_VAGRANTFILE=Vagrantfile vagrant box add \
-                   --force \
-                   --clean \
-                   --name "$OUTPUT_PACKER_BOX_NAME" \
-                   file://"${packer_dir}/download/${DOWNLOAD_PACKER_BOX}"
+                        --force \
+                        --clean \
+                        --name "$OUTPUT_PACKER_BOX_NAME" \
+                        file://"${packer_dir}/download/${DOWNLOAD_PACKER_BOX}"

--- a/virtual/packer/bin/upload-packer-box.sh
+++ b/virtual/packer/bin/upload-packer-box.sh
@@ -36,7 +36,10 @@ fi
 
 #upload base box from s3 storage
 if [ "$S3_CONFIG_FILE" == "null" ]; then
-    s3cmd put --force "${packer_dir}/${UPLOAD_SOURCE_PACKER_BOX}" "${UPLOAD_BUCKET}/${UPLOAD_TARGET_PACKER_BOX}"
+    s3cmd put --force "${packer_dir}/${UPLOAD_SOURCE_PACKER_BOX}" \
+          "${UPLOAD_BUCKET}/${UPLOAD_TARGET_PACKER_BOX}"
 else
-    s3cmd -c "${S3_CONFIG_FILE}" put --force "${packer_dir}/${UPLOAD_SOURCE_PACKER_BOX}" "${UPLOAD_BUCKET}/${UPLOAD_TARGET_PACKER_BOX}"
+    s3cmd -c "${S3_CONFIG_FILE}" put \
+          --force "${packer_dir}/${UPLOAD_SOURCE_PACKER_BOX}" \
+          "${UPLOAD_BUCKET}/${UPLOAD_TARGET_PACKER_BOX}"
 fi


### PR DESCRIPTION
Using `pipx` as part of GitHub Actions has been difficult since `ansible-lint` will sometimes get out-of-sync with `ansible-core`. Using a fresh Python `venv` every time mitigates this.

This changeset has been verified [on my own clone](https://github.com/psipika/chef-bcpc/runs/5393995397?check_suite_focus=true) of this repository.

Signed-off-by: Piotr Sipika <psipika@bloomberg.net>