### PR TITLE
neutron: Pick up MTU settings of the host

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -21,6 +21,8 @@ chef_environment:
         cmdline_linux:
           - net.ifnames=0
           - biosdevname=0
+      networking:
+        mtu: "{{ networking['mtu'] }}"
       nova:
         cpu_config:
           AuthenticAMD:

--- a/chef/cookbooks/bcpc/attributes/neutron.rb
+++ b/chef/cookbooks/bcpc/attributes/neutron.rb
@@ -4,6 +4,10 @@
 default['bcpc']['neutron']['debug'] = false
 default['bcpc']['neutron']['db']['dbname'] = 'neutron'
 
+# underlying network configuration
+default['bcpc']['neutron']['network']['default_network_mtu'] = 1500
+default['bcpc']['neutron']['network']['global_physnet_mtu'] = node['bcpc']['networking']['mtu']
+
 # neutron network nameservers
 # this list is used during the neutron subnet creation process to set the
 # dns-namserver for the instances

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -318,12 +318,14 @@ end
 # create networks starts
 node['bcpc']['neutron']['networks'].each do |network|
   fixed_network = network['name']
+  default_network_mtu = node['bcpc']['neutron']['network']['default_network_mtu']
 
   raise "#{fixed_network}: no subnets defined" unless network.key?('fixed')
 
   # build the create network command line options
   network_create_opts = [
     '--provider-network-type local',
+    "--mtu #{default_network_mtu}",
   ]
 
   # networks are shared by default unless explicitly set to false in the config
@@ -388,6 +390,7 @@ node['bcpc']['neutron']['networks'].each do |network|
       new_fn_output=$(openstack network create #{float_network} \
                         --external \
                         --format shell \
+			--mtu #{default_network_mtu} \
                         --prefix 'fn_')
 
       # evaluate the shell output so we can access the values

--- a/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
@@ -15,6 +15,7 @@ rpc_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 rpc_state_report_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% end %>
 dns_domain = <%= node['bcpc']['cloud']['domain'] %>
+global_physnet_mtu = <%= node['bcpc']['neutron']['network']['global_physnet_mtu'] %>
 
 [agent]
 root_helper = sudo /usr/bin/neutron-rootwrap /etc/neutron/rootwrap.conf


### PR DESCRIPTION
Currently, Ansible configures the MTU of the transit links
via the networking['mtu'] variable.

Neutron has a similar-ish configuration tunable for this,
which is `global_physnet_mtu` (default 1500, the standard
for ethernet networks).

The implication of this variable is that one cannot set the
MTU of an OpenStack network more than `global_physnet_mtu`.
And, moreover, all networks created inherent this MTU by
default.

Add plumbing to BCPC such that such that we set the Neutron
tunable to the same value that Ansible configures the host
with. Also add a Chef attribute that retains a 1500 MTU for
newly created networks so that we do not change the default
yet, and allow operators to create networks by default with
a 'standard' MTU even when the host supports jumbo frames.