### PR TITLE
Upgrade haproxy from 1.8 to 2.4

### DIFF
--- a/chef/cookbooks/bcpc/attributes/haproxy.rb
+++ b/chef/cookbooks/bcpc/attributes/haproxy.rb
@@ -4,7 +4,7 @@
 
 # Installation-related configuration options
 default['bcpc']['haproxy']['repo']['enabled'] = false
-default['bcpc']['haproxy']['repo']['url'] = 'http://ppa.launchpad.net/vbernat/haproxy-1.8/ubuntu'
+default['bcpc']['haproxy']['repo']['url'] = 'http://ppa.launchpad.net/vbernat/haproxy-2.4/ubuntu'
 default['bcpc']['haproxy']['repo']['key'] = 'haproxy/haproxy.key'
 
 # QoS protection-related configuration options

--- a/chef/cookbooks/bcpc/recipes/haproxy.rb
+++ b/chef/cookbooks/bcpc/recipes/haproxy.rb
@@ -46,12 +46,13 @@ end
 begin
 
   certs = []
-  certs.push(Base64.decode64(config['ssl']['key']))
   certs.push(Base64.decode64(config['ssl']['crt']))
 
   if config['ssl']['intermediate']
     certs.push(Base64.decode64(config['ssl']['intermediate']))
   end
+
+  certs.push(Base64.decode64(config['ssl']['key']))
 
   template '/etc/haproxy/haproxy.pem' do
     source 'haproxy/haproxy.pem.erb'

--- a/chef/cookbooks/bcpc/templates/default/haproxy/haproxy.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/haproxy/haproxy.cfg.erb
@@ -44,7 +44,7 @@ frontend https
   stats hide-version
   stats realm Haproxy\ Statistics
   stats auth <%= @user['username'] %>:<%= @user['password'] %>
-  reqadd X-Forwarded-Proto:\ https
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
   acl url_horizon path_beg /horizon
   use_backend horizon-backend if url_horizon
   acl url_horizon_static path_beg /static
@@ -74,7 +74,7 @@ backend rabbitmq-web-backend
   balance source
   option httpchk GET /
   http-check expect status 200
-  reqrep ^([^\ :]*)\ /rabbitmq/(.*) \1\ /\2
+  http-request set-uri %[url,regsub(^/rabbitmq/?,/,)] if { path_beg /rabbitmq }
 <% @rmqnodes.each do |n| -%>
   server <%= n['hostname'] %> <%= n['service_ip'] %>:55672 check inter 5s rise 1 fall 1
 <% end -%>

--- a/chef/cookbooks/bcpc/templates/default/heat/haproxy.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/heat/haproxy.cfg.erb
@@ -14,7 +14,7 @@ listen heat-api
 <% end -%>
 
 <%= render 'haproxy/haproxy.cfg.qos.erb', :option => {} %>
-  reqadd X-Forwarded-Proto:\ https
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }
 
 listen heat-api-cfn
   bind <%= @vip %>:8000 ssl crt /etc/haproxy/haproxy.pem
@@ -28,4 +28,4 @@ listen heat-api-cfn
 <% end -%>
 
 <%= render 'haproxy/haproxy.cfg.qos.erb', :option => {} %>
-  reqadd X-Forwarded-Proto:\ https
+  http-request add-header X-Forwarded-Proto https if { ssl_fc }


### PR DESCRIPTION
haproxy: Replace deprecated use of reqadd/reqrep

These have been deprecated for awhile in HAproxy, and now
no longer work at all in the 2.4 series. Replace them with
suggested equivalents.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>

haproxy: Jump to version 2.4 if using external PPA

There are no HAproxy 1.8.x releases built against Focal,
and 1.8.x is EOL sometime next year anyways. Jump to 2.4.x
as it has releases for both Bionic and Focal both, so
operators can maintain version parity when they swing from
Bionic to Focal.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>

haproxy: Render PEM file in documented fashion

haproxy indicates that the PEM file should be structured
such that the public key appears first, immediate (if
present) next, and finally the private key.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>

**Describe your changes**
Changes required to upgrade haproxy to version 2.4

**Testing performed**
Tested on a local BVE and physical test cluster.

**Additional context**
N/A
