### PR TITLE
Specify the version of tempest used by rally

### DIFF
--- a/chef/cookbooks/bcpc/attributes/rally.rb
+++ b/chef/cookbooks/bcpc/attributes/rally.rb
@@ -3,8 +3,9 @@
 ###############################################################################
 
 default['bcpc']['rally']['enabled'] = false
-default['bcpc']['rally']['rally_openstack']['version'] = '2.1.0'
 default['bcpc']['rally']['rally']['version'] = '3.2.0'
+default['bcpc']['rally']['rally_openstack']['version'] = '2.1.0'
+default['bcpc']['rally']['tempest']['version'] = '30.0.0'
 default['bcpc']['rally']['ssl_verify'] = false
 default['bcpc']['rally']['conf_dir'] = '/etc/rally'
 default['bcpc']['rally']['home_dir'] = '/var/lib/rally'

--- a/chef/cookbooks/bcpc/recipes/rally-deploy.rb
+++ b/chef/cookbooks/bcpc/recipes/rally-deploy.rb
@@ -25,6 +25,7 @@ config = data_bag_item(region, 'config')
 service = node['bcpc']['catalog']['identity']
 auth_url = generate_service_catalog_uri(service, 'public')
 home_dir = node['bcpc']['rally']['home_dir']
+tempest_version = node['bcpc']['rally']['tempest']['version']
 
 env = {
   'HOME' => home_dir,
@@ -79,7 +80,8 @@ execute 'create tempest verifier' do
   command <<-EOH
     rally verify create-verifier \
       --type tempest \
-      --name tempest
+      --name tempest \
+      --version #{tempest_version}
   EOH
   not_if 'rally verify show-verifier tempest'
 end


### PR DESCRIPTION
Install the specified version of tempest when creating a tempest
verifier via rally instead of just pulling from master. Version 30.0.0
is the last version to support python 3.6 and 3.7.

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See commit message

**Testing performed**
Internal Jenkins CI/CD pipeline now passes

**Additional context**
None
