### PR TITLE
BGP changes

### DIFF
--- a/ansible/playbooks/roles/common/templates/bird/bird.conf.j2
+++ b/ansible/playbooks/roles/common/templates/bird/bird.conf.j2
@@ -1,9 +1,8 @@
 router id {{ interfaces['service']['ip'] }};
 
-log "/var/log/bird/bird.log" { info, remote, warning, error, auth, fatal, bug, trace, debug };
+log "/var/log/bird/bird.log" { info, warning, error, auth, fatal, bug, remote, debug };
 
-debug protocols all;
-watchdog warning 2 s;
+watchdog warning 3 s;
 
 filter to_tor {
   if net != 127.0.0.0/8 then accept;
@@ -32,31 +31,31 @@ protocol kernel {
     import filter from_kernel;
   };
 }
-{% set interfaces = ['"lo"','"service*"'] %}
-{% for transit in transit_interfaces -%}
-  {% set interfaces = interfaces.append('"' + transit['name'] + '"') %}
-{%- endfor %}
 
 protocol direct {
   ipv4;
-  interface {{ interfaces | join(', ') }};
+  interface "lo", "service0";
 }
 
 protocol device {
   scan time 2;
 }
 
-{% for transit in transit_interfaces %}
-protocol bgp '{{ transit['neighbor']['name'] }}:{{ transit['name'] }}' {
-  multihop;
+template bgp PEER {
   graceful restart;
-  local {{ transit['ip'] | ipaddr('address') }} as {{ bgp['asn'] }};
-  neighbor {{ transit['neighbor']['ip'] }} as {{ transit['neighbor']['asn'] }};
+  hold time 9;
+  keepalive time 3;
+  error wait time 9,300;
   ipv4 {
-    next hop self;
     import all;
     export filter to_tor;
   };
+}
+
+{% for transit in transit_interfaces %}
+protocol bgp '{{ transit['neighbor']['name'] }}:{{ transit['name'] }}' from PEER {
+  local {{ transit['ip'] | ipaddr('address') }} as {{ bgp['asn'] }};
+  neighbor {{ transit['neighbor']['ip'] }} as {{ transit['neighbor']['asn'] }};
 }
 
 {% endfor %}

--- a/virtual/network/bird/bcpc-pd1-sw1.conf
+++ b/virtual/network/bird/bcpc-pd1-sw1.conf
@@ -15,30 +15,12 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
-        if net = DEFAULT then accept;
-        reject;
-}
-
-filter mynetworks
-prefix set mynetworks_nets;
-{
-        mynetworks_nets = [
-            172.16.0.0/26+,
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -47,12 +29,13 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
-                import filter mynetworks;
+                import none;
         };
 }
 
@@ -60,7 +43,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -68,112 +51,66 @@ protocol direct {
         interface "eth3";
 }
 
-protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw1' {
+template bgp TOR_PEER {
         local as 4200858701;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+template bgp BCPC_PEER {
+        local as 4200858701;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw1' from TOR_PEER {
         neighbor 172.16.0.1 as 4200858601;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw1' {
-        local as 4200858701;
+protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw1' from TOR_PEER {
         neighbor 172.16.0.3 as 4200858601;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw1:r1n0' {
-        local as 4200858701;
+protocol bgp 'bcpc-pd1-sw1:r1n0' from BCPC_PEER {
         neighbor 10.121.84.2 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw1:r1n1' {
-        local as 4200858701;
+protocol bgp 'bcpc-pd1-sw1:r1n1' from BCPC_PEER {
         neighbor 10.121.84.3 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw1:r1n2' {
-        local as 4200858701;
+protocol bgp 'bcpc-pd1-sw1:r1n2' from BCPC_PEER {
         neighbor 10.121.84.4 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw1:r1n3' {
-        local as 4200858701;
+protocol bgp 'bcpc-pd1-sw1:r1n3' from BCPC_PEER {
         neighbor 10.121.84.5 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw1:r1n4' {
-        local as 4200858701;
+protocol bgp 'bcpc-pd1-sw1:r1n4' from BCPC_PEER {
         neighbor 10.121.84.6 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw1:r1n5' {
-        local as 4200858701;
+protocol bgp 'bcpc-pd1-sw1:r1n5' from BCPC_PEER {
         neighbor 10.121.84.7 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw1:r1n6' {
-        local as 4200858701;
+protocol bgp 'bcpc-pd1-sw1:r1n6' from BCPC_PEER {
         neighbor 10.121.84.8 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw1:r1n7' {
-        local as 4200858701;
+protocol bgp 'bcpc-pd1-sw1:r1n7' from BCPC_PEER {
         neighbor 10.121.84.9 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pd1-sw2.conf
+++ b/virtual/network/bird/bcpc-pd1-sw2.conf
@@ -15,30 +15,12 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
-        if net = DEFAULT then accept;
-        reject;
-}
-
-filter mynetworks
-prefix set mynetworks_nets;
-{
-        mynetworks_nets = [
-            172.16.0.0/26+,
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -47,12 +29,13 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
-                import filter mynetworks;
+                import none;
         };
 }
 
@@ -60,7 +43,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -68,101 +51,62 @@ protocol direct {
         interface "eth3";
 }
 
-protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw2' {
+template bgp TOR_PEER {
         local as 4200858703;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+template bgp BCPC_PEER {
+        local as 4200858703;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw2' from TOR_PEER {
         neighbor 172.16.0.5 as 4200858601;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw2' {
-        local as 4200858703;
+protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw2' from TOR_PEER {
         neighbor 172.16.0.7 as 4200858601;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw2:r2n1' {
-        local as 4200858703;
+protocol bgp 'bcpc-pd1-sw2:r2n1' from BCPC_PEER {
         neighbor 10.121.85.3 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw2:r2n2' {
-        local as 4200858703;
+protocol bgp 'bcpc-pd1-sw2:r2n2' from BCPC_PEER {
         neighbor 10.121.85.4 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw2:r2n3' {
-        local as 4200858703;
+protocol bgp 'bcpc-pd1-sw2:r2n3' from BCPC_PEER {
         neighbor 10.121.85.5 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw2:r2n4' {
-        local as 4200858703;
+protocol bgp 'bcpc-pd1-sw2:r2n4' from BCPC_PEER {
         neighbor 10.121.85.6 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw2:r2n5' {
-        local as 4200858703;
+protocol bgp 'bcpc-pd1-sw2:r2n5' from BCPC_PEER {
         neighbor 10.121.85.7 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw2:r2n6' {
-        local as 4200858703;
+protocol bgp 'bcpc-pd1-sw2:r2n6' from BCPC_PEER {
         neighbor 10.121.85.8 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw2:r2n7' {
-        local as 4200858703;
+protocol bgp 'bcpc-pd1-sw2:r2n7' from BCPC_PEER {
         neighbor 10.121.85.9 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pd1-sw3.conf
+++ b/virtual/network/bird/bcpc-pd1-sw3.conf
@@ -15,30 +15,12 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
-        if net = DEFAULT then accept;
-        reject;
-}
-
-filter mynetworks
-prefix set mynetworks_nets;
-{
-        mynetworks_nets = [
-            172.16.0.0/26+,
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -47,12 +29,13 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
-                import filter mynetworks;
+                import none;
         };
 }
 
@@ -60,7 +43,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -68,101 +51,62 @@ protocol direct {
         interface "eth3";
 }
 
-protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw3' {
+template bgp TOR_PEER {
         local as 4200858705;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+template bgp BCPC_PEER {
+        local as 4200858705;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw3' from TOR_PEER {
         neighbor 172.16.0.9 as 4200858601;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw3' {
-        local as 4200858705;
+protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw3' from TOR_PEER {
         neighbor 172.16.0.11 as 4200858601;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw3:r3n1' {
-        local as 4200858705;
+protocol bgp 'bcpc-pd1-sw3:r3n1' from BCPC_PEER {
         neighbor 10.121.86.3 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw3:r3n2' {
-        local as 4200858705;
+protocol bgp 'bcpc-pd1-sw3:r3n2' from BCPC_PEER {
         neighbor 10.121.86.4 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw3:r3n3' {
-        local as 4200858705;
+protocol bgp 'bcpc-pd1-sw3:r3n3' from BCPC_PEER {
         neighbor 10.121.86.5 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw3:r3n4' {
-        local as 4200858705;
+protocol bgp 'bcpc-pd1-sw3:r3n4' from BCPC_PEER {
         neighbor 10.121.86.6 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw3:r3n5' {
-        local as 4200858705;
+protocol bgp 'bcpc-pd1-sw3:r3n5' from BCPC_PEER {
         neighbor 10.121.86.7 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw3:r3n6' {
-        local as 4200858705;
+protocol bgp 'bcpc-pd1-sw3:r3n6' from BCPC_PEER {
         neighbor 10.121.86.8 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd1-sw3:r3n7' {
-        local as 4200858705;
+protocol bgp 'bcpc-pd1-sw3:r3n7' from BCPC_PEER {
         neighbor 10.121.86.9 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pd2-sw1.conf
+++ b/virtual/network/bird/bcpc-pd2-sw1.conf
@@ -15,30 +15,12 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.92.0/22+,
-            10.121.96.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
-        if net = DEFAULT then accept;
-        reject;
-}
-
-filter mynetworks
-prefix set mynetworks_nets;
-{
-        mynetworks_nets = [
-            172.16.0.0/26+,
-            # Transit networks
-            10.121.92.0/22+,
-            10.121.96.0/22+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -47,12 +29,13 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
-                import filter mynetworks;
+                import none;
         };
 }
 
@@ -60,7 +43,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -68,101 +51,62 @@ protocol direct {
         interface "eth3";
 }
 
-protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw1' {
+template bgp TOR_PEER {
         local as 4200858709;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+template bgp BCPC_PEER {
+        local as 4200858709;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw1' from TOR_PEER {
         neighbor 172.16.0.33 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw1' {
-        local as 4200858709;
+protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw1' from TOR_PEER {
         neighbor 172.16.0.35 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw1:r5n1' {
-        local as 4200858709;
+protocol bgp 'bcpc-pd2-sw1:r5n1' from BCPC_PEER {
         neighbor 10.121.92.3 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw1:r5n2' {
-        local as 4200858709;
+protocol bgp 'bcpc-pd2-sw1:r5n2' from BCPC_PEER {
         neighbor 10.121.92.4 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw1:r5n3' {
-        local as 4200858709;
+protocol bgp 'bcpc-pd2-sw1:r5n3' from BCPC_PEER {
         neighbor 10.121.92.5 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw1:r5n4' {
-        local as 4200858709;
+protocol bgp 'bcpc-pd2-sw1:r5n4' from BCPC_PEER {
         neighbor 10.121.92.6 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw1:r5n5' {
-        local as 4200858709;
+protocol bgp 'bcpc-pd2-sw1:r5n5' from BCPC_PEER {
         neighbor 10.121.92.7 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw1:r5n6' {
-        local as 4200858709;
+protocol bgp 'bcpc-pd2-sw1:r5n6' from BCPC_PEER {
         neighbor 10.121.92.8 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw1:r5n7' {
-        local as 4200858709;
+protocol bgp 'bcpc-pd2-sw1:r5n7' from BCPC_PEER {
         neighbor 10.121.92.9 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pd2-sw2.conf
+++ b/virtual/network/bird/bcpc-pd2-sw2.conf
@@ -15,30 +15,12 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.92.0/22+,
-            10.121.96.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
-        if net = DEFAULT then accept;
-        reject;
-}
-
-filter mynetworks
-prefix set mynetworks_nets;
-{
-        mynetworks_nets = [
-            172.16.0.0/26+,
-            # Transit networks
-            10.121.92.0/22+,
-            10.121.96.0/22+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -47,12 +29,13 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
-                import filter mynetworks;
+                import none;
         };
 }
 
@@ -60,7 +43,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -68,101 +51,62 @@ protocol direct {
         interface "eth3";
 }
 
-protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw2' {
+template bgp TOR_PEER {
         local as 4200858711;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+template bgp BCPC_PEER {
+        local as 4200858711;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw2' from TOR_PEER {
         neighbor 172.16.0.37 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw2' {
-        local as 4200858711;
+protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw2' from TOR_PEER {
         neighbor 172.16.0.39 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw2:r6n1' {
-        local as 4200858711;
+protocol bgp 'bcpc-pd2-sw2:r6n1' from BCPC_PEER {
         neighbor 10.121.93.3 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw2:r6n2' {
-        local as 4200858711;
+protocol bgp 'bcpc-pd2-sw2:r6n2' from BCPC_PEER {
         neighbor 10.121.93.4 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw2:r6n3' {
-        local as 4200858711;
+protocol bgp 'bcpc-pd2-sw2:r6n3' from BCPC_PEER {
         neighbor 10.121.93.5 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw2:r6n4' {
-        local as 4200858711;
+protocol bgp 'bcpc-pd2-sw2:r6n4' from BCPC_PEER {
         neighbor 10.121.93.6 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw2:r6n5' {
-        local as 4200858711;
+protocol bgp 'bcpc-pd2-sw2:r6n5' from BCPC_PEER {
         neighbor 10.121.93.7 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw2:r6n6' {
-        local as 4200858711;
+protocol bgp 'bcpc-pd2-sw2:r6n6' from BCPC_PEER {
         neighbor 10.121.93.8 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw2:r6n7' {
-        local as 4200858711;
+protocol bgp 'bcpc-pd2-sw2:r6n7' from BCPC_PEER {
         neighbor 10.121.93.9 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pd2-sw3.conf
+++ b/virtual/network/bird/bcpc-pd2-sw3.conf
@@ -15,30 +15,12 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.92.0/22+,
-            10.121.96.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
-        if net = DEFAULT then accept;
-        reject;
-}
-
-filter mynetworks
-prefix set mynetworks_nets;
-{
-        mynetworks_nets = [
-            172.16.0.0/26+,
-            # Transit networks
-            10.121.92.0/22+,
-            10.121.96.0/22+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -47,12 +29,13 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
-                import filter mynetworks;
+                import none;
         };
 }
 
@@ -60,7 +43,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -68,101 +51,62 @@ protocol direct {
         interface "eth3";
 }
 
-protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw3' {
+template bgp TOR_PEER {
         local as 4200858713;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+template bgp BCPC_PEER {
+        local as 4200858713;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw3' from TOR_PEER {
         neighbor 172.16.0.41 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw3' {
-        local as 4200858713;
+protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw3' from TOR_PEER {
         neighbor 172.16.0.43 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter hypervisors;
-                import filter mynetworks;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw3:r7n1' {
-        local as 4200858713;
+protocol bgp 'bcpc-pd2-sw3:r7n1' from BCPC_PEER {
         neighbor 10.121.94.3 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw3:r7n2' {
-        local as 4200858713;
+protocol bgp 'bcpc-pd2-sw3:r7n2' from BCPC_PEER {
         neighbor 10.121.94.4 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw3:r7n3' {
-        local as 4200858713;
+protocol bgp 'bcpc-pd2-sw3:r7n3' from BCPC_PEER {
         neighbor 10.121.94.5 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw3:r7n4' {
-        local as 4200858713;
+protocol bgp 'bcpc-pd2-sw3:r7n4' from BCPC_PEER {
         neighbor 10.121.94.6 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw3:r7n5' {
-        local as 4200858713;
+protocol bgp 'bcpc-pd2-sw3:r7n5' from BCPC_PEER {
         neighbor 10.121.94.7 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw3:r7n6' {
-        local as 4200858713;
+protocol bgp 'bcpc-pd2-sw3:r7n6' from BCPC_PEER {
         neighbor 10.121.94.8 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pd2-sw3:r7n7' {
-        local as 4200858713;
+protocol bgp 'bcpc-pd2-sw3:r7n7' from BCPC_PEER {
         neighbor 10.121.94.9 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pl1-sp1.conf
+++ b/virtual/network/bird/bcpc-pl1-sp1.conf
@@ -15,14 +15,10 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
         if net = DEFAULT then accept;
@@ -32,10 +28,6 @@ prefix set hypervisors_nets;
 filter mynetworks
 prefix set mynetworks_nets;
 {
-        mynetworks_nets = [
-            172.16.0.0/26+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -44,11 +36,12 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
         # necessary to include DHCP-derived default route
         learn;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -59,7 +52,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -67,57 +60,38 @@ protocol direct {
         interface "eth1", "eth2", "eth3";
 }
 
-protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw1' {
+template bgp PEER {
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw1' from PEER {
         local as 4200858601;
         neighbor 172.16.0.0 as 4200858701;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw2' {
+protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw2' from PEER {
         local as 4200858601;
         neighbor 172.16.0.4 as 4200858703;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw3' {
+protocol bgp 'bcpc-pl1-sp1:bcpc-pd1-sw3' from PEER {
         local as 4200858601;
         neighbor 172.16.0.8 as 4200858705;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl1fs1:bcpc-pl1-sp1' {
+protocol bgp 'bcpc-pl1fs1:bcpc-pl1-sp1' from PEER {
         local as 4200858601;
         neighbor 172.16.0.65 as 4200858501;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl1fs2:bcpc-pl1-sp1' {
+protocol bgp 'bcpc-pl1fs2:bcpc-pl1-sp1' from PEER {
         local as 4200858601;
         neighbor 172.16.0.67 as 4200858501;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pl1-sp2.conf
+++ b/virtual/network/bird/bcpc-pl1-sp2.conf
@@ -15,14 +15,10 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.92.0/22+,
-            10.121.96.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
         if net = DEFAULT then accept;
@@ -32,10 +28,6 @@ prefix set hypervisors_nets;
 filter mynetworks
 prefix set mynetworks_nets;
 {
-        mynetworks_nets = [
-            172.16.0.0/26+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -44,9 +36,10 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
+        graceful restart;
         # necessary to include DHCP-derived default route
         learn;
         ipv4 {
@@ -59,7 +52,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -67,57 +60,38 @@ protocol direct {
         interface "eth1", "eth2", "eth3";
 }
 
-protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw1' {
+template bgp PEER {
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw1' from PEER {
         local as 4200858602;
         neighbor 172.16.0.32 as 4200858709;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw2' {
+protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw2' from PEER {
         local as 4200858602;
         neighbor 172.16.0.36 as 4200858711;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw3' {
+protocol bgp 'bcpc-pl1-sp2:bcpc-pd2-sw3' from PEER {
         local as 4200858602;
         neighbor 172.16.0.40 as 4200858713;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl1fs1:bcpc-pl1-sp2' {
+protocol bgp 'bcpc-pl1fs1:bcpc-pl1-sp2' from PEER {
         local as 4200858602;
         neighbor 172.16.0.69 as 4200858501;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl1fs2:bcpc-pl1-sp2' {
+protocol bgp 'bcpc-pl1fs2:bcpc-pl1-sp2' from PEER {
         local as 4200858602;
         neighbor 172.16.0.71 as 4200858501;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pl1fs1.conf
+++ b/virtual/network/bird/bcpc-pl1fs1.conf
@@ -15,28 +15,19 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+,
-            10.121.92.0/22+,
-            10.121.96.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
+        if net = DEFAULT then accept;
         reject;
 }
 
 filter mynetworks
 prefix set mynetworks_nets;
 {
-        mynetworks_nets = [
-            172.16.0.0/26+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -45,10 +36,12 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
+        persist;
         merge paths on;
         # necessary to include DHCP-derived default route
         learn;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -59,7 +52,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -67,24 +60,22 @@ protocol direct {
         interface "eth1", "eth2";
 }
 
-protocol bgp 'bcpc-pl1fs1:bcpc-pl1-sp1' {
+template bgp PEER {
         local as 4200858501;
-        neighbor 172.16.0.64 as 4200858601;
-        hold time 3;
-        keepalive time 1;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
         ipv4 {
-                export all;
+                export filter hypervisors;
                 import filter hypervisors;
         };
 }
 
-protocol bgp 'bcpc-pl1fs1:bcpc-pl1-sp2' {
-        local as 4200858501;
+protocol bgp 'bcpc-pl1fs1:bcpc-pl1-sp1' from PEER {
+        neighbor 172.16.0.64 as 4200858601;
+}
+
+protocol bgp 'bcpc-pl1fs1:bcpc-pl1-sp2' from PEER {
         neighbor 172.16.0.68 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pl1fs2.conf
+++ b/virtual/network/bird/bcpc-pl1fs2.conf
@@ -15,28 +15,19 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+,
-            10.121.92.0/22+,
-            10.121.96.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
+        if net = DEFAULT then accept;
         reject;
 }
 
 filter mynetworks
 prefix set mynetworks_nets;
 {
-        mynetworks_nets = [
-            172.16.0.0/26+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -45,10 +36,12 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
+        persist;
         merge paths on;
         # necessary to include DHCP-derived default route
         learn;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -59,7 +52,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -67,24 +60,22 @@ protocol direct {
         interface "eth1", "eth2";
 }
 
-protocol bgp 'bcpc-pl1fs2:bcpc-pl1-sp1' {
+template bgp PEER {
         local as 4200858501;
-        neighbor 172.16.0.66 as 4200858601;
-        hold time 3;
-        keepalive time 1;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
         ipv4 {
-                export all;
+                export filter hypervisors;
                 import filter hypervisors;
         };
 }
 
-protocol bgp 'bcpc-pl1fs2:bcpc-pl1-sp2' {
-        local as 4200858501;
+protocol bgp 'bcpc-pl1fs2:bcpc-pl1-sp1' from PEER {
+        neighbor 172.16.0.66 as 4200858601;
+}
+
+protocol bgp 'bcpc-pl1fs2:bcpc-pl1-sp2' from PEER {
         neighbor 172.16.0.70 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pl2-sp1.conf
+++ b/virtual/network/bird/bcpc-pl2-sp1.conf
@@ -15,14 +15,10 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
         if net = DEFAULT then accept;
@@ -32,10 +28,6 @@ prefix set hypervisors_nets;
 filter mynetworks
 prefix set mynetworks_nets;
 {
-        mynetworks_nets = [
-            172.16.0.0/26+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -44,11 +36,12 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
         # necessary to include DHCP-derived default route
         learn;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -59,7 +52,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -67,57 +60,38 @@ protocol direct {
         interface "eth1", "eth2", "eth3";
 }
 
-protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw1' {
+template bgp PEER {
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw1' from PEER {
         local as 4200858601;
         neighbor 172.16.0.2 as 4200858701;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw2' {
+protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw2' from PEER {
         local as 4200858601;
         neighbor 172.16.0.6 as 4200858703;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw3' {
+protocol bgp 'bcpc-pl2-sp1:bcpc-pd1-sw3' from PEER {
         local as 4200858601;
         neighbor 172.16.0.10 as 4200858705;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl2fs1:bcpc-pl2-sp1' {
+protocol bgp 'bcpc-pl2fs1:bcpc-pl2-sp1' from PEER {
         local as 4200858601;
         neighbor 172.16.0.73 as 4200858502;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl2fs2:bcpc-pl2-sp1' {
+protocol bgp 'bcpc-pl2fs2:bcpc-pl2-sp1' from PEER {
         local as 4200858601;
         neighbor 172.16.0.75 as 4200858502;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pl2-sp2.conf
+++ b/virtual/network/bird/bcpc-pl2-sp2.conf
@@ -15,14 +15,10 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.92.0/22+,
-            10.121.96.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
         if net = DEFAULT then accept;
@@ -32,10 +28,6 @@ prefix set hypervisors_nets;
 filter mynetworks
 prefix set mynetworks_nets;
 {
-        mynetworks_nets = [
-            172.16.0.0/26+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -44,11 +36,10 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         persist;
         merge paths on;
-        # necessary to include DHCP-derived default route
-        learn;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -59,7 +50,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -67,57 +58,38 @@ protocol direct {
         interface "eth1", "eth2", "eth3";
 }
 
-protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw1' {
+template bgp PEER {
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter hypervisors;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw1' from PEER {
         local as 4200858602;
         neighbor 172.16.0.34 as 4200858709;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw2' {
+protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw2' from PEER {
         local as 4200858602;
         neighbor 172.16.0.38 as 4200858711;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw3' {
+protocol bgp 'bcpc-pl2-sp2:bcpc-pd2-sw3' from PEER {
         local as 4200858602;
         neighbor 172.16.0.42 as 4200858713;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl2fs1:bcpc-pl2-sp2' {
+protocol bgp 'bcpc-pl2fs1:bcpc-pl2-sp2' from PEER {
         local as 4200858602;
         neighbor 172.16.0.77 as 4200858502;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'bcpc-pl2fs2:bcpc-pl2-sp2' {
+protocol bgp 'bcpc-pl2fs2:bcpc-pl2-sp2' from PEER {
         local as 4200858602;
         neighbor 172.16.0.79 as 4200858502;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pl2fs1.conf
+++ b/virtual/network/bird/bcpc-pl2fs1.conf
@@ -15,28 +15,19 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+,
-            10.121.92.0/22+,
-            10.121.96.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
+        if net = DEFAULT then accept;
         reject;
 }
 
 filter mynetworks
 prefix set mynetworks_nets;
 {
-        mynetworks_nets = [
-            172.16.0.0/26+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -45,10 +36,12 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
+        persist;
         merge paths on;
         # necessary to include DHCP-derived default route
         learn;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -59,7 +52,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -67,24 +60,22 @@ protocol direct {
         interface "eth1", "eth2";
 }
 
-protocol bgp 'bcpc-pl2fs1:bcpc-pl2-sp1' {
+template bgp PEER {
         local as 4200858502;
-        neighbor 172.16.0.72 as 4200858601;
-        hold time 3;
-        keepalive time 1;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
         ipv4 {
-                export all;
+                export filter hypervisors;
                 import filter hypervisors;
         };
 }
 
-protocol bgp 'bcpc-pl2fs1:bcpc-pl2-sp2' {
-        local as 4200858502;
+protocol bgp 'bcpc-pl2fs1:bcpc-pl2-sp1' from PEER {
+        neighbor 172.16.0.72 as 4200858601;
+}
+
+protocol bgp 'bcpc-pl2fs1:bcpc-pl2-sp2' from PEER {
         neighbor 172.16.0.76 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/bcpc-pl2fs2.conf
+++ b/virtual/network/bird/bcpc-pl2fs2.conf
@@ -15,28 +15,19 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+,
-            10.121.92.0/22+,
-            10.121.96.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
+        if net = DEFAULT then accept;
         reject;
 }
 
 filter mynetworks
 prefix set mynetworks_nets;
 {
-        mynetworks_nets = [
-            172.16.0.0/26+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -45,10 +36,12 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
+        persist;
         merge paths on;
         # necessary to include DHCP-derived default route
         learn;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -59,7 +52,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -67,24 +60,22 @@ protocol direct {
         interface "eth1", "eth2";
 }
 
-protocol bgp 'bcpc-pl2fs2:bcpc-pl2-sp1' {
+template bgp PEER {
         local as 4200858502;
-        neighbor 172.16.0.74 as 4200858601;
-        hold time 3;
-        keepalive time 1;
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
         ipv4 {
-                export all;
+                export filter hypervisors;
                 import filter hypervisors;
         };
 }
 
-protocol bgp 'bcpc-pl2fs2:bcpc-pl2-sp2' {
-        local as 4200858502;
+protocol bgp 'bcpc-pl2fs2:bcpc-pl2-sp1' from PEER {
+        neighbor 172.16.0.74 as 4200858601;
+}
+
+protocol bgp 'bcpc-pl2fs2:bcpc-pl2-sp2' from PEER {
         neighbor 172.16.0.78 as 4200858602;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export all;
-                import filter hypervisors;
-        };
 }

--- a/virtual/network/bird/network.conf
+++ b/virtual/network/bird/network.conf
@@ -15,14 +15,10 @@ filter hypervisors
 prefix set hypervisors_nets;
 {
         hypervisors_nets = [
-            172.16.0.0/26+,
             # Tenant networks
             10.1.0.0/16{32,32},
             # Loopback networks
-            10.65.0.0/24{32,32},
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
+            10.65.0.0/24{32,32}
         ];
         if net ~ hypervisors_nets then accept;
         if net = DEFAULT then accept;
@@ -32,13 +28,6 @@ prefix set hypervisors_nets;
 filter mynetworks
 prefix set mynetworks_nets;
 {
-        mynetworks_nets = [
-            172.16.0.0/26+,
-            # Transit networks
-            10.121.84.0/22+,
-            10.121.88.0/22+
-        ];
-        if net ~ mynetworks_nets then accept;
         if net = DEFAULT then accept;
         reject;
 }
@@ -47,11 +36,12 @@ prefix set mynetworks_nets;
 # with other routers in the network, it performs synchronization of BIRD's
 # routing tables with the OS kernel.
 protocol kernel {
-        scan time 60;
+        scan time 2;
         # necessary to include DHCP-derived default route
         learn;
         persist;
         merge paths on;
+        graceful restart;
         ipv4 {
                 export filter hypervisors;
                 import filter mynetworks;
@@ -62,7 +52,7 @@ protocol kernel {
 # routes and it only serves as a module for getting information about network
 # interfaces from the kernel.
 protocol device {
-        scan time 60;
+        scan time 2;
 }
 
 protocol direct {
@@ -70,244 +60,123 @@ protocol direct {
         interface "eth1", "eth2", "eth3";
 }
 
-protocol bgp 'tor1:r1n0' {
+template bgp PEER {
+        graceful restart;
+        hold time 9;
+        keepalive time 3;
+        error wait time 9,300;
+        ipv4 {
+                export filter mynetworks;
+                import filter hypervisors;
+        };
+}
+
+protocol bgp 'tor1:r1n0' from PEER {
         local as 4200858701;
         neighbor 10.121.84.2 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor1:r1n1' {
+protocol bgp 'tor1:r1n1' from PEER {
         local as 4200858701;
         neighbor 10.121.84.3 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor1:r1n2' {
+protocol bgp 'tor1:r1n2' from PEER {
         local as 4200858701;
         neighbor 10.121.84.4 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor1:r1n3' {
+protocol bgp 'tor1:r1n3' from PEER {
         local as 4200858701;
         neighbor 10.121.84.5 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor1:r1n4' {
+protocol bgp 'tor1:r1n4' from PEER {
         local as 4200858701;
         neighbor 10.121.84.6 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor1:r1n5' {
+protocol bgp 'tor1:r1n5' from PEER {
         local as 4200858701;
         neighbor 10.121.84.7 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor1:r1n6' {
+protocol bgp 'tor1:r1n6' from PEER {
         local as 4200858701;
         neighbor 10.121.84.8 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor1:r1n7' {
+protocol bgp 'tor1:r1n7' from PEER {
         local as 4200858701;
         neighbor 10.121.84.9 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor2:r2n1' {
+protocol bgp 'tor2:r2n1' from PEER {
         local as 4200858703;
         neighbor 10.121.85.3 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor2:r2n2' {
+protocol bgp 'tor2:r2n2' from PEER {
         local as 4200858703;
         neighbor 10.121.85.4 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor2:r2n3' {
+protocol bgp 'tor2:r2n3' from PEER {
         local as 4200858703;
         neighbor 10.121.85.5 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor2:r2n4' {
+protocol bgp 'tor2:r2n4' from PEER {
         local as 4200858703;
         neighbor 10.121.85.6 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor2:r2n5' {
+protocol bgp 'tor2:r2n5' from PEER {
         local as 4200858703;
         neighbor 10.121.85.7 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor2:r2n6' {
+protocol bgp 'tor2:r2n6' from PEER {
         local as 4200858703;
         neighbor 10.121.85.8 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor2:r2n7' {
+protocol bgp 'tor2:r2n7' from PEER {
         local as 4200858703;
         neighbor 10.121.85.9 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor3:r3n1' {
+protocol bgp 'tor3:r3n1' from PEER {
         local as 4200858705;
         neighbor 10.121.86.3 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor3:r3n2' {
+protocol bgp 'tor3:r3n2' from PEER {
         local as 4200858705;
         neighbor 10.121.86.4 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor3:r3n3' {
+protocol bgp 'tor3:r3n3' from PEER {
         local as 4200858705;
         neighbor 10.121.86.5 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor3:r3n4' {
+protocol bgp 'tor3:r3n4' from PEER {
         local as 4200858705;
         neighbor 10.121.86.6 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor3:r3n5' {
+protocol bgp 'tor3:r3n5' from PEER {
         local as 4200858705;
         neighbor 10.121.86.7 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor3:r3n6' {
+protocol bgp 'tor3:r3n6' from PEER {
         local as 4200858705;
         neighbor 10.121.86.8 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }
 
-protocol bgp 'tor3:r3n7' {
+protocol bgp 'tor3:r3n7' from PEER {
         local as 4200858705;
         neighbor 10.121.86.9 as 4200858801;
-        hold time 3;
-        keepalive time 1;
-        ipv4 {
-                export filter mynetworks;
-                import filter hypervisors;
-        };
 }


### PR DESCRIPTION
Rejigger the BGP configuration:
  * Remove very verbose debug logging

  * Stop advertising transit routes

  * Leverage bird's templating syntax for configuration

  * Tweak keepalive and hold timer upwards slightly:
    although 1x3 works, users have reported edge cases
    where it results in flaps

  * Remove multihop, next-hop-self as we are not doing
    mixing iBGP and eBGP and thus do not need these
    features

  * Use graceful restart on the switches (in this case,
    they act as GR helper for the hosts with 2 minute
    GR/NSF timer)

  * Optimize response to BGP flaps (tweak error wait timer
    initial starting point down to that of the hold timer)

  * In the virtual network setup, propagate all routes and
    do NOT rely on the default route up towards the spines
    for things like the cloud IP.