### PR TITLE
Make sure shellcheck does not flag externally sourced files as warnings.

### DIFF
--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -16,7 +16,6 @@ function main {
 
 function install_linters_linux {
     python3 -m venv /tmp/linter_venv
-    # shellcheck disable=SC1091
     source /tmp/linter_venv/bin/activate
 
     sudo apt-get install -y shellcheck

--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -17,10 +17,9 @@
 set -ev
 
 function main {
-    # shellcheck disable=SC1091
     source /tmp/linter_venv/bin/activate
 
-    find . -name "*.sh" -exec shellcheck {} \;
+    find . -name "*.sh" -exec shellcheck -x {} \;
     find . -name "*.sh" -exec bashate -e E006 {} \;
     find . -name "*.py" \
          ! -path "./chef/cookbooks/bcpc/files/default/*" \


### PR DESCRIPTION
Signed-off-by: Piotr Sipika <psipika@bloomberg.net>

As a follow-up to #1955, this changeset removes comments relating to `shellcheck`'s validation of `source`ing external files.

Without `shellcheck -x`, this warning is emitted:

```
In ./.github/scripts/run_linters.sh line 20:
    source /tmp/linter_venv/bin/activate
           ^---------------------------^ SC1091 (info): Not following: /tmp/linter_venv/bin/activate was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: /tmp/linter_venv/b...

In ./.github/scripts/install_linters.sh line 19:
    source /tmp/linter_venv/bin/activate
           ^---------------------------^ SC1091 (info): Not following: /tmp/linter_venv/bin/activate was not specified as input (see shellcheck -x).
```
