### PR TITLE
Add serial console to default command line

### DIFF
--- a/virtual/packer/packer_box_provision.sh
+++ b/virtual/packer/packer_box_provision.sh
@@ -80,9 +80,9 @@ function configure_linux_kernel {
             "linux-tools-${kernel_version}"
     fi
 
-    # Disable IPv6
+    # Add serial console and disable IPv6
     eval "$(grep ^GRUB_CMDLINE_LINUX= /etc/default/grub)"
-    NEW_CMDLINE="${GRUB_CMDLINE_LINUX} ipv6.disable=1"
+    NEW_CMDLINE="${GRUB_CMDLINE_LINUX} console=ttyS0,115200 ipv6.disable=1"
     sed -i.orig \
         "s/^[#]*GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=\"${NEW_CMDLINE}\"/" \
         /etc/default/grub


### PR DESCRIPTION
Most virtual environments are spun up off the base packer
image and then never rebooted - even though this option can
be specified in the Chef environment, it is not necessarily
leveraged in such cases.

At the same time, having the serial console aids developers
in troubleshooting virtual builds when the network is
problematic -- so add it as part of the packer build
scripts.