### PR TITLE
Use venv for linters.

### DIFF
--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+set -e
+
 function main {
     install_linters_linux
 }
@@ -13,11 +15,14 @@ function main {
 #
 
 function install_linters_linux {
+    python3 -m venv /tmp/linter_venv
+    # shellcheck disable=SC1091
+    source /tmp/linter_venv/bin/activate
+
     sudo apt-get install -y shellcheck
-    for pkg in bashate flake8 ansible-lint==5.3.2; do
-        pipx install --force "${pkg}"
-    done
-    pipx inject ansible-lint ansible==5.2.0
+    pip install -U setuptools wheel pip
+    pip install --force bashate flake8 ansible-lint ansible
+
     sudo gem install cookstyle
 }
 

--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -17,11 +17,17 @@
 set -ev
 
 function main {
+    # shellcheck disable=SC1091
+    source /tmp/linter_venv/bin/activate
+
     find . -name "*.sh" -exec shellcheck {} \;
     find . -name "*.sh" -exec bashate -e E006 {} \;
     find . -name "*.py" \
-         ! -path "./chef/cookbooks/bcpc/files/default/*" -exec flake8 {} \;
-    ansible-lint -x var-naming -x meta-no-info -x meta-no-tags ansible/
+         ! -path "./chef/cookbooks/bcpc/files/default/*" \
+         -exec flake8 {} \;
+    ansible-lint -x var-naming \
+                 -x meta-no-info \
+                 -x meta-no-tags ansible/
     cookstyle --version && cookstyle .
 }
 


### PR DESCRIPTION
Signed-off-by: Piotr Sipika <psipika@bloomberg.net>

Using `pipx` as part of GitHub Actions has been difficult since `ansible-lint` will sometimes get out-of-sync with `ansible-core`. Using a fresh Python `venv` every time mitigates this.

This changeset has been verified [on my own clone](https://github.com/psipika/chef-bcpc/runs/5393995397?check_suite_focus=true) of this repository.