### PR TITLE
Default to 9K MTU for transit networks on virtual builds

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -221,7 +221,7 @@ host_aggregates: []
 ###############################################################################
 
 networking:
-  mtu: 1500
+  mtu: 9000
 
 use_primary_transit_interface: true
 configure_service_ip: true

--- a/virtual/Vagrantfile.libvirt
+++ b/virtual/Vagrantfile.libvirt
@@ -114,6 +114,7 @@ Vagrant.configure('2') do |config|
             Util.libvirt_prefix() + t_iface['neighbor']['name']
           a[:libvirt__dhcp_enabled] = false
           a[:libvirt__forward_mode] = 'veryisolated'
+          a[:libvirt__mtu] = 9000
         end
         subconfig.vm.network('private_network', args)
       end

--- a/virtual/network/Vagrantfile.libvirt
+++ b/virtual/network/Vagrantfile.libvirt
@@ -62,7 +62,8 @@ def add_private_network(config, name, ipaddr)
                       libvirt__network: netmask,
                       libvirt__network_name: Util.libvirt_prefix() + name,
                       libvirt__dhcp_enabled: false,
-                      libvirt__forward_mode: 'veryisolated')
+                      libvirt__forward_mode: 'veryisolated',
+                      libvirt__mtu: 9000)
 end
 
 def configure_router_vm(config, name)

--- a/virtual/network/netplan/bcpc-pd1-sw1.yaml
+++ b/virtual/network/netplan/bcpc-pd1-sw1.yaml
@@ -8,9 +8,12 @@ network:
     eth1:
       addresses:
         - 172.16.0.0/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.2/31
+      mtu: 9000
     eth3:
       addresses:
         - 10.121.84.1/27
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pd1-sw2.yaml
+++ b/virtual/network/netplan/bcpc-pd1-sw2.yaml
@@ -8,9 +8,12 @@ network:
     eth1:
       addresses:
         - 172.16.0.4/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.6/31
+      mtu: 9000
     eth3:
       addresses:
         - 10.121.85.1/27
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pd1-sw3.yaml
+++ b/virtual/network/netplan/bcpc-pd1-sw3.yaml
@@ -8,9 +8,12 @@ network:
     eth1:
       addresses:
         - 172.16.0.8/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.10/31
+      mtu: 9000
     eth3:
       addresses:
         - 10.121.86.1/27
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pd2-sw1.yaml
+++ b/virtual/network/netplan/bcpc-pd2-sw1.yaml
@@ -8,9 +8,12 @@ network:
     eth1:
       addresses:
         - 172.16.0.32/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.34/31
+      mtu: 9000
     eth3:
       addresses:
         - 10.121.92.1/27
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pd2-sw2.yaml
+++ b/virtual/network/netplan/bcpc-pd2-sw2.yaml
@@ -8,9 +8,12 @@ network:
     eth1:
       addresses:
         - 172.16.0.36/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.38/31
+      mtu: 9000
     eth3:
       addresses:
         - 10.121.93.1/27
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pd2-sw3.yaml
+++ b/virtual/network/netplan/bcpc-pd2-sw3.yaml
@@ -8,9 +8,12 @@ network:
     eth1:
       addresses:
         - 172.16.0.40/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.42/31
+      mtu: 9000
     eth3:
       addresses:
         - 10.121.94.1/27
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pl1-sp1.yaml
+++ b/virtual/network/netplan/bcpc-pl1-sp1.yaml
@@ -8,15 +8,20 @@ network:
     eth1:
       addresses:
         - 172.16.0.1/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.5/31
+      mtu: 9000
     eth3:
       addresses:
         - 172.16.0.9/31
+      mtu: 9000
     eth4:
       addresses:
         - 172.16.0.64/31
+      mtu: 9000
     eth5:
       addresses:
         - 172.16.0.66/31
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pl1-sp2.yaml
+++ b/virtual/network/netplan/bcpc-pl1-sp2.yaml
@@ -8,15 +8,20 @@ network:
     eth1:
       addresses:
         - 172.16.0.33/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.37/31
+      mtu: 9000
     eth3:
       addresses:
         - 172.16.0.41/31
+      mtu: 9000
     eth4:
       addresses:
         - 172.16.0.68/31
+      mtu: 9000
     eth5:
       addresses:
         - 172.16.0.70/31
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pl1fs1.yaml
+++ b/virtual/network/netplan/bcpc-pl1fs1.yaml
@@ -8,6 +8,8 @@ network:
     eth1:
       addresses:
         - 172.16.0.65/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.69/31
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pl1fs2.yaml
+++ b/virtual/network/netplan/bcpc-pl1fs2.yaml
@@ -8,6 +8,8 @@ network:
     eth1:
       addresses:
         - 172.16.0.67/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.71/31
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pl2-sp1.yaml
+++ b/virtual/network/netplan/bcpc-pl2-sp1.yaml
@@ -8,15 +8,20 @@ network:
     eth1:
       addresses:
         - 172.16.0.3/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.7/31
+      mtu: 9000
     eth3:
       addresses:
         - 172.16.0.11/31
+      mtu: 9000
     eth4:
       addresses:
         - 172.16.0.72/31
+      mtu: 9000
     eth5:
       addresses:
         - 172.16.0.74/31
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pl2-sp2.yaml
+++ b/virtual/network/netplan/bcpc-pl2-sp2.yaml
@@ -8,15 +8,20 @@ network:
     eth1:
       addresses:
         - 172.16.0.35/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.39/31
+      mtu: 9000
     eth3:
       addresses:
         - 172.16.0.43/31
+      mtu: 9000
     eth4:
       addresses:
         - 172.16.0.76/31
+      mtu: 9000
     eth5:
       addresses:
         - 172.16.0.78/31
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pl2fs1.yaml
+++ b/virtual/network/netplan/bcpc-pl2fs1.yaml
@@ -8,6 +8,8 @@ network:
     eth1:
       addresses:
         - 172.16.0.73/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.77/31
+      mtu: 9000

--- a/virtual/network/netplan/bcpc-pl2fs2.yaml
+++ b/virtual/network/netplan/bcpc-pl2fs2.yaml
@@ -8,6 +8,8 @@ network:
     eth1:
       addresses:
         - 172.16.0.75/31
+      mtu: 9000
     eth2:
       addresses:
         - 172.16.0.79/31
+      mtu: 9000

--- a/virtual/network/netplan/network.yaml
+++ b/virtual/network/netplan/network.yaml
@@ -8,9 +8,12 @@ network:
     eth1:
       addresses:
         - 10.121.84.1/27
+      mtu: 9000
     eth2:
       addresses:
         - 10.121.85.1/27
+      mtu: 9000
     eth3:
       addresses:
         - 10.121.86.1/27
+      mtu: 9000


### PR DESCRIPTION
In order to test 9K MTU feasibility in a development
environment, we actually need to raise the MTU to 9K by
default.

Existing VMs can continue to operate at 1500 MTU so long
as the Neutron provider network is configured as such
(and it remains so by default).