### PR TITLE
Disable felix logging to syslog and stdout

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
@@ -19,13 +19,13 @@ EtcdCertFile = <%= node['bcpc']['etcd'][@cert_type]['crt']['filepath'] %>
 EtcdKeyFile = <%= node['bcpc']['etcd'][@cert_type]['key']['filepath'] %>
 
 # The log severity above which logs are sent to the stdout.
-LogSeverityScreen = Warning
+LogSeverityScreen = Fatal
 
 # The log severity above which logs are sent to the log file.
 LogSeverityFile = Warning
 
 # The log severity above which logs are sent to the syslog.
-LogSeveritySys = Warning
+LogSeveritySys = none
 
 # Reports anonymous Calico version number and cluster size to
 # projectcalico.org. Logs warnings returned by the usage server. For


### PR DESCRIPTION
Note that felix will continue to log to /var/log/calico/felix.log.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
Disable logging to syslog and stdout for felix. Logs for felix will now only be present in /var/log/calico/felix.log.

**Testing performed**
Tested on a local BVE.

**Additional context**
This reduces log duplication.
