### PR TITLE
Update python dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Create a Python virtual environment (virtualenv) and activate it
 python3 -mvenv venv
 source venv/bin/activate
 pip install 'pip>=19.1.1' wheel
-pip install PyYaml ansible netaddr pyOpenSSL pycryptodome
+pip install PyYaml ansible netaddr pyOpenSSL cryptography>=3.0
 ```
 
 To create a virtualbox build (the default):


### PR DESCRIPTION
We depend on `cryptography`, not `pycryptodome`

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
Update python dependencies of project README

**Testing performed**
Successfully ran our internal jenkins pipeline with said package installed.

**Additional context**
As of [486a99b313701c933d6ddd02739d8b713981ded8](https://github.com/bloomberg/chef-bcpc/commit/486a99b313701c933d6ddd02739d8b713981ded8), `generate-chef-databags.py` depends on `cryptography>=3.0`, not `pycryptodome`.
