### PR TITLE
Makefile: remove dead code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,10 +237,6 @@ upload-all :
 		-i ${inventory} ${playbooks}/site.yml \
 		-t upload-extra-cookbooks --limit bootstraps
 
-	ansible-playbook -v \
-		-i ${inventory} ${playbooks}/site.yml \
-		-t upload-bcpc --limit bootstraps
-
 configure-web-server :
 
 	ansible-playbook -v \


### PR DESCRIPTION
There is no `upload-bcpc` tag defined in the playbooks, so
this step of the Makefile is a no-op.