### PR TITLE
Add more rules to ansible-lint skip list via command-line.

### DIFF
--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -26,7 +26,10 @@ function main {
          -exec flake8 {} \;
     ansible-lint -x var-naming \
                  -x meta-no-info \
-                 -x meta-no-tags ansible/
+                 -x meta-no-tags ansible/ \
+                 -x yaml \
+                 -x fqcn-builtins \
+                 -x experimental
     cookstyle --version && cookstyle .
 }
 


### PR DESCRIPTION
Signed-off-by: Piotr Sipika <psipika@bloomberg.net>

As `ansible` evolves, so do best-practices around the code it handles.
This PR disables some checks that were introduced in the latest version of `ansible-lint`.

Successfully tested [here](https://github.com/psipika/chef-bcpc/actions/runs/1993125043)
