### PR TITLE
Add feature to aid `ceph-mon` migration

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -113,3 +113,10 @@ default['bcpc']['ceph']['osd']['enabled'] = true
 # https://tracker.ceph.com/issues/50778
 # Mons may become unstable when the progress module is enabled.
 default['bcpc']['ceph']['module']['progress']['enabled'] = false
+
+# ceph mon migration configuration
+
+# If enabled, any monitor addresses for RBD volumes (Cinder attachments,
+# Nova block device mappings, etc.) will be sourced from this list.
+default['bcpc']['ceph']['mon-migration']['enabled'] = false
+default['bcpc']['ceph']['mon-migration']['hosts'] = []

--- a/chef/cookbooks/bcpc/files/default/cinder/rbd.py
+++ b/chef/cookbooks/bcpc/files/default/cinder/rbd.py
@@ -511,9 +511,9 @@ class RBDDriver(driver.CloneableImageVD, driver.MigrateVD,
             host, port = host_port.rsplit(':', 1)
             hosts.append(host.strip('[]'))
             ports.append(port)
-        # Overwrite the mon addrs using those in ceph.conf, not the monmap
+        # Overwrite the mon addrs using those in migration.conf, not the monmap
         try:
-            with open('/etc/ceph/ceph.conf', 'r') as config_file:
+            with open('/etc/ceph/migration.conf', 'r') as config_file:
                 config = ConfigParser()
                 config.read_file(config_file)
                 mon_host = config['global']['mon host']

--- a/chef/cookbooks/bcpc/files/default/cinder/rbd.py
+++ b/chef/cookbooks/bcpc/files/default/cinder/rbd.py
@@ -1,0 +1,2103 @@
+#    Copyright 2013 OpenStack Foundation
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""RADOS Block Device Driver"""
+
+import binascii
+from configparser import ConfigParser
+import errno
+from ipaddress import AddressValueError, IPv4Address
+import json
+import math
+import os
+import tempfile
+
+from castellan import key_manager
+from eventlet import tpool
+from os_brick.initiator import linuxrbd
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_service import loopingcall
+from oslo_utils import encodeutils
+from oslo_utils import excutils
+from oslo_utils import fileutils
+from oslo_utils import units
+try:
+    import rados
+    import rbd
+except ImportError:
+    rados = None
+    rbd = None
+import six
+from six.moves import urllib
+
+from cinder import exception
+from cinder.i18n import _
+from cinder.image import image_utils
+from cinder import interface
+from cinder import objects
+from cinder.objects import fields
+from cinder import utils
+from cinder.volume import configuration
+from cinder.volume import driver
+from cinder.volume import volume_utils
+
+LOG = logging.getLogger(__name__)
+
+RBD_OPTS = [
+    cfg.StrOpt('rbd_cluster_name',
+               default='ceph',
+               help='The name of ceph cluster'),
+    cfg.StrOpt('rbd_pool',
+               default='rbd',
+               help='The RADOS pool where rbd volumes are stored'),
+    cfg.StrOpt('rbd_user',
+               help='The RADOS client name for accessing rbd volumes '
+                    '- only set when using cephx authentication'),
+    cfg.StrOpt('rbd_ceph_conf',
+               default='',  # default determined by librados
+               help='Path to the ceph configuration file'),
+    cfg.StrOpt('rbd_keyring_conf',
+               deprecated_for_removal=True,
+               deprecated_reason='Use of this option exposes a security '
+                                 'vulnerability.  See OSSN-0085 for details.',
+               deprecated_since='Ussuri',
+               default='',
+               help='Path to the ceph keyring file'),
+    cfg.BoolOpt('rbd_flatten_volume_from_snapshot',
+                default=False,
+                help='Flatten volumes created from snapshots to remove '
+                     'dependency from volume to snapshot'),
+    cfg.StrOpt('rbd_secret_uuid',
+               help='The libvirt uuid of the secret for the rbd_user '
+                    'volumes'),
+    cfg.IntOpt('rbd_max_clone_depth',
+               default=5,
+               help='Maximum number of nested volume clones that are '
+                    'taken before a flatten occurs. Set to 0 to disable '
+                    'cloning. Note: lowering this value will not affect '
+                    'existing volumes whose clone depth exceeds the new '
+                    'value.'),
+    cfg.IntOpt('rbd_store_chunk_size', default=4,
+               help='Volumes will be chunked into objects of this size '
+                    '(in megabytes).'),
+    cfg.IntOpt('rados_connect_timeout', default=-1,
+               help='Timeout value (in seconds) used when connecting to '
+                    'ceph cluster. If value < 0, no timeout is set and '
+                    'default librados value is used.'),
+    cfg.IntOpt('rados_connection_retries', default=3,
+               help='Number of retries if connection to ceph cluster '
+                    'failed.'),
+    cfg.IntOpt('rados_connection_interval', default=5,
+               help='Interval value (in seconds) between connection '
+                    'retries to ceph cluster.'),
+    cfg.IntOpt('replication_connect_timeout', default=5,
+               help='Timeout value (in seconds) used when connecting to '
+                    'ceph cluster to do a demotion/promotion of volumes. '
+                    'If value < 0, no timeout is set and default librados '
+                    'value is used.'),
+    cfg.BoolOpt('report_dynamic_total_capacity', default=True,
+                help='Set to True for driver to report total capacity as a '
+                     'dynamic value (used + current free) and to False to '
+                     'report a static value (quota max bytes if defined and '
+                     'global size of cluster if not).'),
+    cfg.BoolOpt('rbd_exclusive_cinder_pool', default=False,
+                help="Set to True if the pool is used exclusively by Cinder. "
+                     "On exclusive use driver won't query images' provisioned "
+                     "size as they will match the value calculated by the "
+                     "Cinder core code for allocated_capacity_gb. This "
+                     "reduces the load on the Ceph cluster as well as on the "
+                     "volume service."),
+    cfg.BoolOpt('enable_deferred_deletion', default=False,
+                help='Enable deferred deletion. Upon deletion, volumes are '
+                     'tagged for deletion but will only be removed '
+                     'asynchronously at a later time.'),
+    cfg.IntOpt('deferred_deletion_delay', default=0,
+               help='Time delay in seconds before a volume is eligible '
+                    'for permanent removal after being tagged for deferred '
+                    'deletion.'),
+    cfg.IntOpt('deferred_deletion_purge_interval', default=60,
+               help='Number of seconds between runs of the periodic task '
+                    'to purge volumes tagged for deletion.'),
+]
+
+CONF = cfg.CONF
+CONF.register_opts(RBD_OPTS, group=configuration.SHARED_CONF_GROUP)
+
+EXTRA_SPECS_REPL_ENABLED = "replication_enabled"
+EXTRA_SPECS_MULTIATTACH = "multiattach"
+
+
+# RBD
+class RBDDriverException(exception.VolumeDriverException):
+    message = _("RBD Cinder driver failure: %(reason)s")
+
+
+class RBDVolumeProxy(object):
+    """Context manager for dealing with an existing rbd volume.
+
+    This handles connecting to rados and opening an ioctx automatically, and
+    otherwise acts like a librbd Image object.
+
+    Also this may reuse an external connection (client and ioctx args), but
+    note, that caller will be responsible for opening/closing connection.
+    Also `pool`, `remote`, `timeout` args will be ignored in that case.
+
+    The underlying librados client and ioctx can be accessed as the attributes
+    'client' and 'ioctx'.
+    """
+    def __init__(self, driver, name, pool=None, snapshot=None,
+                 read_only=False, remote=None, timeout=None,
+                 client=None, ioctx=None):
+        self._close_conn = not (client and ioctx)
+        rados_client, rados_ioctx = driver._connect_to_rados(
+            pool, remote, timeout) if self._close_conn else (client, ioctx)
+
+        if snapshot is not None:
+            snapshot = utils.convert_str(snapshot)
+        try:
+            self.volume = driver.rbd.Image(rados_ioctx,
+                                           utils.convert_str(name),
+                                           snapshot=snapshot,
+                                           read_only=read_only)
+            self.volume = tpool.Proxy(self.volume)
+        except driver.rbd.Error:
+            if self._close_conn:
+                driver._disconnect_from_rados(rados_client, rados_ioctx)
+            raise
+        self.driver = driver
+        self.client = rados_client
+        self.ioctx = rados_ioctx
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        try:
+            self.volume.close()
+        finally:
+            if self._close_conn:
+                self.driver._disconnect_from_rados(self.client, self.ioctx)
+
+    def __getattr__(self, attrib):
+        return getattr(self.volume, attrib)
+
+
+class RADOSClient(object):
+    """Context manager to simplify error handling for connecting to ceph."""
+    def __init__(self, driver, pool=None):
+        self.driver = driver
+        self.cluster, self.ioctx = driver._connect_to_rados(pool)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        self.driver._disconnect_from_rados(self.cluster, self.ioctx)
+
+    @property
+    def features(self):
+        features = self.cluster.conf_get('rbd_default_features')
+        if ((features is None) or (int(features) == 0)):
+            features = self.driver.RBD_FEATURE_LAYERING
+        return int(features)
+
+
+@interface.volumedriver
+class RBDDriver(driver.CloneableImageVD, driver.MigrateVD,
+                driver.ManageableVD, driver.ManageableSnapshotsVD,
+                driver.BaseVD):
+    """Implements RADOS block device (RBD) volume commands."""
+
+    VERSION = '1.2.0'
+
+    # ThirdPartySystems wiki page
+    CI_WIKI_NAME = "Cinder_Jenkins"
+
+    SUPPORTS_ACTIVE_ACTIVE = True
+
+    SYSCONFDIR = '/etc/ceph/'
+
+    RBD_FEATURE_LAYERING = 1
+    RBD_FEATURE_EXCLUSIVE_LOCK = 4
+    RBD_FEATURE_OBJECT_MAP = 8
+    RBD_FEATURE_FAST_DIFF = 16
+    RBD_FEATURE_JOURNALING = 64
+
+    def __init__(self, active_backend_id=None, *args, **kwargs):
+        super(RBDDriver, self).__init__(*args, **kwargs)
+        self.configuration.append_config_values(RBD_OPTS)
+        self._stats = {}
+        # allow overrides for testing
+        self.rados = kwargs.get('rados', rados)
+        self.rbd = kwargs.get('rbd', rbd)
+
+        # All string args used with librbd must be None or utf-8 otherwise
+        # librbd will break.
+        for attr in ['rbd_cluster_name', 'rbd_user',
+                     'rbd_ceph_conf', 'rbd_pool']:
+            val = getattr(self.configuration, attr)
+            if val is not None:
+                setattr(self.configuration, attr, utils.convert_str(val))
+
+        self._backend_name = (self.configuration.volume_backend_name or
+                              self.__class__.__name__)
+        self._active_backend_id = active_backend_id
+        self._active_config = {}
+        self._is_replication_enabled = False
+        self._replication_targets = []
+        self._target_names = []
+        self._clone_v2_api_checked = False
+
+        if self.rbd is not None:
+            self.RBD_FEATURE_LAYERING = self.rbd.RBD_FEATURE_LAYERING
+            self.RBD_FEATURE_EXCLUSIVE_LOCK = \
+                self.rbd.RBD_FEATURE_EXCLUSIVE_LOCK
+            self.RBD_FEATURE_OBJECT_MAP = self.rbd.RBD_FEATURE_OBJECT_MAP
+            self.RBD_FEATURE_FAST_DIFF = self.rbd.RBD_FEATURE_FAST_DIFF
+            self.RBD_FEATURE_JOURNALING = self.rbd.RBD_FEATURE_JOURNALING
+
+        self.MULTIATTACH_EXCLUSIONS = (
+            self.RBD_FEATURE_JOURNALING |
+            self.RBD_FEATURE_FAST_DIFF |
+            self.RBD_FEATURE_OBJECT_MAP |
+            self.RBD_FEATURE_EXCLUSIVE_LOCK)
+
+    @classmethod
+    def get_driver_options(cls):
+        additional_opts = cls._get_oslo_driver_opts(
+            'replication_device', 'reserved_percentage',
+            'max_over_subscription_ratio', 'volume_dd_blocksize')
+        return RBD_OPTS + additional_opts
+
+    def _show_msg_check_clone_v2_api(self, volume_name):
+        if not self._clone_v2_api_checked:
+            self._clone_v2_api_checked = True
+            with RBDVolumeProxy(self, volume_name, read_only=True) as volume:
+                try:
+                    if (volume.volume.op_features() &
+                            self.rbd.RBD_OPERATION_FEATURE_CLONE_PARENT):
+                        LOG.info('Using v2 Clone API')
+                        return
+                except AttributeError:
+                    pass
+                LOG.warning('Not using v2 clone API, please upgrade to'
+                            ' mimic+ and set the OSD minimum client'
+                            ' compat version to mimic for better'
+                            ' performance, fewer deletion issues')
+
+    def _get_target_config(self, target_id):
+        """Get a replication target from known replication targets."""
+        for target in self._replication_targets:
+            if target['name'] == target_id:
+                return target
+        if not target_id or target_id == 'default':
+            return {
+                'name': self.configuration.rbd_cluster_name,
+                'conf': self.configuration.rbd_ceph_conf,
+                'user': self.configuration.rbd_user,
+                'secret_uuid': self.configuration.rbd_secret_uuid
+            }
+        raise exception.InvalidReplicationTarget(
+            reason=_('RBD: Unknown failover target host %s.') % target_id)
+
+    def do_setup(self, context):
+        """Performs initialization steps that could raise exceptions."""
+        self._do_setup_replication()
+        self._active_config = self._get_target_config(self._active_backend_id)
+
+    def _do_setup_replication(self):
+        replication_devices = self.configuration.safe_get(
+            'replication_device')
+        if replication_devices:
+            self._parse_replication_configs(replication_devices)
+            self._is_replication_enabled = True
+            self._target_names.append('default')
+
+    def _parse_replication_configs(self, replication_devices):
+        for replication_device in replication_devices:
+            if 'backend_id' not in replication_device:
+                msg = _('Missing backend_id in replication_device '
+                        'configuration.')
+                raise exception.InvalidConfigurationValue(msg)
+
+            name = replication_device['backend_id']
+            conf = replication_device.get('conf',
+                                          self.SYSCONFDIR + name + '.conf')
+            user = replication_device.get(
+                'user', self.configuration.rbd_user or 'cinder')
+            secret_uuid = replication_device.get(
+                'secret_uuid', self.configuration.rbd_secret_uuid)
+            # Pool has to be the same in all clusters
+            replication_target = {'name': name,
+                                  'conf': utils.convert_str(conf),
+                                  'user': utils.convert_str(user),
+                                  'secret_uuid': secret_uuid}
+            LOG.info('Adding replication target: %s.', name)
+            self._replication_targets.append(replication_target)
+            self._target_names.append(name)
+
+    def _get_config_tuple(self, remote=None):
+        if not remote:
+            remote = self._active_config
+        return (remote.get('name'), remote.get('conf'), remote.get('user'),
+                remote.get('secret_uuid', None))
+
+    def _trash_purge(self):
+        LOG.info("Purging trash for backend '%s'", self._backend_name)
+        with RADOSClient(self) as client:
+            for vol in self.RBDProxy().trash_list(client.ioctx):
+                try:
+                    self.RBDProxy().trash_remove(client.ioctx, vol.get('id'))
+                    LOG.info("Deleted %s from trash for backend '%s'",
+                             vol.get('name'),
+                             self._backend_name)
+                except Exception as e:
+                    # NOTE(arne_wiebalck): trash_remove raises EPERM in case
+                    # the volume's deferral time has not expired yet, so we
+                    # want to explicitly handle this "normal" situation.
+                    # All other exceptions, e.g. ImageBusy, are not re-raised
+                    # so that the periodic purge retries on the next iteration
+                    # and leaves ERRORs in the logs in case the deletion fails
+                    # repeatedly.
+                    if e.errno == errno.EPERM:
+                        LOG.debug("%s has not expired yet on backend '%s'",
+                                  vol.get('name'),
+                                  self._backend_name)
+                    else:
+                        LOG.exception("Error deleting %s from trash "
+                                      "backend '%s'",
+                                      vol.get('name'),
+                                      self._backend_name)
+
+    def _start_periodic_tasks(self):
+        if self.configuration.enable_deferred_deletion:
+            LOG.info("Starting periodic trash purge for backend '%s'",
+                     self._backend_name)
+            deferred_deletion_ptask = loopingcall.FixedIntervalLoopingCall(
+                self._trash_purge)
+            deferred_deletion_ptask.start(
+                interval=self.configuration.deferred_deletion_purge_interval)
+
+    def check_for_setup_error(self):
+        """Returns an error if prerequisites aren't met."""
+        if rados is None:
+            msg = _('rados and rbd python libraries not found')
+            raise exception.VolumeBackendAPIException(data=msg)
+
+        for attr in ['rbd_cluster_name', 'rbd_pool']:
+            val = getattr(self.configuration, attr)
+            if not val:
+                raise exception.InvalidConfigurationValue(option=attr,
+                                                          value=val)
+        # NOTE: Checking connection to ceph
+        # RADOSClient __init__ method invokes _connect_to_rados
+        # so no need to check for self.rados.Error here.
+        with RADOSClient(self):
+            pass
+
+        # NOTE(arne_wiebalck): If deferred deletion is enabled, check if the
+        # local Ceph client has support for the trash API.
+        if self.configuration.enable_deferred_deletion:
+            if not hasattr(self.RBDProxy(), 'trash_list'):
+                msg = _("Deferred deletion is enabled, but the local Ceph "
+                        "client has no support for the trash API. Support "
+                        "for this feature started with v12.2.0 Luminous.")
+                LOG.error(msg)
+                raise exception.VolumeBackendAPIException(data=msg)
+
+        self._start_periodic_tasks()
+
+    def RBDProxy(self):
+        return tpool.Proxy(self.rbd.RBD())
+
+    def _ceph_args(self):
+        args = []
+
+        name, conf, user, secret_uuid = self._get_config_tuple()
+
+        if user:
+            args.extend(['--id', user])
+        if name:
+            args.extend(['--cluster', name])
+        if conf:
+            args.extend(['--conf', conf])
+
+        return args
+
+    def _connect_to_rados(self, pool=None, remote=None, timeout=None):
+        @utils.retry(exception.VolumeBackendAPIException,
+                     self.configuration.rados_connection_interval,
+                     self.configuration.rados_connection_retries)
+        def _do_conn(pool, remote, timeout):
+            name, conf, user, secret_uuid = self._get_config_tuple(remote)
+
+            if pool is not None:
+                pool = utils.convert_str(pool)
+            else:
+                pool = self.configuration.rbd_pool
+
+            if timeout is None:
+                timeout = self.configuration.rados_connect_timeout
+
+            LOG.debug("connecting to %(user)s@%(name)s (conf=%(conf)s, "
+                      "timeout=%(timeout)s).",
+                      {'user': user, 'name': name, 'conf': conf,
+                       'timeout': timeout})
+
+            client = self.rados.Rados(rados_id=user,
+                                      clustername=name,
+                                      conffile=conf)
+
+            try:
+                if timeout >= 0:
+                    timeout = six.text_type(timeout)
+                    client.conf_set('rados_osd_op_timeout', timeout)
+                    client.conf_set('rados_mon_op_timeout', timeout)
+                    client.conf_set('client_mount_timeout', timeout)
+
+                client.connect()
+                ioctx = client.open_ioctx(pool)
+                return client, ioctx
+            except self.rados.Error:
+                msg = _("Error connecting to ceph cluster.")
+                LOG.exception(msg)
+                client.shutdown()
+                raise exception.VolumeBackendAPIException(data=msg)
+
+        return _do_conn(pool, remote, timeout)
+
+    def _disconnect_from_rados(self, client, ioctx):
+        # closing an ioctx cannot raise an exception
+        ioctx.close()
+        client.shutdown()
+
+    def _get_backup_snaps(self, rbd_image):
+        """Get list of any backup snapshots that exist on this volume.
+
+        There should only ever be one but accept all since they need to be
+        deleted before the volume can be.
+        """
+        # NOTE(dosaboy): we do the import here otherwise we get import conflict
+        # issues between the rbd driver and the ceph backup driver. These
+        # issues only seem to occur when NOT using them together and are
+        # triggered when the ceph backup driver imports the rbd volume driver.
+        from cinder.backup.drivers import ceph
+        return ceph.CephBackupDriver.get_backup_snaps(rbd_image)
+
+    def _get_mon_addrs(self):
+        args = ['ceph', 'mon', 'dump', '--format=json']
+        args.extend(self._ceph_args())
+        out, _ = self._execute(*args)
+        lines = out.split('\n')
+        if lines[0].startswith('dumped monmap epoch'):
+            lines = lines[1:]
+        monmap = json.loads('\n'.join(lines))
+        addrs = [mon['addr'] for mon in monmap['mons']]
+        hosts = []
+        ports = []
+        for addr in addrs:
+            host_port = addr[:addr.rindex('/')]
+            host, port = host_port.rsplit(':', 1)
+            hosts.append(host.strip('[]'))
+            ports.append(port)
+        # Overwrite the mon addrs using those in ceph.conf, not the monmap
+        try:
+            with open('/etc/ceph/ceph.conf', 'r') as config_file:
+                config = ConfigParser()
+                config.read_file(config_file)
+                mon_host = config['global']['mon host']
+                mons = [h.strip() for h in mon_host.split(',')]
+                validated_mons = [IPv4Address(host) for host in mons]
+                hosts = mons
+        except (FileNotFoundError, KeyError, ValueError) as exception:
+            LOG.error('ceph-mon-migration: {0}'.format(str(exception)))
+        return hosts, ports
+
+    def _get_usage_info(self):
+        """Calculate provisioned volume space in GiB.
+
+        Stats report should send provisioned size of volumes (snapshot must not
+        be included) and not the physical size of those volumes.
+
+        We must include all volumes, not only Cinder created volumes, because
+        Cinder created volumes are reported by the Cinder core code as
+        allocated_capacity_gb.
+        """
+        total_provisioned = 0
+        with RADOSClient(self) as client:
+            for t in self.RBDProxy().list(client.ioctx):
+                try:
+                    with RBDVolumeProxy(self, t, read_only=True,
+                                        client=client.cluster,
+                                        ioctx=client.ioctx) as v:
+                        size = v.size()
+                except (self.rbd.ImageNotFound, self.rbd.OSError):
+                    LOG.debug("Image %s is not found.", t)
+                else:
+                    total_provisioned += size
+
+        total_provisioned = math.ceil(float(total_provisioned) / units.Gi)
+        return total_provisioned
+
+    def _get_pool_stats(self):
+        """Gets pool free and total capacity in GiB.
+
+        Calculate free and total capacity of the pool based on the pool's
+        defined quota and pools stats.
+
+        Returns a tuple with (free, total) where they are either unknown or a
+        real number with a 2 digit precision.
+        """
+        pool_name = self.configuration.rbd_pool
+
+        with RADOSClient(self) as client:
+            ret, df_outbuf, __ = client.cluster.mon_command(
+                '{"prefix":"df", "format":"json"}', b'')
+            if ret:
+                LOG.warning('Unable to get rados pool stats.')
+                return 'unknown', 'unknown'
+
+            ret, quota_outbuf, __ = client.cluster.mon_command(
+                '{"prefix":"osd pool get-quota", "pool": "%s",'
+                ' "format":"json"}' % pool_name, b'')
+            if ret:
+                LOG.warning('Unable to get rados pool quotas.')
+                return 'unknown', 'unknown'
+
+        df_outbuf = encodeutils.safe_decode(df_outbuf)
+        df_data = json.loads(df_outbuf)
+        pool_stats = [pool for pool in df_data['pools']
+                      if pool['name'] == pool_name][0]['stats']
+
+        quota_outbuf = encodeutils.safe_decode(quota_outbuf)
+        bytes_quota = json.loads(quota_outbuf)['quota_max_bytes']
+        # With quota the total is the quota limit and free is quota - used
+        if bytes_quota:
+            total_capacity = bytes_quota
+            free_capacity = max(min(total_capacity - pool_stats['bytes_used'],
+                                    pool_stats['max_avail']),
+                                0)
+        # Without quota free is pools max available and total is global size
+        else:
+            total_capacity = df_data['stats']['total_bytes']
+            free_capacity = pool_stats['max_avail']
+
+        # If we want dynamic total capacity (default behavior)
+        if self.configuration.safe_get('report_dynamic_total_capacity'):
+            total_capacity = free_capacity + pool_stats['bytes_used']
+
+        free_capacity = round((float(free_capacity) / units.Gi), 2)
+        total_capacity = round((float(total_capacity) / units.Gi), 2)
+
+        return free_capacity, total_capacity
+
+    def _update_volume_stats(self):
+        location_info = '%s:%s:%s:%s:%s' % (
+            self.configuration.rbd_cluster_name,
+            self.configuration.rbd_ceph_conf,
+            self._get_fsid(),
+            self.configuration.rbd_user,
+            self.configuration.rbd_pool)
+
+        stats = {
+            'vendor_name': 'Open Source',
+            'driver_version': self.VERSION,
+            'storage_protocol': 'ceph',
+            'total_capacity_gb': 'unknown',
+            'free_capacity_gb': 'unknown',
+            'reserved_percentage': (
+                self.configuration.safe_get('reserved_percentage')),
+            'multiattach': True,
+            'thin_provisioning_support': True,
+            'max_over_subscription_ratio': (
+                self.configuration.safe_get('max_over_subscription_ratio')),
+            'location_info': location_info,
+            'backend_state': 'down'
+        }
+
+        backend_name = self.configuration.safe_get('volume_backend_name')
+        stats['volume_backend_name'] = backend_name or 'RBD'
+
+        stats['replication_enabled'] = self._is_replication_enabled
+        if self._is_replication_enabled:
+            stats['replication_targets'] = self._target_names
+
+        try:
+            free_capacity, total_capacity = self._get_pool_stats()
+            stats['free_capacity_gb'] = free_capacity
+            stats['total_capacity_gb'] = total_capacity
+
+            # For exclusive pools let scheduler set provisioned_capacity_gb to
+            # allocated_capacity_gb, and for non exclusive query the value.
+            if not self.configuration.safe_get('rbd_exclusive_cinder_pool'):
+                total_gbi = self._get_usage_info()
+                stats['provisioned_capacity_gb'] = total_gbi
+
+            stats['backend_state'] = 'up'
+        except self.rados.Error:
+            # just log and return unknown capacities and let scheduler set
+            # provisioned_capacity_gb = allocated_capacity_gb
+            LOG.exception('error refreshing volume stats')
+        self._stats = stats
+
+    def get_volume_stats(self, refresh=False):
+        """Return the current state of the volume service.
+
+        If 'refresh' is True, run the update first.
+        """
+        if refresh:
+            self._update_volume_stats()
+        return self._stats
+
+    def _get_clone_depth(self, client, volume_name, depth=0):
+        """Returns the number of ancestral clones of the given volume."""
+        parent_volume = self.rbd.Image(client.ioctx,
+                                       volume_name,
+                                       read_only=True)
+        try:
+            _pool, parent, _snap = self._get_clone_info(parent_volume,
+                                                        volume_name)
+        finally:
+            parent_volume.close()
+
+        if not parent:
+            return depth
+
+        return self._get_clone_depth(client, parent, depth + 1)
+
+    def _extend_if_required(self, volume, src_vref):
+        """Extends a volume if required
+
+        In case src_vref size is smaller than the size if the requested
+        new volume call _resize().
+        """
+        if volume.size != src_vref.size:
+            LOG.debug("resize volume '%(dst_vol)s' from %(src_size)d to "
+                      "%(dst_size)d",
+                      {'dst_vol': volume.name, 'src_size': src_vref.size,
+                       'dst_size': volume.size})
+            self._resize(volume)
+
+    def create_cloned_volume(self, volume, src_vref):
+        """Create a cloned volume from another volume.
+
+        Since we are cloning from a volume and not a snapshot, we must first
+        create a snapshot of the source volume.
+
+        The user has the option to limit how long a volume's clone chain can be
+        by setting rbd_max_clone_depth. If a clone is made of another clone
+        and that clone has rbd_max_clone_depth clones behind it, the dest
+        volume will be flattened.
+        """
+        src_name = utils.convert_str(src_vref.name)
+        dest_name = utils.convert_str(volume.name)
+        clone_snap = "%s.clone_snap" % dest_name
+
+        # Do full copy if requested
+        if self.configuration.rbd_max_clone_depth <= 0:
+            with RBDVolumeProxy(self, src_name, read_only=True) as vol:
+                vol.copy(vol.ioctx, dest_name)
+                self._extend_if_required(volume, src_vref)
+            return
+
+        # Otherwise do COW clone.
+        with RADOSClient(self) as client:
+            src_volume = self.rbd.Image(client.ioctx, src_name)
+            LOG.debug("creating snapshot='%s'", clone_snap)
+            try:
+                # Create new snapshot of source volume
+                src_volume.create_snap(clone_snap)
+                src_volume.protect_snap(clone_snap)
+                # Now clone source volume snapshot
+                LOG.debug("cloning '%(src_vol)s@%(src_snap)s' to "
+                          "'%(dest)s'",
+                          {'src_vol': src_name, 'src_snap': clone_snap,
+                           'dest': dest_name})
+                self.RBDProxy().clone(client.ioctx, src_name, clone_snap,
+                                      client.ioctx, dest_name,
+                                      features=client.features)
+            except Exception as e:
+                src_volume.unprotect_snap(clone_snap)
+                src_volume.remove_snap(clone_snap)
+                src_volume.close()
+                msg = (_("Failed to clone '%(src_vol)s@%(src_snap)s' to "
+                         "'%(dest)s', error: %(error)s") %
+                       {'src_vol': src_name,
+                        'src_snap': clone_snap,
+                        'dest': dest_name,
+                        'error': e})
+                LOG.exception(msg)
+                raise exception.VolumeBackendAPIException(data=msg)
+
+            depth = self._get_clone_depth(client, src_name)
+            # If dest volume is a clone and rbd_max_clone_depth reached,
+            # flatten the dest after cloning. Zero rbd_max_clone_depth means
+            # volumes are always flattened.
+            if depth >= self.configuration.rbd_max_clone_depth:
+                LOG.info("maximum clone depth (%d) has been reached - "
+                         "flattening dest volume",
+                         self.configuration.rbd_max_clone_depth)
+
+                # Flatten destination volume
+                try:
+                    with RBDVolumeProxy(self, dest_name, client=client,
+                                        ioctx=client.ioctx) as dest_volume:
+                        LOG.debug("flattening dest volume %s", dest_name)
+                        dest_volume.flatten()
+                except Exception as e:
+                    msg = (_("Failed to flatten volume %(volume)s with "
+                             "error: %(error)s.") %
+                           {'volume': dest_name,
+                            'error': e})
+                    LOG.exception(msg)
+                    src_volume.close()
+                    raise exception.VolumeBackendAPIException(data=msg)
+
+                try:
+                    # remove temporary snap
+                    LOG.debug("remove temporary snap %s", clone_snap)
+                    src_volume.unprotect_snap(clone_snap)
+                    src_volume.remove_snap(clone_snap)
+                except Exception as e:
+                    msg = (_("Failed to remove temporary snap "
+                             "%(snap_name)s, error: %(error)s") %
+                           {'snap_name': clone_snap,
+                            'error': e})
+                    LOG.exception(msg)
+                    src_volume.close()
+                    raise exception.VolumeBackendAPIException(data=msg)
+
+            try:
+                volume_update = self._setup_volume(volume)
+            except Exception:
+                self.RBDProxy().remove(client.ioctx, dest_name)
+                src_volume.unprotect_snap(clone_snap)
+                src_volume.remove_snap(clone_snap)
+                err_msg = (_('Failed to enable image replication'))
+                raise exception.ReplicationError(reason=err_msg,
+                                                 volume_id=volume.id)
+            finally:
+                src_volume.close()
+
+            self._extend_if_required(volume, src_vref)
+
+        LOG.debug("clone created successfully")
+        return volume_update
+
+    def _enable_replication(self, volume):
+        """Enable replication for a volume.
+
+        Returns required volume update.
+        """
+        vol_name = utils.convert_str(volume.name)
+        with RBDVolumeProxy(self, vol_name) as image:
+            had_exclusive_lock = (image.features() &
+                                  self.RBD_FEATURE_EXCLUSIVE_LOCK)
+            had_journaling = image.features() & self.RBD_FEATURE_JOURNALING
+            if not had_exclusive_lock:
+                image.update_features(self.RBD_FEATURE_EXCLUSIVE_LOCK,
+                                      True)
+            if not had_journaling:
+                image.update_features(self.RBD_FEATURE_JOURNALING, True)
+            image.mirror_image_enable()
+
+        driver_data = self._dumps({
+            'had_journaling': bool(had_journaling),
+            'had_exclusive_lock': bool(had_exclusive_lock)
+        })
+        return {'replication_status': fields.ReplicationStatus.ENABLED,
+                'replication_driver_data': driver_data}
+
+    def _enable_multiattach(self, volume):
+        vol_name = utils.convert_str(volume.name)
+        with RBDVolumeProxy(self, vol_name) as image:
+            image_features = image.features()
+            change_features = self.MULTIATTACH_EXCLUSIONS & image_features
+            image.update_features(change_features, False)
+
+        return {'provider_location':
+                self._dumps({'saved_features': image_features})}
+
+    def _disable_multiattach(self, volume):
+        vol_name = utils.convert_str(volume.name)
+        with RBDVolumeProxy(self, vol_name) as image:
+            try:
+                provider_location = json.loads(volume.provider_location)
+                image_features = provider_location['saved_features']
+                change_features = self.MULTIATTACH_EXCLUSIONS & image_features
+                image.update_features(change_features, True)
+            except IndexError:
+                msg = "Could not find saved image features."
+                raise RBDDriverException(reason=msg)
+            except self.rbd.InvalidArgument:
+                msg = "Failed to restore image features."
+                raise RBDDriverException(reason=msg)
+
+        return {'provider_location': None}
+
+    def _is_replicated_type(self, volume_type):
+        try:
+            extra_specs = volume_type.extra_specs
+            LOG.debug('extra_specs: %s', extra_specs)
+            return extra_specs.get(EXTRA_SPECS_REPL_ENABLED) == "<is> True"
+        except Exception:
+            LOG.debug('Unable to retrieve extra specs info')
+            return False
+
+    def _is_multiattach_type(self, volume_type):
+        try:
+            extra_specs = volume_type.extra_specs
+            LOG.debug('extra_specs: %s', extra_specs)
+            return extra_specs.get(EXTRA_SPECS_MULTIATTACH) == "<is> True"
+        except Exception:
+            LOG.debug('Unable to retrieve extra specs info')
+            return False
+
+    def _setup_volume(self, volume, volume_type=None):
+
+        if volume_type:
+            had_replication = self._is_replicated_type(volume.volume_type)
+            had_multiattach = self._is_multiattach_type(volume.volume_type)
+        else:
+            had_replication = False
+            had_multiattach = False
+            volume_type = volume.volume_type
+
+        want_replication = self._is_replicated_type(volume_type)
+        want_multiattach = self._is_multiattach_type(volume_type)
+
+        if want_replication and want_multiattach:
+            msg = _('Replication and Multiattach are mutually exclusive.')
+            raise RBDDriverException(reason=msg)
+
+        volume_update = dict()
+
+        if want_replication:
+            if had_multiattach:
+                volume_update.update(self._disable_multiattach(volume))
+            if not had_replication:
+                try:
+                    volume_update.update(self._enable_replication(volume))
+                except Exception:
+                    err_msg = (_('Failed to enable image replication'))
+                    raise exception.ReplicationError(reason=err_msg,
+                                                     volume_id=volume.id)
+        elif had_replication:
+            try:
+                volume_update.update(self._disable_replication(volume))
+            except Exception:
+                err_msg = (_('Failed to disable image replication'))
+                raise exception.ReplicationError(reason=err_msg,
+                                                 volume_id=volume.id)
+        elif self._is_replication_enabled:
+            volume_update.update({'replication_status':
+                                  fields.ReplicationStatus.DISABLED})
+
+        if want_multiattach:
+            volume_update.update(self._enable_multiattach(volume))
+        elif had_multiattach:
+            volume_update.update(self._disable_multiattach(volume))
+
+        return volume_update
+
+    def _create_encrypted_volume(self, volume, context):
+        """Create an encrypted volume.
+
+        This works by creating an encrypted image locally,
+        and then uploading it to the volume.
+        """
+
+        encryption = volume_utils.check_encryption_provider(self.db,
+                                                            volume,
+                                                            context)
+
+        # Fetch the key associated with the volume and decode the passphrase
+        keymgr = key_manager.API(CONF)
+        key = keymgr.get(context, encryption['encryption_key_id'])
+        passphrase = binascii.hexlify(key.get_encoded()).decode('utf-8')
+
+        # create a file
+        tmp_dir = volume_utils.image_conversion_dir()
+
+        with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp_image:
+            with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp_key:
+                with open(tmp_key.name, 'w') as f:
+                    f.write(passphrase)
+
+                cipher_spec = image_utils.decode_cipher(encryption['cipher'],
+                                                        encryption['key_size'])
+
+                create_cmd = (
+                    'qemu-img', 'create', '-f', 'luks',
+                    '-o', 'cipher-alg=%(cipher_alg)s,'
+                    'cipher-mode=%(cipher_mode)s,'
+                    'ivgen-alg=%(ivgen_alg)s' % cipher_spec,
+                    '--object', 'secret,id=luks_sec,'
+                    'format=raw,file=%(passfile)s' % {'passfile':
+                                                      tmp_key.name},
+                    '-o', 'key-secret=luks_sec',
+                    tmp_image.name,
+                    '%sM' % (volume.size * 1024))
+                self._execute(*create_cmd)
+
+            # Copy image into RBD
+            chunk_size = self.configuration.rbd_store_chunk_size * units.Mi
+            order = int(math.log(chunk_size, 2))
+
+            cmd = ['rbd', 'import',
+                   '--pool', self.configuration.rbd_pool,
+                   '--order', order,
+                   tmp_image.name, volume.name]
+            cmd.extend(self._ceph_args())
+            self._execute(*cmd)
+
+    def create_volume(self, volume):
+        """Creates a logical volume."""
+
+        if volume.encryption_key_id:
+            return self._create_encrypted_volume(volume, volume.obj_context)
+
+        size = int(volume.size) * units.Gi
+
+        LOG.debug("creating volume '%s'", volume.name)
+
+        chunk_size = self.configuration.rbd_store_chunk_size * units.Mi
+        order = int(math.log(chunk_size, 2))
+        vol_name = utils.convert_str(volume.name)
+
+        with RADOSClient(self) as client:
+            self.RBDProxy().create(client.ioctx,
+                                   vol_name,
+                                   size,
+                                   order,
+                                   old_format=False,
+                                   features=client.features)
+
+        try:
+            volume_update = self._setup_volume(volume)
+        except Exception:
+            with excutils.save_and_reraise_exception():
+                LOG.error('Error creating rbd image %(vol)s.',
+                          {'vol': vol_name})
+                self.RBDProxy().remove(client.ioctx, vol_name)
+
+        return volume_update
+
+    def _flatten(self, pool, volume_name):
+        LOG.debug('flattening %(pool)s/%(img)s',
+                  dict(pool=pool, img=volume_name))
+        with RBDVolumeProxy(self, volume_name, pool) as vol:
+            vol.flatten()
+
+    def _get_stripe_unit(self, ioctx, volume_name):
+        """Return the correct stripe unit for a cloned volume.
+
+        A cloned volume must be created with a stripe unit at least as large
+        as the source volume.  We compute the desired stripe width from
+        rbd_store_chunk_size and compare that to the incoming source volume's
+        stripe width, selecting the larger to avoid error.
+        """
+        default_stripe_unit = \
+            self.configuration.rbd_store_chunk_size * units.Mi
+
+        image = self.rbd.Image(ioctx, volume_name, read_only=True)
+        try:
+            image_stripe_unit = image.stripe_unit()
+        finally:
+            image.close()
+
+        return max(image_stripe_unit, default_stripe_unit)
+
+    def _clone(self, volume, src_pool, src_image, src_snap):
+        LOG.debug('cloning %(pool)s/%(img)s@%(snap)s to %(dst)s',
+                  dict(pool=src_pool, img=src_image, snap=src_snap,
+                       dst=volume.name))
+
+        vol_name = utils.convert_str(volume.name)
+
+        with RADOSClient(self, src_pool) as src_client:
+            stripe_unit = self._get_stripe_unit(src_client.ioctx, src_image)
+            order = int(math.log(stripe_unit, 2))
+            with RADOSClient(self) as dest_client:
+                self.RBDProxy().clone(src_client.ioctx,
+                                      utils.convert_str(src_image),
+                                      utils.convert_str(src_snap),
+                                      dest_client.ioctx,
+                                      vol_name,
+                                      features=src_client.features,
+                                      order=order)
+            try:
+                volume_update = self._setup_volume(volume)
+            except Exception:
+                self.RBDProxy().remove(dest_client.ioctx, vol_name)
+                err_msg = (_('Failed to enable image replication'))
+                raise exception.ReplicationError(reason=err_msg,
+                                                 volume_id=volume.id)
+            return volume_update or {}
+
+    def _resize(self, volume, **kwargs):
+        size = kwargs.get('size', None)
+        if not size:
+            size = int(volume.size) * units.Gi
+
+        with RBDVolumeProxy(self, volume.name) as vol:
+            vol.resize(size)
+
+    def create_volume_from_snapshot(self, volume, snapshot):
+        """Creates a volume from a snapshot."""
+        volume_update = self._clone(volume, self.configuration.rbd_pool,
+                                    snapshot.volume_name, snapshot.name)
+        if self.configuration.rbd_flatten_volume_from_snapshot:
+            self._flatten(self.configuration.rbd_pool, volume.name)
+        if int(volume.size):
+            self._resize(volume)
+
+        self._show_msg_check_clone_v2_api(snapshot.volume_name)
+        return volume_update
+
+    def _delete_backup_snaps(self, rbd_image):
+        backup_snaps = self._get_backup_snaps(rbd_image)
+        if backup_snaps:
+            for snap in backup_snaps:
+                rbd_image.remove_snap(snap['name'])
+        else:
+            LOG.debug("volume has no backup snaps")
+
+    def _get_clone_info(self, volume, volume_name, snap=None):
+        """If volume is a clone, return its parent info.
+
+        Returns a tuple of (pool, parent, snap). A snapshot may optionally be
+        provided for the case where a cloned volume has been flattened but it's
+        snapshot still depends on the parent.
+        """
+        try:
+            if snap:
+                volume.set_snap(snap)
+            pool, parent, parent_snap = tuple(volume.parent_info())
+            if snap:
+                volume.set_snap(None)
+            # Strip the tag off the end of the volume name since it will not be
+            # in the snap name.
+            if volume_name.endswith('.deleted'):
+                volume_name = volume_name[:-len('.deleted')]
+            # Now check the snap name matches.
+            if parent_snap == "%s.clone_snap" % volume_name:
+                return pool, parent, parent_snap
+        except self.rbd.ImageNotFound:
+            LOG.debug("Volume %s is not a clone.", volume_name)
+            volume.set_snap(None)
+
+        return (None, None, None)
+
+    def _get_children_info(self, volume, snap):
+        """List children for the given snapshot of a volume(image).
+
+        Returns a list of (pool, image).
+        """
+
+        children_list = []
+
+        if snap:
+            volume.set_snap(snap)
+            children_list = volume.list_children()
+            volume.set_snap(None)
+
+        return children_list
+
+    def _delete_clone_parent_refs(self, client, parent_name, parent_snap):
+        """Walk back up the clone chain and delete references.
+
+        Deletes references i.e. deleted parent volumes and snapshots.
+        """
+        parent_rbd = self.rbd.Image(client.ioctx, parent_name)
+        parent_has_snaps = False
+        try:
+            # Check for grandparent
+            _pool, g_parent, g_parent_snap = self._get_clone_info(parent_rbd,
+                                                                  parent_name,
+                                                                  parent_snap)
+
+            LOG.debug("deleting parent snapshot %s", parent_snap)
+            parent_rbd.unprotect_snap(parent_snap)
+            parent_rbd.remove_snap(parent_snap)
+
+            parent_has_snaps = bool(list(parent_rbd.list_snaps()))
+        finally:
+            parent_rbd.close()
+
+        # If parent has been deleted in Cinder, delete the silent reference and
+        # keep walking up the chain if it is itself a clone.
+        if (not parent_has_snaps) and parent_name.endswith('.deleted'):
+            LOG.debug("deleting parent %s", parent_name)
+            if self.configuration.enable_deferred_deletion:
+                LOG.debug("moving volume %s to trash", parent_name)
+                delay = self.configuration.deferred_deletion_delay
+                self.RBDProxy().trash_move(client.ioctx,
+                                           parent_name,
+                                           delay)
+            else:
+                self.RBDProxy().remove(client.ioctx, parent_name)
+
+            # Now move up to grandparent if there is one
+            if g_parent:
+                self._delete_clone_parent_refs(client, g_parent, g_parent_snap)
+
+    def delete_volume(self, volume):
+        """Deletes a logical volume."""
+        # NOTE(dosaboy): this was broken by commit cbe1d5f. Ensure names are
+        #                utf-8 otherwise librbd will barf.
+        volume_name = utils.convert_str(volume.name)
+        with RADOSClient(self) as client:
+            try:
+                rbd_image = self.rbd.Image(client.ioctx, volume_name)
+            except self.rbd.ImageNotFound:
+                LOG.info("volume %s no longer exists in backend",
+                         volume_name)
+                return
+
+            clone_snap = None
+            parent = None
+
+            # Ensure any backup snapshots are deleted
+            self._delete_backup_snaps(rbd_image)
+
+            # If the volume has non-clone snapshots this delete is expected to
+            # raise VolumeIsBusy so do so straight away.
+            try:
+                snaps = rbd_image.list_snaps()
+                for snap in snaps:
+                    if snap['name'].endswith('.clone_snap'):
+                        LOG.debug("volume has clone snapshot(s)")
+                        # We grab one of these and use it when fetching parent
+                        # info in case the volume has been flattened.
+                        clone_snap = snap['name']
+                        break
+
+                    raise exception.VolumeIsBusy(volume_name=volume_name)
+
+                # Determine if this volume is itself a clone
+                _pool, parent, parent_snap = self._get_clone_info(rbd_image,
+                                                                  volume_name,
+                                                                  clone_snap)
+            finally:
+                rbd_image.close()
+
+            @utils.retry(self.rbd.ImageBusy,
+                         self.configuration.rados_connection_interval,
+                         self.configuration.rados_connection_retries)
+            def _try_remove_volume(client, volume_name):
+                if self.configuration.enable_deferred_deletion:
+                    LOG.debug("moving volume %s to trash", volume_name)
+                    delay = self.configuration.deferred_deletion_delay
+                    self.RBDProxy().trash_move(client.ioctx,
+                                               volume_name,
+                                               delay)
+                else:
+                    self.RBDProxy().remove(client.ioctx, volume_name)
+
+            if clone_snap is None:
+                LOG.debug("deleting rbd volume %s", volume_name)
+                try:
+                    _try_remove_volume(client, volume_name)
+                except self.rbd.ImageBusy:
+                    msg = (_("ImageBusy error raised while deleting rbd "
+                             "volume. This may have been caused by a "
+                             "connection from a client that has crashed and, "
+                             "if so, may be resolved by retrying the delete "
+                             "after 30 seconds has elapsed."))
+                    LOG.warning(msg)
+                    # Now raise this so that the volume stays available and the
+                    # deletion can be retried.
+                    raise exception.VolumeIsBusy(msg, volume_name=volume_name)
+                except self.rbd.ImageNotFound:
+                    LOG.info("RBD volume %s not found, allowing delete "
+                             "operation to proceed.", volume_name)
+                    return
+
+                # If it is a clone, walk back up the parent chain deleting
+                # references.
+                if parent:
+                    LOG.debug("volume is a clone so cleaning references")
+                    self._delete_clone_parent_refs(client, parent, parent_snap)
+            else:
+                # If the volume has copy-on-write clones we will not be able to
+                # delete it. Instead we will keep it as a silent volume which
+                # will be deleted when it's snapshot and clones are deleted.
+                new_name = "%s.deleted" % (volume_name)
+                self.RBDProxy().rename(client.ioctx, volume_name, new_name)
+
+    def create_snapshot(self, snapshot):
+        """Creates an rbd snapshot."""
+        with RBDVolumeProxy(self, snapshot.volume_name) as volume:
+            snap = utils.convert_str(snapshot.name)
+            volume.create_snap(snap)
+            volume.protect_snap(snap)
+
+    def delete_snapshot(self, snapshot):
+        """Deletes an rbd snapshot."""
+        # NOTE(dosaboy): this was broken by commit cbe1d5f. Ensure names are
+        #                utf-8 otherwise librbd will barf.
+        volume_name = utils.convert_str(snapshot.volume_name)
+        snap_name = utils.convert_str(snapshot.name)
+
+        with RBDVolumeProxy(self, volume_name) as volume:
+            try:
+                volume.unprotect_snap(snap_name)
+            except self.rbd.InvalidArgument:
+                LOG.info(
+                    "InvalidArgument: Unable to unprotect snapshot %s.",
+                    snap_name)
+            except self.rbd.ImageNotFound:
+                LOG.info(
+                    "ImageNotFound: Unable to unprotect snapshot %s.",
+                    snap_name)
+            except self.rbd.ImageBusy:
+                children_list = self._get_children_info(volume, snap_name)
+
+                if children_list:
+                    for (pool, image) in children_list:
+                        LOG.info('Image %(pool)s/%(image)s is dependent '
+                                 'on the snapshot %(snap)s.',
+                                 {'pool': pool,
+                                  'image': image,
+                                  'snap': snap_name})
+
+                raise exception.SnapshotIsBusy(snapshot_name=snap_name)
+            try:
+                volume.remove_snap(snap_name)
+            except self.rbd.ImageNotFound:
+                LOG.info("Snapshot %s does not exist in backend.",
+                         snap_name)
+
+    def snapshot_revert_use_temp_snapshot(self):
+        """Disable the use of a temporary snapshot on revert."""
+        return False
+
+    def revert_to_snapshot(self, context, volume, snapshot):
+        """Revert a volume to a given snapshot."""
+        # NOTE(rosmaita): The Ceph documentation notes that this operation is
+        # inefficient on the backend for large volumes, and that the preferred
+        # method of returning to a pre-existing state in Ceph is to clone from
+        # a snapshot.
+        # So why don't we do something like that here?
+        # (a) an end user can do the more efficient operation on their own if
+        #     they value speed over the convenience of reverting their existing
+        #     volume
+        # (b) revert-to-snapshot is properly a backend operation, and should
+        #     be handled by the backend -- trying to "fake it" in this driver
+        #     is both dishonest and likely to cause subtle bugs
+        # (c) the Ceph project undergoes continual improvement.  It may be
+        #     the case that there are things an operator can do on the Ceph
+        #     side (for example, use BlueStore for the Ceph backend storage)
+        #     to improve the efficiency of this operation.
+        # Thus, a motivated operator reading this is encouraged to consult
+        # the Ceph documentation.
+        with RBDVolumeProxy(self, volume.name) as image:
+            image.rollback_to_snap(snapshot.name)
+
+    def _disable_replication(self, volume):
+        """Disable replication on the given volume."""
+        vol_name = utils.convert_str(volume.name)
+        with RBDVolumeProxy(self, vol_name) as image:
+            image.mirror_image_disable(False)
+            driver_data = json.loads(volume.replication_driver_data)
+            # If 'journaling' and/or 'exclusive-lock' have
+            # been enabled in '_enable_replication',
+            # they will be disabled here. If not, it will keep
+            # what it was before.
+            if not driver_data['had_journaling']:
+                image.update_features(self.RBD_FEATURE_JOURNALING, False)
+            if not driver_data['had_exclusive_lock']:
+                image.update_features(self.RBD_FEATURE_EXCLUSIVE_LOCK, False)
+        return {'replication_status': fields.ReplicationStatus.DISABLED,
+                'replication_driver_data': None}
+
+    def retype(self, context, volume, new_type, diff, host):
+        """Retype from one volume type to another on the same backend."""
+        return True, self._setup_volume(volume, new_type)
+
+    def _dumps(self, obj):
+        return json.dumps(obj, separators=(',', ':'), sort_keys=True)
+
+    def _exec_on_volume(self, volume_name, remote, operation, *args, **kwargs):
+        @utils.retry(rbd.ImageBusy,
+                     self.configuration.rados_connection_interval,
+                     self.configuration.rados_connection_retries)
+        def _do_exec():
+            timeout = self.configuration.replication_connect_timeout
+            with RBDVolumeProxy(self, volume_name, self.configuration.rbd_pool,
+                                remote=remote, timeout=timeout) as rbd_image:
+                return getattr(rbd_image, operation)(*args, **kwargs)
+        return _do_exec()
+
+    def _failover_volume(self, volume, remote, is_demoted, replication_status):
+        """Process failover for a volume.
+
+        There are 2 different cases that will return different update values
+        for the volume:
+
+        - Volume has replication enabled and failover succeeded: Set
+          replication status to failed-over.
+        - Volume has replication enabled and failover fails: Set status to
+          error, replication status to failover-error, and store previous
+          status in previous_status field.
+        """
+        # Failover is allowed when volume has it enabled or it has already
+        # failed over, because we may want to do a second failover.
+        vol_name = utils.convert_str(volume.name)
+        try:
+            self._exec_on_volume(vol_name, remote,
+                                 'mirror_image_promote', not is_demoted)
+
+            return {'volume_id': volume.id,
+                    'updates': {'replication_status': replication_status}}
+        except Exception as e:
+            replication_status = fields.ReplicationStatus.FAILOVER_ERROR
+            LOG.error('Failed to failover volume %(volume)s with '
+                      'error: %(error)s.',
+                      {'volume': volume.name, 'error': e})
+
+        # Failover failed
+        error_result = {
+            'volume_id': volume.id,
+            'updates': {
+                'status': 'error',
+                'previous_status': volume.status,
+                'replication_status': replication_status
+            }
+        }
+
+        return error_result
+
+    def _demote_volumes(self, volumes, until_failure=True):
+        """Try to demote volumes on the current primary cluster."""
+        result = []
+        try_demoting = True
+        for volume in volumes:
+            demoted = False
+            if try_demoting:
+                vol_name = utils.convert_str(volume.name)
+                try:
+                    self._exec_on_volume(vol_name, self._active_config,
+                                         'mirror_image_demote')
+                    demoted = True
+                except Exception as e:
+                    LOG.debug('Failed to demote %(volume)s with error: '
+                              '%(error)s.',
+                              {'volume': volume.name, 'error': e})
+                    try_demoting = not until_failure
+            result.append(demoted)
+        return result
+
+    def _get_failover_target_config(self, secondary_id=None):
+        if not secondary_id:
+            # In auto mode exclude failback and active
+            candidates = set(self._target_names).difference(
+                ('default', self._active_backend_id))
+            if not candidates:
+                raise exception.InvalidReplicationTarget(
+                    reason=_('RBD: No available failover target host.'))
+            secondary_id = candidates.pop()
+        return secondary_id, self._get_target_config(secondary_id)
+
+    def failover(self, context, volumes, secondary_id=None, groups=None):
+        """Failover replicated volumes."""
+        LOG.info('RBD driver failover started.')
+        if not self._is_replication_enabled:
+            raise exception.UnableToFailOver(
+                reason=_('RBD: Replication is not enabled.'))
+
+        if secondary_id == 'default':
+            replication_status = fields.ReplicationStatus.ENABLED
+        else:
+            replication_status = fields.ReplicationStatus.FAILED_OVER
+
+        secondary_id, remote = self._get_failover_target_config(secondary_id)
+
+        # Try to demote the volumes first
+        demotion_results = self._demote_volumes(volumes)
+
+        # Do the failover taking into consideration if they have been demoted
+        updates = [self._failover_volume(volume, remote, is_demoted,
+                                         replication_status)
+                   for volume, is_demoted in zip(volumes, demotion_results)]
+
+        LOG.info('RBD driver failover completed.')
+        return secondary_id, updates, []
+
+    def failover_completed(self, context, secondary_id=None):
+        """Failover to replication target."""
+        LOG.info('RBD driver failover completion started.')
+        secondary_id, remote = self._get_failover_target_config(secondary_id)
+
+        self._active_backend_id = secondary_id
+        self._active_config = remote
+        LOG.info('RBD driver failover completion completed.')
+
+    def failover_host(self, context, volumes, secondary_id=None, groups=None):
+        """Failover to replication target.
+
+        This function combines calls to failover() and failover_completed() to
+        perform failover when Active/Active is not enabled.
+        """
+        active_backend_id, volume_update_list, group_update_list = (
+            self.failover(context, volumes, secondary_id, groups))
+        self.failover_completed(context, secondary_id)
+        return active_backend_id, volume_update_list, group_update_list
+
+    def ensure_export(self, context, volume):
+        """Synchronously recreates an export for a logical volume."""
+        pass
+
+    def create_export(self, context, volume, connector):
+        """Exports the volume."""
+        pass
+
+    def remove_export(self, context, volume):
+        """Removes an export for a logical volume."""
+        pass
+
+    def _get_keyring_contents(self):
+        # NOTE(danpawlik) If keyring is not provided in Cinder configuration,
+        # os-brick library will take keyring from default path.
+        keyring_file = self.configuration.rbd_keyring_conf
+        keyring_data = None
+        try:
+            if os.path.isfile(keyring_file):
+                with open(keyring_file, 'r') as k_file:
+                    keyring_data = k_file.read()
+        except IOError:
+            LOG.debug('Cannot read RBD keyring file: %s.', keyring_file)
+
+        return keyring_data
+
+    def initialize_connection(self, volume, connector):
+        hosts, ports = self._get_mon_addrs()
+        name, conf, user, secret_uuid = self._get_config_tuple()
+        data = {
+            'driver_volume_type': 'rbd',
+            'data': {
+                'name': '%s/%s' % (self.configuration.rbd_pool,
+                                   volume.name),
+                'hosts': hosts,
+                'ports': ports,
+                'cluster_name': name,
+                'auth_enabled': (user is not None),
+                'auth_username': user,
+                'secret_type': 'ceph',
+                'secret_uuid': secret_uuid,
+                'volume_id': volume.id,
+                "discard": True,
+                'keyring': self._get_keyring_contents(),
+            }
+        }
+        LOG.debug('connection data: %s', data)
+        return data
+
+    def terminate_connection(self, volume, connector, **kwargs):
+        pass
+
+    def _parse_location(self, location):
+        prefix = 'rbd://'
+        if not location.startswith(prefix):
+            reason = _('Not stored in rbd')
+            raise exception.ImageUnacceptable(image_id=location, reason=reason)
+        pieces = [urllib.parse.unquote(loc)
+                  for loc in location[len(prefix):].split('/')]
+        if any(map(lambda p: p == '', pieces)):
+            reason = _('Blank components')
+            raise exception.ImageUnacceptable(image_id=location, reason=reason)
+        if len(pieces) != 4:
+            reason = _('Not an rbd snapshot')
+            raise exception.ImageUnacceptable(image_id=location, reason=reason)
+        return pieces
+
+    def _get_fsid(self):
+        with RADOSClient(self) as client:
+            # Librados's get_fsid is represented as binary
+            # in py3 instead of str as it is in py2.
+            # This causes problems with cinder rbd
+            # driver as we rely on get_fsid return value
+            # which should be string, not bytes.
+            # Decode binary to str fixes these issues.
+            # Fix with encodeutils.safe_decode CAN BE REMOVED
+            # after librados's fix will be in stable for some time.
+            #
+            # More informations:
+            # https://bugs.launchpad.net/glance-store/+bug/1816721
+            # https://bugs.launchpad.net/cinder/+bug/1816468
+            # https://tracker.ceph.com/issues/38381
+            return encodeutils.safe_decode(client.cluster.get_fsid())
+
+    def _is_cloneable(self, image_location, image_meta):
+        try:
+            fsid, pool, image, snapshot = self._parse_location(image_location)
+        except exception.ImageUnacceptable as e:
+            LOG.debug('not cloneable: %s.', e)
+            return False
+
+        if self._get_fsid() != fsid:
+            LOG.debug('%s is in a different ceph cluster.', image_location)
+            return False
+
+        if image_meta['disk_format'] != 'raw':
+            LOG.debug("rbd image clone requires image format to be "
+                      "'raw' but image %(image)s is '%(format)s'",
+                      {"image": image_location,
+                       "format": image_meta['disk_format']})
+            return False
+
+        # check that we can read the image
+        try:
+            with RBDVolumeProxy(self, image,
+                                pool=pool,
+                                snapshot=snapshot,
+                                read_only=True):
+                return True
+        except self.rbd.Error as e:
+            LOG.debug('Unable to open image %(loc)s: %(err)s.',
+                      dict(loc=image_location, err=e))
+            return False
+
+    def clone_image(self, context, volume,
+                    image_location, image_meta,
+                    image_service):
+        if image_location:
+            # Note: image_location[0] is glance image direct_url.
+            # image_location[1] contains the list of all locations (including
+            # direct_url) or None if show_multiple_locations is False in
+            # glance configuration.
+            if image_location[1]:
+                url_locations = [location['url'] for
+                                 location in image_location[1]]
+            else:
+                url_locations = [image_location[0]]
+
+            # iterate all locations to look for a cloneable one.
+            for url_location in url_locations:
+                if url_location and self._is_cloneable(
+                        url_location, image_meta):
+                    _prefix, pool, image, snapshot = \
+                        self._parse_location(url_location)
+                    volume_update = self._clone(volume, pool, image, snapshot)
+                    volume_update['provider_location'] = None
+                    self._resize(volume)
+                    return volume_update, True
+        return ({}, False)
+
+    def copy_image_to_encrypted_volume(self, context, volume, image_service,
+                                       image_id):
+        self._copy_image_to_volume(context, volume, image_service, image_id,
+                                   encrypted=True)
+
+    def copy_image_to_volume(self, context, volume, image_service, image_id):
+        self._copy_image_to_volume(context, volume, image_service, image_id)
+
+    def _encrypt_image(self, context, volume, tmp_dir, src_image_path):
+        encryption = volume_utils.check_encryption_provider(
+            self.db,
+            volume,
+            context)
+
+        # Fetch the key associated with the volume and decode the passphrase
+        keymgr = key_manager.API(CONF)
+        key = keymgr.get(context, encryption['encryption_key_id'])
+        passphrase = binascii.hexlify(key.get_encoded()).decode('utf-8')
+
+        # Decode the dm-crypt style cipher spec into something qemu-img can use
+        cipher_spec = image_utils.decode_cipher(encryption['cipher'],
+                                                encryption['key_size'])
+
+        tmp_dir = volume_utils.image_conversion_dir()
+
+        with tempfile.NamedTemporaryFile(prefix='luks_',
+                                         dir=tmp_dir) as pass_file:
+            with open(pass_file.name, 'w') as f:
+                f.write(passphrase)
+
+            # Convert the raw image to luks
+            dest_image_path = src_image_path + '.luks'
+            try:
+                image_utils.convert_image(src_image_path, dest_image_path,
+                                          'luks', src_format='raw',
+                                          cipher_spec=cipher_spec,
+                                          passphrase_file=pass_file.name)
+
+                # Replace the original image with the now encrypted image
+                os.rename(dest_image_path, src_image_path)
+            finally:
+                fileutils.delete_if_exists(dest_image_path)
+
+    def _copy_image_to_volume(self, context, volume, image_service, image_id,
+                              encrypted=False):
+
+        tmp_dir = volume_utils.image_conversion_dir()
+
+        with tempfile.NamedTemporaryFile(dir=tmp_dir) as tmp:
+            image_utils.fetch_to_raw(context, image_service, image_id,
+                                     tmp.name,
+                                     self.configuration.volume_dd_blocksize,
+                                     size=volume.size)
+
+            if encrypted:
+                self._encrypt_image(context, volume, tmp_dir, tmp.name)
+
+            @utils.retry(exception.VolumeIsBusy,
+                         self.configuration.rados_connection_interval,
+                         self.configuration.rados_connection_retries)
+            def _delete_volume(volume):
+                self.delete_volume(volume)
+
+            _delete_volume(volume)
+
+            chunk_size = self.configuration.rbd_store_chunk_size * units.Mi
+            order = int(math.log(chunk_size, 2))
+            # keep using the command line import instead of librbd since it
+            # detects zeroes to preserve sparseness in the image
+            args = ['rbd', 'import',
+                    '--pool', self.configuration.rbd_pool,
+                    '--order', order,
+                    tmp.name, volume.name,
+                    '--new-format']
+            args.extend(self._ceph_args())
+            self._try_execute(*args)
+        self._resize(volume)
+        # We may need to re-enable replication because we have deleted the
+        # original image and created a new one using the command line import.
+        try:
+            self._setup_volume(volume)
+        except Exception:
+            err_msg = (_('Failed to enable image replication'))
+            raise exception.ReplicationError(reason=err_msg,
+                                             volume_id=volume.id)
+
+    def copy_volume_to_image(self, context, volume, image_service, image_meta):
+        tmp_dir = volume_utils.image_conversion_dir()
+        tmp_file = os.path.join(tmp_dir,
+                                volume.name + '-' + image_meta['id'])
+        with fileutils.remove_path_on_error(tmp_file):
+            args = ['rbd', 'export',
+                    '--pool', self.configuration.rbd_pool,
+                    volume.name, tmp_file]
+            args.extend(self._ceph_args())
+            self._try_execute(*args)
+            volume_utils.upload_volume(context, image_service,
+                                       image_meta, tmp_file,
+                                       volume)
+        os.unlink(tmp_file)
+
+    def extend_volume(self, volume, new_size):
+        """Extend an existing volume."""
+        old_size = volume.size
+
+        try:
+            size = int(new_size) * units.Gi
+            self._resize(volume, size=size)
+        except Exception:
+            msg = _('Failed to Extend Volume '
+                    '%(volname)s') % {'volname': volume.name}
+            LOG.error(msg)
+            raise exception.VolumeBackendAPIException(data=msg)
+
+        LOG.debug("Extend volume from %(old_size)s GB to %(new_size)s GB.",
+                  {'old_size': old_size, 'new_size': new_size})
+
+    def manage_existing(self, volume, existing_ref):
+        """Manages an existing image.
+
+        Renames the image name to match the expected name for the volume.
+        Error checking done by manage_existing_get_size is not repeated.
+
+        :param volume:
+            volume ref info to be set
+        :param existing_ref:
+            existing_ref is a dictionary of the form:
+            {'source-name': <name of rbd image>}
+        """
+        # Raise an exception if we didn't find a suitable rbd image.
+        with RADOSClient(self) as client:
+            rbd_name = existing_ref['source-name']
+            self.RBDProxy().rename(client.ioctx,
+                                   utils.convert_str(rbd_name),
+                                   utils.convert_str(volume.name))
+
+    def manage_existing_get_size(self, volume, existing_ref):
+        """Return size of an existing image for manage_existing.
+
+        :param volume:
+            volume ref info to be set
+        :param existing_ref:
+            existing_ref is a dictionary of the form:
+            {'source-name': <name of rbd image>}
+        """
+
+        # Check that the reference is valid
+        if 'source-name' not in existing_ref:
+            reason = _('Reference must contain source-name element.')
+            raise exception.ManageExistingInvalidReference(
+                existing_ref=existing_ref, reason=reason)
+
+        rbd_name = utils.convert_str(existing_ref['source-name'])
+
+        with RADOSClient(self) as client:
+            # Raise an exception if we didn't find a suitable rbd image.
+            try:
+                rbd_image = self.rbd.Image(client.ioctx,
+                                           rbd_name,
+                                           read_only=True)
+            except self.rbd.ImageNotFound:
+                kwargs = {'existing_ref': rbd_name,
+                          'reason': 'Specified rbd image does not exist.'}
+                raise exception.ManageExistingInvalidReference(**kwargs)
+
+            image_size = rbd_image.size()
+            rbd_image.close()
+
+            # RBD image size is returned in bytes.  Attempt to parse
+            # size as a float and round up to the next integer.
+            try:
+                convert_size = int(math.ceil(float(image_size) / units.Gi))
+                return convert_size
+            except ValueError:
+                exception_message = (_("Failed to manage existing volume "
+                                       "%(name)s, because reported size "
+                                       "%(size)s was not a floating-point"
+                                       " number.")
+                                     % {'name': rbd_name,
+                                        'size': image_size})
+                raise exception.VolumeBackendAPIException(
+                    data=exception_message)
+
+    def _get_image_status(self, image_name):
+        args = ['rbd', 'status',
+                '--pool', self.configuration.rbd_pool,
+                '--format=json',
+                image_name]
+        args.extend(self._ceph_args())
+        out, _ = self._execute(*args)
+        return json.loads(out)
+
+    def get_manageable_volumes(self, cinder_volumes, marker, limit, offset,
+                               sort_keys, sort_dirs):
+        manageable_volumes = []
+        cinder_ids = [resource['id'] for resource in cinder_volumes]
+
+        with RADOSClient(self) as client:
+            for image_name in self.RBDProxy().list(client.ioctx):
+                image_id = volume_utils.extract_id_from_volume_name(image_name)
+                with RBDVolumeProxy(self, image_name, read_only=True,
+                                    client=client.cluster,
+                                    ioctx=client.ioctx) as image:
+                    try:
+                        image_info = {
+                            'reference': {'source-name': image_name},
+                            'size': int(math.ceil(
+                                float(image.size()) / units.Gi)),
+                            'cinder_id': None,
+                            'extra_info': None
+                        }
+                        if image_id in cinder_ids:
+                            image_info['cinder_id'] = image_id
+                            image_info['safe_to_manage'] = False
+                            image_info['reason_not_safe'] = 'already managed'
+                        elif len(self._get_image_status(
+                                image_name)['watchers']) > 0:
+                            # If the num of watchers of image is >= 1, then the
+                            # image is considered to be used by client(s).
+                            image_info['safe_to_manage'] = False
+                            image_info['reason_not_safe'] = 'volume in use'
+                        elif image_name.endswith('.deleted'):
+                            # parent of cloned volume which marked as deleted
+                            # should not be manageable.
+                            image_info['safe_to_manage'] = False
+                            image_info['reason_not_safe'] = (
+                                'volume marked as deleted')
+                        else:
+                            image_info['safe_to_manage'] = True
+                            image_info['reason_not_safe'] = None
+                        manageable_volumes.append(image_info)
+                    except self.rbd.ImageNotFound:
+                        LOG.debug("Image %s is not found.", image_name)
+
+        return volume_utils.paginate_entries_list(
+            manageable_volumes, marker, limit, offset, sort_keys, sort_dirs)
+
+    def unmanage(self, volume):
+        pass
+
+    def update_migrated_volume(self, ctxt, volume, new_volume,
+                               original_volume_status):
+        """Return model update from RBD for migrated volume.
+
+        This method should rename the back-end volume name(id) on the
+        destination host back to its original name(id) on the source host.
+
+        :param ctxt: The context used to run the method update_migrated_volume
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :param original_volume_status: The status of the original volume
+        :returns: model_update to update DB with any needed changes
+        """
+        name_id = None
+        provider_location = None
+
+        if original_volume_status == 'in-use':
+            # The back-end will not be renamed.
+            name_id = new_volume['_name_id'] or new_volume['id']
+            provider_location = new_volume['provider_location']
+            return {'_name_id': name_id,
+                    'provider_location': provider_location}
+
+        existing_name = CONF.volume_name_template % new_volume.id
+        wanted_name = CONF.volume_name_template % volume.id
+        with RADOSClient(self) as client:
+            try:
+                self.RBDProxy().rename(client.ioctx,
+                                       utils.convert_str(existing_name),
+                                       utils.convert_str(wanted_name))
+            except (self.rbd.ImageNotFound, self.rbd.ImageExists):
+                LOG.error('Unable to rename the logical volume '
+                          'for volume %s.', volume.id)
+                # If the rename fails, _name_id should be set to the new
+                # volume id and provider_location should be set to the
+                # one from the new volume as well.
+                name_id = new_volume._name_id or new_volume.id
+                provider_location = new_volume['provider_location']
+        return {'_name_id': name_id,
+                'provider_location': provider_location}
+
+    def migrate_volume(self, context, volume, host):
+
+        refuse_to_migrate = (False, None)
+
+        if volume.status not in ('available', 'retyping', 'maintenance',
+                                 'in-use'):
+            LOG.debug('Only available or in-use volumes can be migrated using '
+                      'backend assisted migration. Falling back to generic '
+                      'migration.')
+            return refuse_to_migrate
+
+        if (host['capabilities']['storage_protocol'] != 'ceph'):
+            LOG.debug('Source and destination drivers need to be RBD '
+                      'to use backend assisted migration. Falling back to '
+                      'generic migration.')
+            return refuse_to_migrate
+
+        loc_info = host['capabilities'].get('location_info')
+
+        LOG.debug('Attempting RBD assisted volume migration. volume: %(id)s, '
+                  'host: %(host)s, status=%(status)s.',
+                  {'id': volume.id, 'host': host, 'status': volume.status})
+
+        if not loc_info:
+            LOG.debug('Could not find location_info in capabilities reported '
+                      'by the destination driver. Falling back to generic '
+                      'migration.')
+            return refuse_to_migrate
+
+        try:
+            (rbd_cluster_name, rbd_ceph_conf, rbd_fsid, rbd_user, rbd_pool) = (
+                utils.convert_str(loc_info).split(':'))
+        except ValueError:
+            LOG.error('Location info needed for backend enabled volume '
+                      'migration not in correct format: %s. Falling back to '
+                      'generic volume migration.', loc_info)
+            return refuse_to_migrate
+
+        with linuxrbd.RBDClient(rbd_user, rbd_pool, conffile=rbd_ceph_conf,
+                                rbd_cluster_name=rbd_cluster_name) as target:
+            if (rbd_fsid != self._get_fsid()) or \
+                    (rbd_fsid != encodeutils.safe_decode(
+                        target.client.get_fsid())):
+                LOG.info('Migration between clusters is not supported. '
+                         'Falling back to generic migration.')
+                return refuse_to_migrate
+
+            if rbd_pool == self.configuration.rbd_pool:
+                LOG.debug('Migration in the same pool, just need to update '
+                          "volume's host value to destination host.")
+                return (True, None)
+
+            if volume.status == 'in-use':
+                LOG.debug('Migration in-use volume between different pools. '
+                          'Falling back to generic migration.')
+                return refuse_to_migrate
+
+            with RBDVolumeProxy(self, volume.name, read_only=True) as source:
+                try:
+                    source.copy(target.ioctx, volume.name)
+                except Exception:
+                    with excutils.save_and_reraise_exception():
+                        LOG.error('Error copying rbd image %(vol)s to target '
+                                  'pool %(pool)s.',
+                                  {'vol': volume.name, 'pool': rbd_pool})
+                        self.RBDProxy().remove(target.ioctx, volume.name)
+
+        try:
+            # If the source fails to delete for some reason, we want to leave
+            # the target volume in place in case deleting it might cause a lose
+            # of data.
+            self.delete_volume(volume)
+        except Exception:
+            reason = 'Failed to delete migration source volume %s.', volume.id
+            raise exception.VolumeMigrationFailed(reason=reason)
+
+        LOG.info('Successful RBD assisted volume migration.')
+
+        return (True, None)
+
+    def manage_existing_snapshot_get_size(self, snapshot, existing_ref):
+        """Return size of an existing image for manage_existing.
+
+        :param snapshot:
+            snapshot ref info to be set
+        :param existing_ref:
+            existing_ref is a dictionary of the form:
+            {'source-name': <name of snapshot>}
+        """
+        # Check that the reference is valid
+        if not isinstance(existing_ref, dict):
+            existing_ref = {"source-name": existing_ref}
+        if 'source-name' not in existing_ref:
+            reason = _('Reference must contain source-name element.')
+            raise exception.ManageExistingInvalidReference(
+                existing_ref=existing_ref, reason=reason)
+
+        volume_name = utils.convert_str(snapshot.volume_name)
+        snapshot_name = utils.convert_str(existing_ref['source-name'])
+
+        with RADOSClient(self) as client:
+            # Raise an exception if we didn't find a suitable rbd image.
+            try:
+                rbd_snapshot = self.rbd.Image(client.ioctx, volume_name,
+                                              snapshot=snapshot_name,
+                                              read_only=True)
+            except self.rbd.ImageNotFound:
+                kwargs = {'existing_ref': snapshot_name,
+                          'reason': 'Specified snapshot does not exist.'}
+                raise exception.ManageExistingInvalidReference(**kwargs)
+
+            snapshot_size = rbd_snapshot.size()
+            rbd_snapshot.close()
+
+            # RBD image size is returned in bytes.  Attempt to parse
+            # size as a float and round up to the next integer.
+            try:
+                convert_size = int(math.ceil(float(snapshot_size) / units.Gi))
+                return convert_size
+            except ValueError:
+                exception_message = (_("Failed to manage existing snapshot "
+                                       "%(name)s, because reported size "
+                                       "%(size)s was not a floating-point"
+                                       " number.")
+                                     % {'name': snapshot_name,
+                                        'size': snapshot_size})
+                raise exception.VolumeBackendAPIException(
+                    data=exception_message)
+
+    def manage_existing_snapshot(self, snapshot, existing_ref):
+        """Manages an existing snapshot.
+
+        Renames the snapshot name to match the expected name for the snapshot.
+        Error checking done by manage_existing_get_size is not repeated.
+
+        :param snapshot:
+            snapshot ref info to be set
+        :param existing_ref:
+            existing_ref is a dictionary of the form:
+            {'source-name': <name of rbd snapshot>}
+        """
+        if not isinstance(existing_ref, dict):
+            existing_ref = {"source-name": existing_ref}
+        volume_name = utils.convert_str(snapshot.volume_name)
+        with RBDVolumeProxy(self, volume_name) as volume:
+            snapshot_name = existing_ref['source-name']
+            volume.rename_snap(utils.convert_str(snapshot_name),
+                               utils.convert_str(snapshot.name))
+            if not volume.is_protected_snap(snapshot.name):
+                volume.protect_snap(snapshot.name)
+
+    def get_manageable_snapshots(self, cinder_snapshots, marker, limit, offset,
+                                 sort_keys, sort_dirs):
+        """List manageable snapshots on RBD backend."""
+        manageable_snapshots = []
+        cinder_snapshot_ids = [resource['id'] for resource in cinder_snapshots]
+
+        with RADOSClient(self) as client:
+            for image_name in self.RBDProxy().list(client.ioctx):
+                with RBDVolumeProxy(self, image_name, read_only=True,
+                                    client=client.cluster,
+                                    ioctx=client.ioctx) as image:
+                    try:
+                        for snapshot in image.list_snaps():
+                            snapshot_id = (
+                                volume_utils.extract_id_from_snapshot_name(
+                                    snapshot['name']))
+                            snapshot_info = {
+                                'reference': {'source-name': snapshot['name']},
+                                'size': int(math.ceil(
+                                    float(snapshot['size']) / units.Gi)),
+                                'cinder_id': None,
+                                'extra_info': None,
+                                'safe_to_manage': False,
+                                'reason_not_safe': None,
+                                'source_reference': {'source-name': image_name}
+                            }
+
+                            if snapshot_id in cinder_snapshot_ids:
+                                # Exclude snapshots already managed.
+                                snapshot_info['reason_not_safe'] = (
+                                    'already managed')
+                                snapshot_info['cinder_id'] = snapshot_id
+                            elif snapshot['name'].endswith('.clone_snap'):
+                                # Exclude clone snapshot.
+                                snapshot_info['reason_not_safe'] = (
+                                    'used for clone snap')
+                            elif (snapshot['name'].startswith('backup')
+                                  and '.snap.' in snapshot['name']):
+                                # Exclude intermediate snapshots created by the
+                                # Ceph backup driver.
+                                snapshot_info['reason_not_safe'] = (
+                                    'used for volume backup')
+                            else:
+                                snapshot_info['safe_to_manage'] = True
+                            manageable_snapshots.append(snapshot_info)
+                    except self.rbd.ImageNotFound:
+                        LOG.debug("Image %s is not found.", image_name)
+
+        return volume_utils.paginate_entries_list(
+            manageable_snapshots, marker, limit, offset, sort_keys, sort_dirs)
+
+    def unmanage_snapshot(self, snapshot):
+        """Removes the specified snapshot from Cinder management."""
+        with RBDVolumeProxy(self, snapshot.volume_name) as volume:
+            volume.set_snap(snapshot.name)
+            children = volume.list_children()
+            volume.set_snap(None)
+            if not children and volume.is_protected_snap(snapshot.name):
+                volume.unprotect_snap(snapshot.name)
+
+    def get_backup_device(self, context, backup):
+        """Get a backup device from an existing volume.
+
+        To support incremental backups on Ceph to Ceph we don't clone
+        the volume.
+        """
+
+        if not ('backup.drivers.ceph' in backup.service) or backup.snapshot_id:
+            return super(RBDDriver, self).get_backup_device(context, backup)
+
+        volume = objects.Volume.get_by_id(context, backup.volume_id)
+        return (volume, False)

--- a/chef/cookbooks/bcpc/files/default/nova/block_device.py
+++ b/chef/cookbooks/bcpc/files/default/nova/block_device.py
@@ -701,11 +701,11 @@ class DriverVolumeBlockDevice(DriverBlockDevice):
             if multiattach:
                 connection_info['multiattach'] = True
 
-        # Rewrite the connection_info using the list of mons in ceph.conf
+        # Rewrite the connection_info using the list of mons in migration.conf
         mons = []
 
         try:
-            with open('/etc/ceph/ceph.conf', 'r') as config_file:
+            with open('/etc/ceph/migration.conf', 'r') as config_file:
                 config = ConfigParser()
                 config.read_file(config_file)
                 mon_host = config['global']['mon host']
@@ -715,7 +715,7 @@ class DriverVolumeBlockDevice(DriverBlockDevice):
         except (FileNotFoundError, KeyError, ValueError) as exception:
             LOG.error('ceph-mon-migration: {0}'.format(str(exception)))
 
-        if len(mons) and 'hosts' in connection_info.get('data', {}):
+        if len(mons) > 0 and 'hosts' in connection_info.get('data', {}):
             connection_info['data']['hosts'] = mons
 
         if 'serial' not in connection_info:

--- a/chef/cookbooks/bcpc/files/default/nova/block_device.py
+++ b/chef/cookbooks/bcpc/files/default/nova/block_device.py
@@ -1,0 +1,963 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from configparser import ConfigParser
+import functools
+from ipaddress import AddressValueError, IPv4Address
+import itertools
+
+from os_brick import encryptors
+from os_brick.initiator import utils as brick_utils
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+from oslo_utils import excutils
+
+
+from nova import block_device
+import nova.conf
+from nova import exception
+
+CONF = nova.conf.CONF
+
+LOG = logging.getLogger(__name__)
+
+
+class _NotTransformable(Exception):
+    pass
+
+
+class _InvalidType(_NotTransformable):
+    pass
+
+
+def update_db(method):
+    @functools.wraps(method)
+    def wrapped(obj, context, *args, **kwargs):
+        try:
+            ret_val = method(obj, context, *args, **kwargs)
+        finally:
+            obj.save()
+        return ret_val
+    return wrapped
+
+
+def _get_volume_create_az_value(instance):
+    """Determine az to use when creating a volume
+
+    Uses the cinder.cross_az_attach config option to determine the availability
+    zone value to use when creating a volume.
+
+    :param nova.objects.Instance instance: The instance for which the volume
+        will be created and attached.
+    :returns: The availability_zone value to pass to volume_api.create
+    """
+    # If we're allowed to attach a volume in any AZ to an instance in any AZ,
+    # then we don't care what AZ the volume is in so don't specify anything.
+    if CONF.cinder.cross_az_attach:
+        return None
+    # Else the volume has to be in the same AZ as the instance otherwise we
+    # fail. If the AZ is not in Cinder the volume create will fail. But on the
+    # other hand if the volume AZ and instance AZ don't match and
+    # cross_az_attach is False, then volume_api.check_attach will fail too, so
+    # we can't really win. :)
+    # TODO(mriedem): It would be better from a UX perspective if we could do
+    # some validation in the API layer such that if we know we're going to
+    # specify the AZ when creating the volume and that AZ is not in Cinder, we
+    # could fail the boot from volume request early with a 400 rather than
+    # fail to build the instance on the compute node which results in a
+    # NoValidHost error.
+    return instance.availability_zone
+
+
+class DriverBlockDevice(dict):
+    """A dict subclass that represents block devices used by the virt layer.
+
+    Uses block device objects internally to do the database access.
+
+    _fields and _legacy_fields class attributes present a set of fields that
+    are expected on a certain DriverBlockDevice type. We may have more legacy
+    versions in the future.
+
+    If an attribute access is attempted for a name that is found in the
+    _proxy_as_attr set, it will be proxied to the underlying object. This
+    allows us to access stuff that is not part of the data model that all
+    drivers understand.
+
+    The save() method allows us to update the database using the underlying
+    object. _update_on_save class attribute dictionary keeps the following
+    mapping:
+
+        {'object field name': 'driver dict field name (or None if same)'}
+
+    These fields will be updated on the internal object, from the values in the
+    dict, before the actual database update is done.
+    """
+
+    _fields = set()
+    _legacy_fields = set()
+
+    _proxy_as_attr_inherited = set(['uuid', 'is_volume'])
+    _update_on_save = {'disk_bus': None,
+                       'device_name': None,
+                       'device_type': None}
+
+    # A hash containing the combined inherited members of _proxy_as_attr for
+    # each subclass
+    _proxy_as_attr_by_class = {}
+
+    def __init__(self, bdm):
+        self.__dict__['_bdm_obj'] = bdm
+
+        if self._bdm_obj.no_device:
+            raise _NotTransformable()
+
+        self.update({field: None for field in self._fields})
+        self._transform()
+
+    @property
+    def _proxy_as_attr(self):
+        # Combine the members of all _proxy_as_attr sets for this class and its
+        # ancestors
+        if self.__class__ not in self._proxy_as_attr_by_class:
+            attr_all = set()
+            for cls in self.__class__.mro():
+                attr_one = getattr(cls, '_proxy_as_attr_inherited', None)
+                if attr_one is not None:
+                    attr_all = attr_all | attr_one
+
+            # We don't need to lock here because as long as insertion into a
+            # dict is threadsafe, the only consequence of a race is calculating
+            # the inherited set multiple times.
+            self._proxy_as_attr_by_class[self.__class__] = attr_all
+
+        return self._proxy_as_attr_by_class[self.__class__]
+
+    def __getattr__(self, name):
+        if name in self._proxy_as_attr:
+            return getattr(self._bdm_obj, name)
+        elif name in self._fields:
+            return self[name]
+        else:
+            return super(DriverBlockDevice, self).__getattr__(name)
+
+    def __setattr__(self, name, value):
+        if name in self._proxy_as_attr:
+            setattr(self._bdm_obj, name, value)
+        elif name in self._fields:
+            self[name] = value
+        else:
+            super(DriverBlockDevice, self).__setattr__(name, value)
+
+    def __getitem__(self, name):
+        if name in self._proxy_as_attr:
+            return getattr(self._bdm_obj, name)
+        return super(DriverBlockDevice, self).__getitem__(name)
+
+    def __setitem__(self, name, value):
+        if name in self._proxy_as_attr:
+            setattr(self._bdm_obj, name, value)
+        super(DriverBlockDevice, self).__setitem__(name, value)
+
+    def _transform(self):
+        """Transform bdm to the format that is passed to drivers."""
+        raise NotImplementedError()
+
+    def get(self, name, default=None):
+        if name in self._proxy_as_attr:
+            return getattr(self._bdm_obj, name)
+        elif name in self._fields:
+            return self[name]
+        else:
+            return super(DriverBlockDevice, self).get(name, default)
+
+    def legacy(self):
+        """Basic legacy transformation.
+
+        Basic method will just drop the fields that are not in
+        _legacy_fields set. Override this in subclass if needed.
+        """
+        return {key: self.get(key) for key in self._legacy_fields}
+
+    def attach(self, **kwargs):
+        """Make the device available to be used by VMs.
+
+        To be overridden in subclasses with the connecting logic for
+        the type of device the subclass represents.
+        """
+        raise NotImplementedError()
+
+    def detach(self, **kwargs):
+        """Detach the device from an instance and detach in Cinder.
+
+        Note: driver_detach is called as part of this method.
+
+        To be overridden in subclasses with the detaching logic for
+        the type of device the subclass represents.
+        """
+        raise NotImplementedError()
+
+    def driver_detach(self, **kwargs):
+        """Detach the device from an instance (don't detach in Cinder).
+
+        To be overridden in subclasses with the detaching logic for
+        the type of device the subclass represents.
+        """
+        raise NotImplementedError()
+
+    def save(self):
+        for attr_name, key_name in self._update_on_save.items():
+            lookup_name = key_name or attr_name
+            if self[lookup_name] != getattr(self._bdm_obj, attr_name):
+                setattr(self._bdm_obj, attr_name, self[lookup_name])
+        self._bdm_obj.save()
+
+
+class DriverSwapBlockDevice(DriverBlockDevice):
+    _fields = set(['device_name', 'swap_size', 'disk_bus'])
+    _legacy_fields = _fields - set(['disk_bus'])
+
+    _update_on_save = {'disk_bus': None,
+                       'device_name': None}
+
+    def _transform(self):
+        if not block_device.new_format_is_swap(self._bdm_obj):
+            raise _InvalidType
+        self.update({
+            'device_name': self._bdm_obj.device_name,
+            'swap_size': self._bdm_obj.volume_size or 0,
+            'disk_bus': self._bdm_obj.disk_bus
+        })
+
+
+class DriverEphemeralBlockDevice(DriverBlockDevice):
+    _new_only_fields = set(['disk_bus', 'device_type', 'guest_format'])
+    _fields = set(['device_name', 'size']) | _new_only_fields
+    _legacy_fields = (_fields - _new_only_fields |
+                      set(['num', 'virtual_name']))
+
+    def _transform(self):
+        if not block_device.new_format_is_ephemeral(self._bdm_obj):
+            raise _InvalidType
+        self.update({
+            'device_name': self._bdm_obj.device_name,
+            'size': self._bdm_obj.volume_size or 0,
+            'disk_bus': self._bdm_obj.disk_bus,
+            'device_type': self._bdm_obj.device_type,
+            'guest_format': self._bdm_obj.guest_format
+        })
+
+    def legacy(self, num=0):
+        legacy_bdm = super(DriverEphemeralBlockDevice, self).legacy()
+        legacy_bdm['num'] = num
+        legacy_bdm['virtual_name'] = 'ephemeral' + str(num)
+        return legacy_bdm
+
+
+class DriverVolumeBlockDevice(DriverBlockDevice):
+    _legacy_fields = set(['connection_info', 'mount_device',
+                          'delete_on_termination'])
+    _new_fields = set(['guest_format', 'device_type',
+                       'disk_bus', 'boot_index',
+                       'attachment_id'])
+    _fields = _legacy_fields | _new_fields
+
+    _valid_source = 'volume'
+    _valid_destination = 'volume'
+
+    _proxy_as_attr_inherited = set(['volume_size', 'volume_id', 'volume_type'])
+    _update_on_save = {'disk_bus': None,
+                       'device_name': 'mount_device',
+                       'device_type': None,
+                       # needed for boot from volume for blank/image/snapshot
+                       'attachment_id': None}
+
+    def _transform(self):
+        if (not self._bdm_obj.source_type == self._valid_source or
+                not self._bdm_obj.destination_type == self._valid_destination):
+            raise _InvalidType
+
+        self.update(
+            {k: v for k, v in self._bdm_obj.items()
+             if k in self._new_fields | set(['delete_on_termination'])}
+        )
+        self['mount_device'] = self._bdm_obj.device_name
+        # connection_info might not be set so default to an empty dict so that
+        # it can be serialized to an empty JSON object.
+        try:
+            self['connection_info'] = jsonutils.loads(
+                self._bdm_obj.connection_info)
+        except TypeError:
+            self['connection_info'] = {}
+        # volume_type might not be set on the internal bdm object so default
+        # to None if not set
+        self['volume_type'] = (
+            self.volume_type if 'volume_type' in self._bdm_obj else None)
+
+    def _preserve_multipath_id(self, connection_info):
+        if self['connection_info'] and 'data' in self['connection_info']:
+            if 'multipath_id' in self['connection_info']['data']:
+                connection_info['data']['multipath_id'] =\
+                    self['connection_info']['data']['multipath_id']
+                LOG.info('preserve multipath_id %s',
+                         connection_info['data']['multipath_id'])
+
+    def driver_detach(self, context, instance, volume_api, virt_driver):
+        connection_info = self['connection_info']
+        mp = self['mount_device']
+        volume_id = self.volume_id
+
+        LOG.info('Attempting to driver detach volume %(volume_id)s from '
+                 'mountpoint %(mp)s', {'volume_id': volume_id, 'mp': mp},
+                 instance=instance)
+        try:
+            if not virt_driver.instance_exists(instance):
+                LOG.warning('Detaching volume from unknown instance',
+                            instance=instance)
+
+            encryption = encryptors.get_encryption_metadata(context,
+                    volume_api, volume_id, connection_info)
+            virt_driver.detach_volume(context, connection_info, instance, mp,
+                                      encryption=encryption)
+        except exception.DiskNotFound as err:
+            LOG.warning('Ignoring DiskNotFound exception while '
+                        'detaching volume %(volume_id)s from '
+                        '%(mp)s : %(err)s',
+                        {'volume_id': volume_id, 'mp': mp,
+                         'err': err}, instance=instance)
+        except exception.DeviceDetachFailed:
+            with excutils.save_and_reraise_exception():
+                LOG.warning('Guest refused to detach volume %(vol)s',
+                            {'vol': volume_id}, instance=instance)
+                volume_api.roll_detaching(context, volume_id)
+        except Exception:
+            with excutils.save_and_reraise_exception():
+                LOG.exception('Failed to detach volume '
+                              '%(volume_id)s from %(mp)s',
+                              {'volume_id': volume_id, 'mp': mp},
+                              instance=instance)
+                volume_api.roll_detaching(context, volume_id)
+
+    @staticmethod
+    def _get_volume(context, volume_api, volume_id):
+        # First try to get the volume at microversion 3.48 so we can get the
+        # shared_targets parameter exposed in that version. If that API version
+        # is not available, we just fallback.
+        try:
+            return volume_api.get(context, volume_id, microversion='3.48')
+        except exception.CinderAPIVersionNotAvailable:
+            return volume_api.get(context, volume_id)
+
+    def _create_volume(self, context, instance, volume_api, size,
+                       wait_func=None, **create_kwargs):
+        """Create a volume and attachment record.
+
+        :param context: nova auth RequestContext
+        :param instance: Instance object to which the created volume will be
+            attached.
+        :param volume_api: nova.volume.cinder.API instance
+        :param size: The size of the volume to create in GiB.
+        :param wait_func: Optional callback function to wait for the volume to
+            reach some status before continuing with a signature of::
+
+                wait_func(context, volume_id)
+        :param create_kwargs: Additional optional parameters used to create the
+            volume. See nova.volume.cinder.API.create for keys.
+        :return: A two-item tuple of volume ID and attachment ID.
+        """
+        av_zone = _get_volume_create_az_value(instance)
+        name = create_kwargs.pop('name', '')
+        description = create_kwargs.pop('description', '')
+        vol = volume_api.create(
+            context, size, name, description, volume_type=self.volume_type,
+            availability_zone=av_zone, **create_kwargs)
+
+        if wait_func:
+            self._call_wait_func(context, wait_func, volume_api, vol['id'])
+
+        # Unconditionally create an attachment record for the volume so the
+        # attach/detach flows use the "new style" introduced in Queens. Note
+        # that nova required the Cinder Queens level APIs (3.44+) starting in
+        # Train.
+        attachment_id = (
+            volume_api.attachment_create(
+                context, vol['id'], instance.uuid)['id'])
+
+        return vol['id'], attachment_id
+
+    def _do_detach(self, context, instance, volume_api, virt_driver,
+                   attachment_id=None, destroy_bdm=False):
+        """Private method that actually does the detach.
+
+        This is separate from the detach() method so the caller can optionally
+        lock this call.
+        """
+        volume_id = self.volume_id
+
+        # Only attempt to detach and disconnect from the volume if the instance
+        # is currently associated with the local compute host.
+        if CONF.host == instance.host:
+            self.driver_detach(context, instance, volume_api, virt_driver)
+        elif not destroy_bdm:
+            LOG.debug("Skipping driver_detach during remote rebuild.",
+                      instance=instance)
+        elif destroy_bdm:
+            LOG.error("Unable to call for a driver detach of volume "
+                      "%(vol_id)s due to the instance being "
+                      "registered to the remote host %(inst_host)s.",
+                      {'vol_id': volume_id,
+                       'inst_host': instance.host}, instance=instance)
+
+        # NOTE(jdg): For now we need to actually inspect the bdm for an
+        # attachment_id as opposed to relying on what may have been passed
+        # in, we want to force usage of the old detach flow for now and only
+        # use the new flow when we explicitly used it for the attach.
+        if not self['attachment_id']:
+            connector = virt_driver.get_volume_connector(instance)
+            connection_info = self['connection_info']
+            if connection_info and not destroy_bdm and (
+               connector.get('host') != instance.host):
+                # If the volume is attached to another host (evacuate) then
+                # this connector is for the wrong host. Use the connector that
+                # was stored in connection_info instead (if we have one, and it
+                # is for the expected host).
+                stashed_connector = connection_info.get('connector')
+                if not stashed_connector:
+                    # Volume was attached before we began stashing connectors
+                    LOG.warning("Host mismatch detected, but stashed "
+                                "volume connector not found. Instance host is "
+                                "%(ihost)s, but volume connector host is "
+                                "%(chost)s.",
+                                {'ihost': instance.host,
+                                 'chost': connector.get('host')})
+                elif stashed_connector.get('host') != instance.host:
+                    # Unexpected error. The stashed connector is also not
+                    # matching the needed instance host.
+                    LOG.error("Host mismatch detected in stashed volume "
+                              "connector. Will use local volume connector. "
+                              "Instance host is %(ihost)s. Local volume "
+                              "connector host is %(chost)s. Stashed volume "
+                              "connector host is %(schost)s.",
+                              {'ihost': instance.host,
+                               'chost': connector.get('host'),
+                               'schost': stashed_connector.get('host')})
+                else:
+                    # Fix found. Use stashed connector.
+                    LOG.debug("Host mismatch detected. Found usable stashed "
+                              "volume connector. Instance host is %(ihost)s. "
+                              "Local volume connector host was %(chost)s. "
+                              "Stashed volume connector host is %(schost)s.",
+                              {'ihost': instance.host,
+                               'chost': connector.get('host'),
+                               'schost': stashed_connector.get('host')})
+                    connector = stashed_connector
+
+            volume_api.terminate_connection(context, volume_id, connector)
+            volume_api.detach(context.elevated(), volume_id, instance.uuid,
+                              attachment_id)
+        else:
+            volume_api.attachment_delete(context, self['attachment_id'])
+
+    def detach(self, context, instance, volume_api, virt_driver,
+               attachment_id=None, destroy_bdm=False):
+        volume = self._get_volume(context, volume_api, self.volume_id)
+        # Let OS-Brick handle high level locking that covers the local os-brick
+        # detach and the Cinder call to call unmap the volume.  Not all volume
+        # backends or hosts require locking.
+        with brick_utils.guard_connection(volume):
+            self._do_detach(context, instance, volume_api, virt_driver,
+                            attachment_id, destroy_bdm)
+
+    def _legacy_volume_attach(self, context, volume, connector, instance,
+                              volume_api, virt_driver,
+                              do_driver_attach=False):
+        volume_id = volume['id']
+
+        connection_info = volume_api.initialize_connection(context,
+                                                           volume_id,
+                                                           connector)
+        if 'serial' not in connection_info:
+            connection_info['serial'] = self.volume_id
+        self._preserve_multipath_id(connection_info)
+
+        # If do_driver_attach is False, we will attach a volume to an instance
+        # at boot time. So actual attach is done by instance creation code.
+        if do_driver_attach:
+            encryption = encryptors.get_encryption_metadata(
+                context, volume_api, volume_id, connection_info)
+
+            try:
+                virt_driver.attach_volume(
+                        context, connection_info, instance,
+                        self['mount_device'], disk_bus=self['disk_bus'],
+                        device_type=self['device_type'], encryption=encryption)
+            except Exception:
+                with excutils.save_and_reraise_exception():
+                    LOG.exception("Driver failed to attach volume "
+                                  "%(volume_id)s at %(mountpoint)s",
+                                  {'volume_id': volume_id,
+                                   'mountpoint': self['mount_device']},
+                                  instance=instance)
+                    volume_api.terminate_connection(context, volume_id,
+                                                    connector)
+        self['connection_info'] = connection_info
+        if self.volume_size is None:
+            self.volume_size = volume.get('size')
+
+        mode = 'rw'
+        if 'data' in connection_info:
+            mode = connection_info['data'].get('access_mode', 'rw')
+        if volume['attach_status'] == "detached":
+            # NOTE(mriedem): save our current state so connection_info is in
+            # the database before the volume status goes to 'in-use' because
+            # after that we can detach and connection_info is required for
+            # detach.
+            self.save()
+            try:
+                volume_api.attach(context, volume_id, instance.uuid,
+                                  self['mount_device'], mode=mode)
+            except Exception:
+                with excutils.save_and_reraise_exception():
+                    if do_driver_attach:
+                        try:
+                            virt_driver.detach_volume(context,
+                                                      connection_info,
+                                                      instance,
+                                                      self['mount_device'],
+                                                      encryption=encryption)
+                        except Exception:
+                            LOG.warning("Driver failed to detach volume "
+                                        "%(volume_id)s at %(mount_point)s.",
+                                        {'volume_id': volume_id,
+                                         'mount_point': self['mount_device']},
+                                        exc_info=True, instance=instance)
+                    volume_api.terminate_connection(context, volume_id,
+                                                    connector)
+
+                    # Cinder-volume might have completed volume attach. So
+                    # we should detach the volume. If the attach did not
+                    # happen, the detach request will be ignored.
+                    volume_api.detach(context, volume_id)
+
+    def _volume_attach(self, context, volume, connector, instance,
+                       volume_api, virt_driver, attachment_id,
+                       do_driver_attach=False):
+        # This is where we actually (finally) make a call down to the device
+        # driver and actually create/establish the connection.  We'll go from
+        # here to block driver-->os-brick and back up.
+
+        volume_id = volume['id']
+        if self.volume_size is None:
+            self.volume_size = volume.get('size')
+
+        vol_multiattach = volume.get('multiattach', False)
+        virt_multiattach = virt_driver.capabilities.get(
+            'supports_multiattach', False)
+
+        if vol_multiattach and not virt_multiattach:
+            raise exception.MultiattachNotSupportedByVirtDriver(
+                      volume_id=volume_id)
+
+        LOG.debug("Updating existing volume attachment record: %s",
+                  attachment_id, instance=instance)
+        connection_info = volume_api.attachment_update(
+            context, attachment_id, connector,
+            self['mount_device'])['connection_info']
+        if 'serial' not in connection_info:
+            connection_info['serial'] = self.volume_id
+        self._preserve_multipath_id(connection_info)
+        if vol_multiattach:
+            # This will be used by the volume driver to determine the proper
+            # disk configuration.
+            # TODO(mriedem): Long-term we should stop stashing the multiattach
+            # flag in the bdm.connection_info since that should be an untouched
+            # set of values we can refresh from Cinder as needed. Putting the
+            # multiattach flag on the bdm directly will require schema and
+            # online data migrations, plus some refactoring to anything that
+            # needs to get a block device disk config, like spawn/migrate/swap
+            # and the LibvirtLiveMigrateBDMInfo would also need to store the
+            # value.
+            connection_info['multiattach'] = True
+
+        if do_driver_attach:
+            encryption = encryptors.get_encryption_metadata(
+                context, volume_api, volume_id, connection_info)
+
+            try:
+                virt_driver.attach_volume(
+                        context, connection_info, instance,
+                        self['mount_device'], disk_bus=self['disk_bus'],
+                        device_type=self['device_type'], encryption=encryption)
+            except Exception:
+                with excutils.save_and_reraise_exception():
+                    LOG.exception("Driver failed to attach volume "
+                                      "%(volume_id)s at %(mountpoint)s",
+                                  {'volume_id': volume_id,
+                                   'mountpoint': self['mount_device']},
+                                  instance=instance)
+                    volume_api.attachment_delete(context,
+                                                 attachment_id)
+
+        # NOTE(mriedem): save our current state so connection_info is in
+        # the database before the volume status goes to 'in-use' because
+        # after that we can detach and connection_info is required for
+        # detach.
+        # TODO(mriedem): Technically for the new flow, we shouldn't have to
+        # rely on the BlockDeviceMapping.connection_info since it's stored
+        # with the attachment in Cinder (see refresh_connection_info).
+        # Therefore we should phase out code that relies on the
+        # BDM.connection_info and get it from Cinder if it's needed.
+        self['connection_info'] = connection_info
+        self.save()
+
+        try:
+            # This marks the volume as "in-use".
+            volume_api.attachment_complete(context, attachment_id)
+        except Exception:
+            with excutils.save_and_reraise_exception():
+                if do_driver_attach:
+                    # Disconnect the volume from the host.
+                    try:
+                        virt_driver.detach_volume(context,
+                                                  connection_info,
+                                                  instance,
+                                                  self['mount_device'],
+                                                  encryption=encryption)
+                    except Exception:
+                        LOG.warning("Driver failed to detach volume "
+                                    "%(volume_id)s at %(mount_point)s.",
+                                    {'volume_id': volume_id,
+                                     'mount_point': self['mount_device']},
+                                    exc_info=True, instance=instance)
+                # Delete the attachment to mark the volume as "available".
+                volume_api.attachment_delete(context, self['attachment_id'])
+
+    def _do_attach(self, context, instance, volume, volume_api, virt_driver,
+                   do_driver_attach):
+        """Private method that actually does the attach.
+
+        This is separate from the attach() method so the caller can optionally
+        lock this call.
+        """
+        context = context.elevated()
+        connector = virt_driver.get_volume_connector(instance)
+        if not self['attachment_id']:
+            self._legacy_volume_attach(context, volume, connector, instance,
+                                       volume_api, virt_driver,
+                                       do_driver_attach)
+        else:
+            self._volume_attach(context, volume, connector, instance,
+                                volume_api, virt_driver,
+                                self['attachment_id'],
+                                do_driver_attach)
+
+    @update_db
+    def attach(self, context, instance, volume_api, virt_driver,
+               do_driver_attach=False, **kwargs):
+        volume = self._get_volume(context, volume_api, self.volume_id)
+        volume_api.check_availability_zone(context, volume,
+                                           instance=instance)
+        # Let OS-Brick handle high level locking that covers the call to
+        # Cinder that exports & maps the volume, and for the local os-brick
+        # attach.  Not all volume backends or hosts require locking.
+        with brick_utils.guard_connection(volume):
+            self._do_attach(context, instance, volume, volume_api,
+                            virt_driver, do_driver_attach)
+
+    @update_db
+    def refresh_connection_info(self, context, instance,
+                                volume_api, virt_driver):
+        # NOTE (ndipanov): A no-op if there is no connection info already
+        if not self['connection_info']:
+            return
+
+        if not self['attachment_id']:
+            connector = virt_driver.get_volume_connector(instance)
+            connection_info = volume_api.initialize_connection(context,
+                                                               self.volume_id,
+                                                               connector)
+        else:
+            attachment_ref = volume_api.attachment_get(context,
+                                                       self['attachment_id'])
+            # The _volume_attach method stashes a 'multiattach' flag in the
+            # BlockDeviceMapping.connection_info which is not persisted back
+            # in cinder so before we overwrite the BDM.connection_info (via
+            # the update_db decorator on this method), we need to make sure
+            # and preserve the multiattach flag if it's set. Note that this
+            # is safe to do across refreshes because the multiattach capability
+            # of a volume cannot be changed while the volume is in-use.
+            multiattach = self['connection_info'].get('multiattach', False)
+            connection_info = attachment_ref['connection_info']
+            if multiattach:
+                connection_info['multiattach'] = True
+
+        # Rewrite the connection_info using the list of mons in ceph.conf
+        mons = []
+
+        try:
+            with open('/etc/ceph/ceph.conf', 'r') as config_file:
+                config = ConfigParser()
+                config.read_file(config_file)
+                mon_host = config['global']['mon host']
+                t_mons = [h.strip() for h in mon_host.split(',')]
+                validated_mons = [IPv4Address(host) for host in t_mons]
+                mons = t_mons
+        except (FileNotFoundError, KeyError, ValueError) as exception:
+            LOG.error('ceph-mon-migration: {0}'.format(str(exception)))
+
+        if len(mons) and 'hosts' in connection_info.get('data', {}):
+            connection_info['data']['hosts'] = mons
+
+        if 'serial' not in connection_info:
+            connection_info['serial'] = self.volume_id
+        self._preserve_multipath_id(connection_info)
+        self['connection_info'] = connection_info
+
+    def save(self):
+        # NOTE(ndipanov): we might want to generalize this by adding it to the
+        # _update_on_save and adding a transformation function.
+        try:
+            connection_info_string = jsonutils.dumps(
+                self.get('connection_info'))
+            if connection_info_string != self._bdm_obj.connection_info:
+                self._bdm_obj.connection_info = connection_info_string
+        except TypeError:
+            pass
+        super(DriverVolumeBlockDevice, self).save()
+
+    def _call_wait_func(self, context, wait_func, volume_api, volume_id):
+        try:
+            wait_func(context, volume_id)
+        except exception.VolumeNotCreated:
+            with excutils.save_and_reraise_exception():
+                if self['delete_on_termination']:
+                    try:
+                        volume_api.delete(context, volume_id)
+                    except Exception as exc:
+                        LOG.warning(
+                            'Failed to delete volume: %(volume_id)s '
+                            'due to %(exc)s',
+                            {'volume_id': volume_id, 'exc': exc})
+
+
+class DriverVolSnapshotBlockDevice(DriverVolumeBlockDevice):
+
+    _valid_source = 'snapshot'
+    _proxy_as_attr_inherited = set(['snapshot_id'])
+
+    def attach(self, context, instance, volume_api,
+               virt_driver, wait_func=None):
+
+        if not self.volume_id:
+            snapshot = volume_api.get_snapshot(context,
+                                               self.snapshot_id)
+            # NOTE(lyarwood): Try to use the original volume type if one isn't
+            # set against the bdm but is on the original volume.
+            if not self.volume_type and snapshot.get('volume_id'):
+                snap_volume_id = snapshot.get('volume_id')
+                orig_volume = volume_api.get(context, snap_volume_id)
+                self.volume_type = orig_volume.get('volume_type_id')
+
+            self.volume_id, self.attachment_id = self._create_volume(
+                context, instance, volume_api, self.volume_size,
+                wait_func=wait_func, snapshot=snapshot)
+
+        # Call the volume attach now
+        super(DriverVolSnapshotBlockDevice, self).attach(
+            context, instance, volume_api, virt_driver)
+
+
+class DriverVolImageBlockDevice(DriverVolumeBlockDevice):
+
+    _valid_source = 'image'
+    _proxy_as_attr_inherited = set(['image_id'])
+
+    def attach(self, context, instance, volume_api,
+               virt_driver, wait_func=None):
+        if not self.volume_id:
+            self.volume_id, self.attachment_id = self._create_volume(
+                context, instance, volume_api, self.volume_size,
+                wait_func=wait_func, image_id=self.image_id)
+
+        super(DriverVolImageBlockDevice, self).attach(
+            context, instance, volume_api, virt_driver)
+
+
+class DriverVolBlankBlockDevice(DriverVolumeBlockDevice):
+
+    _valid_source = 'blank'
+    _proxy_as_attr_inherited = set(['image_id'])
+
+    def attach(self, context, instance, volume_api,
+               virt_driver, wait_func=None):
+        if not self.volume_id:
+            vol_name = instance.uuid + '-blank-vol'
+            self.volume_id, self.attachment_id = self._create_volume(
+                context, instance, volume_api, self.volume_size,
+                wait_func=wait_func, name=vol_name)
+
+        super(DriverVolBlankBlockDevice, self).attach(
+            context, instance, volume_api, virt_driver)
+
+
+def _convert_block_devices(device_type, block_device_mapping):
+    devices = []
+    for bdm in block_device_mapping:
+        try:
+            devices.append(device_type(bdm))
+        except _NotTransformable:
+            pass
+
+    return devices
+
+
+convert_swap = functools.partial(_convert_block_devices,
+                                 DriverSwapBlockDevice)
+
+
+convert_ephemerals = functools.partial(_convert_block_devices,
+                                      DriverEphemeralBlockDevice)
+
+
+convert_volumes = functools.partial(_convert_block_devices,
+                                   DriverVolumeBlockDevice)
+
+
+convert_snapshots = functools.partial(_convert_block_devices,
+                                     DriverVolSnapshotBlockDevice)
+
+convert_images = functools.partial(_convert_block_devices,
+                                     DriverVolImageBlockDevice)
+
+convert_blanks = functools.partial(_convert_block_devices,
+                                   DriverVolBlankBlockDevice)
+
+
+def convert_all_volumes(*volume_bdms):
+    source_volume = convert_volumes(volume_bdms)
+    source_snapshot = convert_snapshots(volume_bdms)
+    source_image = convert_images(volume_bdms)
+    source_blank = convert_blanks(volume_bdms)
+
+    return [vol for vol in
+            itertools.chain(source_volume, source_snapshot,
+                            source_image, source_blank)]
+
+
+def convert_volume(volume_bdm):
+    try:
+        return convert_all_volumes(volume_bdm)[0]
+    except IndexError:
+        pass
+
+
+def attach_block_devices(block_device_mapping, *attach_args, **attach_kwargs):
+    def _log_and_attach(bdm):
+        instance = attach_args[1]
+        if bdm.get('volume_id'):
+            LOG.info('Booting with volume %(volume_id)s at '
+                     '%(mountpoint)s',
+                     {'volume_id': bdm.volume_id,
+                      'mountpoint': bdm['mount_device']},
+                     instance=instance)
+        elif bdm.get('snapshot_id'):
+            LOG.info('Booting with volume snapshot %(snapshot_id)s at '
+                     '%(mountpoint)s',
+                     {'snapshot_id': bdm.snapshot_id,
+                      'mountpoint': bdm['mount_device']},
+                     instance=instance)
+        elif bdm.get('image_id'):
+            LOG.info('Booting with volume-backed-image %(image_id)s at '
+                     '%(mountpoint)s',
+                     {'image_id': bdm.image_id,
+                      'mountpoint': bdm['mount_device']},
+                     instance=instance)
+        else:
+            LOG.info('Booting with blank volume at %(mountpoint)s',
+                     {'mountpoint': bdm['mount_device']},
+                     instance=instance)
+
+        bdm.attach(*attach_args, **attach_kwargs)
+
+    for device in block_device_mapping:
+        _log_and_attach(device)
+    return block_device_mapping
+
+
+def refresh_conn_infos(block_device_mapping, *refresh_args, **refresh_kwargs):
+    for device in block_device_mapping:
+        # NOTE(lyarwood): At present only DriverVolumeBlockDevice derived
+        # devices provide a refresh_connection_info method.
+        if hasattr(device, 'refresh_connection_info'):
+            device.refresh_connection_info(*refresh_args, **refresh_kwargs)
+    return block_device_mapping
+
+
+def legacy_block_devices(block_device_mapping):
+    bdms = [bdm.legacy() for bdm in block_device_mapping]
+
+    # Re-enumerate ephemeral devices
+    if all(isinstance(bdm, DriverEphemeralBlockDevice)
+           for bdm in block_device_mapping):
+        for i, dev in enumerate(bdms):
+            dev['virtual_name'] = dev['virtual_name'][:-1] + str(i)
+            dev['num'] = i
+
+    return bdms
+
+
+def get_swap(transformed_list):
+    """Get the swap device out of the list context.
+
+    The block_device_info needs swap to be a single device,
+    not a list - otherwise this is a no-op.
+    """
+    if not all(isinstance(device, DriverSwapBlockDevice) or
+               'swap_size' in device
+                for device in transformed_list):
+        return None
+    try:
+        return transformed_list.pop()
+    except IndexError:
+        return None
+
+
+_IMPLEMENTED_CLASSES = (DriverSwapBlockDevice, DriverEphemeralBlockDevice,
+                        DriverVolumeBlockDevice, DriverVolSnapshotBlockDevice,
+                        DriverVolImageBlockDevice, DriverVolBlankBlockDevice)
+
+
+def is_implemented(bdm):
+    for cls in _IMPLEMENTED_CLASSES:
+        try:
+            cls(bdm)
+            return True
+        except _NotTransformable:
+            pass
+    return False
+
+
+def is_block_device_mapping(bdm):
+    return (bdm.source_type in ('image', 'volume', 'snapshot', 'blank') and
+            bdm.destination_type == 'volume' and
+            is_implemented(bdm))
+
+
+def get_volume_id(connection_info):
+    if connection_info:
+        # Check for volume_id in 'data' and if not there, fallback to
+        # the 'serial' that the DriverVolumeBlockDevice adds during attach.
+        volume_id = connection_info.get('data', {}).get('volume_id')
+        if not volume_id:
+            volume_id = connection_info.get('serial')
+        return volume_id

--- a/chef/cookbooks/bcpc/files/default/nova/migration.py
+++ b/chef/cookbooks/bcpc/files/default/nova/migration.py
@@ -1,0 +1,749 @@
+# Copyright (c) 2016 Red Hat, Inc
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+"""Utility methods to manage guests migration
+
+"""
+
+from collections import deque
+from configparser import ConfigParser
+from ipaddress import AddressValueError, IPv4Address
+
+from lxml import etree
+from oslo_log import log as logging
+
+from nova.compute import power_state
+import nova.conf
+from nova import exception
+from nova import objects
+from nova.virt import hardware
+from nova.virt.libvirt import config as vconfig
+
+LOG = logging.getLogger(__name__)
+
+CONF = nova.conf.CONF
+
+# TODO(berrange): hack to avoid a "import libvirt" in this file.
+# Remove this and similar hacks in guest.py, driver.py, host.py
+# etc in Ocata.
+libvirt = None
+
+
+def graphics_listen_addrs(migrate_data):
+    """Returns listen addresses of vnc/spice from a LibvirtLiveMigrateData"""
+    listen_addrs = None
+    if (migrate_data.obj_attr_is_set('graphics_listen_addr_vnc') or
+            migrate_data.obj_attr_is_set('graphics_listen_addr_spice')):
+        listen_addrs = {'vnc': None, 'spice': None}
+    if migrate_data.obj_attr_is_set('graphics_listen_addr_vnc'):
+        listen_addrs['vnc'] = str(migrate_data.graphics_listen_addr_vnc)
+    if migrate_data.obj_attr_is_set('graphics_listen_addr_spice'):
+        listen_addrs['spice'] = str(
+            migrate_data.graphics_listen_addr_spice)
+    return listen_addrs
+
+
+def serial_listen_addr(migrate_data):
+    """Returns listen address serial from a LibvirtLiveMigrateData"""
+    listen_addr = None
+    # NOTE (markus_z/dansmith): Our own from_legacy_dict() code can return
+    # an object with nothing set here. That can happen based on the
+    # compute RPC version pin. Until we can bump that major (which we
+    # can do just before Ocata releases), we may still get a legacy
+    # dict over the wire, converted to an object, and thus is may be unset
+    # here.
+    if migrate_data.obj_attr_is_set('serial_listen_addr'):
+        # NOTE (markus_z): The value of 'serial_listen_addr' is either
+        # an IP address (as string type) or None. There's no need of a
+        # conversion, in fact, doing a string conversion of None leads to
+        # 'None', which is an invalid (string type) value here.
+        listen_addr = migrate_data.serial_listen_addr
+    return listen_addr
+
+
+# TODO(sahid): remove me for Q*
+def serial_listen_ports(migrate_data):
+    """Returns ports serial from a LibvirtLiveMigrateData"""
+    ports = []
+    if migrate_data.obj_attr_is_set('serial_listen_ports'):
+        ports = migrate_data.serial_listen_ports
+    return ports
+
+
+def get_updated_guest_xml(guest, migrate_data, get_volume_config,
+                          get_vif_config=None, new_resources=None):
+    xml_doc = etree.fromstring(guest.get_xml_desc(dump_migratable=True))
+    xml_doc = _update_graphics_xml(xml_doc, migrate_data)
+    xml_doc = _update_serial_xml(xml_doc, migrate_data)
+    xml_doc = _update_volume_xml(xml_doc, migrate_data, get_volume_config)
+    xml_doc = _rewrite_ceph_monitor_hosts(xml_doc)
+    xml_doc = _update_perf_events_xml(xml_doc, migrate_data)
+    xml_doc = _update_memory_backing_xml(xml_doc, migrate_data)
+    if get_vif_config is not None:
+        xml_doc = _update_vif_xml(xml_doc, migrate_data, get_vif_config)
+    if 'dst_numa_info' in migrate_data:
+        xml_doc = _update_numa_xml(xml_doc, migrate_data)
+    if new_resources:
+        xml_doc = _update_device_resources_xml(xml_doc, new_resources)
+    return etree.tostring(xml_doc, encoding='unicode')
+
+
+def _update_device_resources_xml(xml_doc, new_resources):
+    vpmems = []
+    for resource in new_resources:
+        if 'metadata' in resource:
+            res_meta = resource.metadata
+            if isinstance(res_meta, objects.LibvirtVPMEMDevice):
+                vpmems.append(res_meta)
+    # If there are other resources in the future, the xml should
+    # be updated here like vpmems
+    xml_doc = _update_vpmems_xml(xml_doc, vpmems)
+    return xml_doc
+
+
+def _update_vpmems_xml(xml_doc, vpmems):
+    memory_devices = xml_doc.findall("./devices/memory")
+    for pos, memory_dev in enumerate(memory_devices):
+        if memory_dev.get('model') == 'nvdimm':
+            devpath = memory_dev.find('./source/path')
+            devpath.text = vpmems[pos].devpath
+    return xml_doc
+
+
+def _update_numa_xml(xml_doc, migrate_data):
+    LOG.debug('_update_numa_xml input xml=%s',
+              etree.tostring(xml_doc, encoding='unicode', pretty_print=True))
+    info = migrate_data.dst_numa_info
+    # NOTE(artom) cpu_pins, cell_pins and emulator_pins should always come
+    # together, or not at all.
+    if ('cpu_pins' in info and
+          'cell_pins' in info and
+          'emulator_pins' in info):
+        for guest_id, host_ids in info.cpu_pins.items():
+            vcpupin = xml_doc.find(
+                './cputune/vcpupin[@vcpu="%d"]' % int(guest_id))
+            vcpupin.set('cpuset',
+                        hardware.format_cpu_spec(host_ids))
+
+        emulatorpin = xml_doc.find('./cputune/emulatorpin')
+        emulatorpin.set('cpuset',
+                        hardware.format_cpu_spec(info.emulator_pins))
+
+        all_cells = []
+        for guest_id, host_ids in info.cell_pins.items():
+            all_cells.extend(host_ids)
+            memnode = xml_doc.find(
+                './numatune/memnode[@cellid="%d"]' % int(guest_id))
+            memnode.set('nodeset',
+                        hardware.format_cpu_spec(host_ids))
+
+        memory = xml_doc.find('./numatune/memory')
+        memory.set('nodeset', hardware.format_cpu_spec(set(all_cells)))
+
+    if 'sched_vcpus' and 'sched_priority' in info:
+        cputune = xml_doc.find('./cputune')
+
+        # delete the old variant(s)
+        for elem in cputune.findall('./vcpusched'):
+            elem.getparent().remove(elem)
+
+        # ...and create a new, shiny one
+        vcpusched = vconfig.LibvirtConfigGuestCPUTuneVCPUSched()
+        vcpusched.vcpus = info.sched_vcpus
+        vcpusched.priority = info.sched_priority
+        # TODO(stephenfin): Stop assuming scheduler type. We currently only
+        # create these elements for real-time instances and 'fifo' is the only
+        # scheduler policy we currently support so this is reasonably safe to
+        # assume, but it's still unnecessary
+        vcpusched.scheduler = 'fifo'
+
+        cputune.append(vcpusched.format_dom())
+
+    LOG.debug('_update_numa_xml output xml=%s',
+              etree.tostring(xml_doc, encoding='unicode', pretty_print=True))
+
+    return xml_doc
+
+
+def _update_graphics_xml(xml_doc, migrate_data):
+    listen_addrs = graphics_listen_addrs(migrate_data)
+
+    # change over listen addresses
+    for dev in xml_doc.findall('./devices/graphics'):
+        gr_type = dev.get('type')
+        listen_tag = dev.find('listen')
+        if gr_type in ('vnc', 'spice'):
+            if listen_tag is not None:
+                listen_tag.set('address', listen_addrs[gr_type])
+            if dev.get('listen') is not None:
+                dev.set('listen', listen_addrs[gr_type])
+    return xml_doc
+
+
+def _update_serial_xml(xml_doc, migrate_data):
+    listen_addr = serial_listen_addr(migrate_data)
+    listen_ports = serial_listen_ports(migrate_data)
+
+    def set_listen_addr_and_port(source, listen_addr, serial_listen_ports):
+        # The XML nodes can be empty, which would make checks like
+        # "if source.get('host'):" different to an explicit check for
+        # None. That's why we have to check for None in this method.
+        if source.get('host') is not None:
+            source.set('host', listen_addr)
+        device = source.getparent()
+        target = device.find("target")
+        if target is not None and source.get('service') is not None:
+            port_index = int(target.get('port'))
+            # NOTE (markus_z): Previous releases might not give us the
+            # ports yet, that's why we have this check here.
+            if len(serial_listen_ports) > port_index:
+                source.set('service', str(serial_listen_ports[port_index]))
+
+    # This updates all "LibvirtConfigGuestSerial" devices
+    for source in xml_doc.findall("./devices/serial[@type='tcp']/source"):
+        set_listen_addr_and_port(source, listen_addr, listen_ports)
+
+    # This updates all "LibvirtConfigGuestConsole" devices
+    for source in xml_doc.findall("./devices/console[@type='tcp']/source"):
+        set_listen_addr_and_port(source, listen_addr, listen_ports)
+
+    return xml_doc
+
+
+def _update_volume_xml(xml_doc, migrate_data, get_volume_config):
+    """Update XML using device information of destination host."""
+    migrate_bdm_info = migrate_data.bdms
+
+    # Update volume xml
+    parser = etree.XMLParser(remove_blank_text=True)
+    disk_nodes = xml_doc.findall('./devices/disk')
+
+    bdm_info_by_serial = {x.serial: x for x in migrate_bdm_info}
+    for pos, disk_dev in enumerate(disk_nodes):
+        serial_source = disk_dev.findtext('serial')
+        bdm_info = bdm_info_by_serial.get(serial_source)
+        if (serial_source is None or
+            not bdm_info or not bdm_info.connection_info or
+            serial_source not in bdm_info_by_serial):
+            continue
+        conf = get_volume_config(
+            bdm_info.connection_info, bdm_info.as_disk_info())
+
+        if bdm_info.obj_attr_is_set('encryption_secret_uuid'):
+            conf.encryption = vconfig.LibvirtConfigGuestDiskEncryption()
+            conf.encryption.format = 'luks'
+            secret = vconfig.LibvirtConfigGuestDiskEncryptionSecret()
+            secret.type = 'passphrase'
+            secret.uuid = bdm_info.encryption_secret_uuid
+            conf.encryption.secret = secret
+
+        xml_doc2 = etree.XML(conf.to_xml(), parser)
+        serial_dest = xml_doc2.findtext('serial')
+
+        # Compare source serial and destination serial number.
+        # If these serial numbers match, continue the process.
+        if (serial_dest and (serial_source == serial_dest)):
+            LOG.debug("Find same serial number: pos=%(pos)s, "
+                      "serial=%(num)s",
+                      {'pos': pos, 'num': serial_source})
+            for cnt, item_src in enumerate(disk_dev):
+                # If source and destination have same item, update
+                # the item using destination value.
+                for item_dst in xml_doc2.findall(item_src.tag):
+                    if item_dst.tag != 'address':
+                        # hw address presented to guest must never change,
+                        # especially during live migration as it can be fatal
+                        disk_dev.remove(item_src)
+                        item_dst.tail = None
+                        disk_dev.insert(cnt, item_dst)
+
+            # If destination has additional items, thses items should be
+            # added here.
+            for item_dst in list(xml_doc2):
+                if item_dst.tag != 'address':
+                    # again, hw address presented to guest must never change
+                    item_dst.tail = None
+                    disk_dev.insert(cnt, item_dst)
+    return xml_doc
+
+
+def _rewrite_ceph_monitor_hosts(xml_doc):
+    """Rewrite monitor addresses for RBD volumes in the domain configuration
+
+    Extract monitor addresses from ceph.conf and overwrite whatever monitor
+    addresses associated with RBD volumes for the domain with these ones.
+    """
+    mons = []
+    try:
+        with open('/etc/ceph/ceph.conf', 'r') as config_file:
+            config = ConfigParser()
+            config.read_file(config_file)
+            mons = [h.strip() for h in config['global']['mon host'].split(',')]
+            validated_mons = [IPv4Address(host) for host in mons]
+    except (FileNotFoundError, KeyError, ValueError) as exception:
+        LOG.error('ceph-mon-migration: {0}'.format(str(exception)))
+        return xml_doc
+
+    for disk in xml_doc.findall('./devices/disk/source'):
+        if disk.get('protocol') != 'rbd':
+            continue
+
+        # Wax all the existing host pairs...
+        for host in disk.findall('host'):
+            disk.remove(host)
+
+        # ...and slot in the new mons
+        for mon_host in mons:
+            host = etree.SubElement(disk, 'host')
+            host.set('name', mon_host)
+            host.set('port', '6789')
+    return xml_doc
+
+
+def _update_perf_events_xml(xml_doc, migrate_data):
+    """Update XML by the supported events of destination host."""
+
+    supported_perf_events = []
+    old_xml_has_perf = True
+
+    if 'supported_perf_events' in migrate_data:
+        supported_perf_events = migrate_data.supported_perf_events
+
+    perf_events = xml_doc.findall('./perf')
+
+    # remove perf events from xml
+    if not perf_events:
+        perf_events = etree.Element("perf")
+        old_xml_has_perf = False
+    else:
+        perf_events = perf_events[0]
+        for _, event in enumerate(perf_events):
+            perf_events.remove(event)
+
+    if not supported_perf_events:
+        return xml_doc
+
+    # add supported perf events
+    for e in supported_perf_events:
+        new_event = etree.Element("event", enabled="yes", name=e)
+        perf_events.append(new_event)
+
+    if not old_xml_has_perf:
+        xml_doc.append(perf_events)
+
+    return xml_doc
+
+
+def _update_memory_backing_xml(xml_doc, migrate_data):
+    """Update libvirt domain XML for file-backed memory
+
+    If incoming XML has a memoryBacking element, remove access, source,
+    and allocation children elements to get it to a known consistent state.
+
+    If no incoming memoryBacking element, create one.
+
+    If destination wants file-backed memory, add source, access,
+    and allocation children.
+    """
+    old_xml_has_memory_backing = True
+    file_backed = False
+    discard = False
+
+    memory_backing = xml_doc.findall('./memoryBacking')
+
+    if 'dst_wants_file_backed_memory' in migrate_data:
+        file_backed = migrate_data.dst_wants_file_backed_memory
+
+    if 'file_backed_memory_discard' in migrate_data:
+        discard = migrate_data.file_backed_memory_discard
+
+    if not memory_backing:
+        # Create memoryBacking element
+        memory_backing = etree.Element("memoryBacking")
+        old_xml_has_memory_backing = False
+    else:
+        memory_backing = memory_backing[0]
+        # Remove existing file-backed memory tags, if they exist.
+        for name in ("access", "source", "allocation", "discard"):
+            tag = memory_backing.findall(name)
+            if tag:
+                memory_backing.remove(tag[0])
+
+    # Leave empty memoryBacking element
+    if not file_backed:
+        return xml_doc
+
+    # Add file_backed memoryBacking children
+    memory_backing.append(etree.Element("source", type="file"))
+    memory_backing.append(etree.Element("access", mode="shared"))
+    memory_backing.append(etree.Element("allocation", mode="immediate"))
+
+    if discard:
+        memory_backing.append(etree.Element("discard"))
+
+    if not old_xml_has_memory_backing:
+        xml_doc.append(memory_backing)
+
+    return xml_doc
+
+
+def _update_vif_xml(xml_doc, migrate_data, get_vif_config):
+    # Loop over each interface element in the original xml and find the
+    # corresponding vif based on mac and then overwrite the xml with the new
+    # attributes but maintain the order of the interfaces and maintain the
+    # guest pci address.
+    instance_uuid = xml_doc.findtext('uuid')
+    parser = etree.XMLParser(remove_blank_text=True)
+    interface_nodes = xml_doc.findall('./devices/interface')
+    migrate_vif_by_mac = {vif.source_vif['address']: vif
+                          for vif in migrate_data.vifs}
+    for interface_dev in interface_nodes:
+        mac = interface_dev.find('mac')
+        mac = mac if mac is not None else {}
+        mac_addr = mac.get('address')
+        if mac_addr:
+            migrate_vif = migrate_vif_by_mac[mac_addr]
+            vif = migrate_vif.get_dest_vif()
+            # get_vif_config is a partial function of
+            # nova.virt.libvirt.vif.LibvirtGenericVIFDriver.get_config
+            # with all but the 'vif' kwarg set already and returns a
+            # LibvirtConfigGuestInterface object.
+            vif_config = get_vif_config(vif=vif)
+        else:
+            # This shouldn't happen but if it does, we need to abort the
+            # migration.
+            raise exception.NovaException(
+                'Unable to find MAC address in interface XML for '
+                'instance %s: %s' % (
+                    instance_uuid,
+                    etree.tostring(interface_dev, encoding='unicode')))
+
+        # At this point we want to replace the interface elements with the
+        # destination vif config xml *except* for the guest PCI address.
+        conf_xml = vif_config.to_xml()
+        LOG.debug('Updating guest XML with vif config: %s', conf_xml,
+                  instance_uuid=instance_uuid)
+        dest_interface_elem = etree.XML(conf_xml, parser)
+        # Save off the hw address and MTU presented to the guest since that
+        # can't change during live migration.
+        address = interface_dev.find('address')
+        mtu = interface_dev.find('mtu')
+        # Now clear the interface's current elements and insert everything
+        # from the destination vif config xml.
+        interface_dev.clear()
+        # Insert attributes.
+        for attr_name, attr_value in dest_interface_elem.items():
+            interface_dev.set(attr_name, attr_value)
+        # Insert sub-elements.
+        for index, dest_interface_subelem in enumerate(dest_interface_elem):
+            # NOTE(mnaser): If we don't have an MTU, don't define one, else
+            #               the live migration will crash.
+            if dest_interface_subelem.tag == 'mtu' and mtu is None:
+                continue
+            interface_dev.insert(index, dest_interface_subelem)
+        # And finally re-insert the hw address.
+        interface_dev.insert(index + 1, address)
+
+    return xml_doc
+
+
+def find_job_type(guest, instance, logging_ok=True):
+    """Determine the (likely) current migration job type
+
+    :param guest: a nova.virt.libvirt.guest.Guest
+    :param instance: a nova.objects.Instance
+    :param logging_ok: If logging in this method is OK. If called from a
+        native thread then logging is generally prohibited.
+
+    Annoyingly when job type == NONE and migration is
+    no longer running, we don't know whether we stopped
+    because of failure or completion. We can distinguish
+    these cases by seeing if the VM still exists & is
+    running on the current host
+
+    :returns: a libvirt job type constant
+    """
+    def _log(func, msg, *args, **kwargs):
+        if logging_ok:
+            func(msg, *args, **kwargs)
+
+    try:
+        if guest.is_active():
+            _log(LOG.debug, "VM running on src, migration failed",
+                 instance=instance)
+            return libvirt.VIR_DOMAIN_JOB_FAILED
+        else:
+            _log(LOG.debug, "VM is shutoff, migration finished",
+                 instance=instance)
+            return libvirt.VIR_DOMAIN_JOB_COMPLETED
+    except libvirt.libvirtError as ex:
+        _log(LOG.debug, "Error checking domain status %(ex)s", {"ex": ex},
+             instance=instance)
+        if ex.get_error_code() == libvirt.VIR_ERR_NO_DOMAIN:
+            _log(LOG.debug, "VM is missing, migration finished",
+                 instance=instance)
+            return libvirt.VIR_DOMAIN_JOB_COMPLETED
+        else:
+            _log(LOG.info, "Error %(ex)s, migration failed", {"ex": ex},
+                 instance=instance)
+            return libvirt.VIR_DOMAIN_JOB_FAILED
+
+
+def should_trigger_timeout_action(instance, elapsed, completion_timeout,
+                                  migration_status):
+    """Determine if the migration timeout action should be triggered
+
+    :param instance: a nova.objects.Instance
+    :param elapsed: total elapsed time of migration in secs
+    :param completion_timeout: time in secs to allow for completion
+    :param migration_status: current status of the migration
+
+    Check the completion timeout to determine if it has been hit,
+    and should thus cause migration timeout action to be triggered.
+
+    Avoid migration to be aborted or triggered post-copy again if it is
+    running in post-copy mode
+
+    :returns: True if the migration completion timeout action should be
+              performed, False otherwise
+    """
+    if not completion_timeout:
+        return False
+
+    if migration_status == 'running (post-copy)':
+        return False
+
+    if elapsed > completion_timeout:
+        LOG.warning("Live migration not completed after %d sec",
+                    completion_timeout, instance=instance)
+        return True
+
+    return False
+
+
+def update_downtime(guest, instance,
+                    olddowntime,
+                    downtime_steps, elapsed):
+    """Update max downtime if needed
+
+    :param guest: a nova.virt.libvirt.guest.Guest to set downtime for
+    :param instance: a nova.objects.Instance
+    :param olddowntime: current set downtime, or None
+    :param downtime_steps: list of downtime steps
+    :param elapsed: total time of migration in secs
+
+    Determine if the maximum downtime needs to be increased
+    based on the downtime steps. Each element in the downtime
+    steps list should be a 2 element tuple. The first element
+    contains a time marker and the second element contains
+    the downtime value to set when the marker is hit.
+
+    The guest object will be used to change the current
+    downtime value on the instance.
+
+    Any errors hit when updating downtime will be ignored
+
+    :returns: the new downtime value
+    """
+    LOG.debug("Current %(dt)s elapsed %(elapsed)d steps %(steps)s",
+              {"dt": olddowntime, "elapsed": elapsed,
+               "steps": downtime_steps}, instance=instance)
+    thisstep = None
+    for step in downtime_steps:
+        if elapsed > step[0]:
+            thisstep = step
+
+    if thisstep is None:
+        LOG.debug("No current step", instance=instance)
+        return olddowntime
+
+    if thisstep[1] == olddowntime:
+        LOG.debug("Downtime does not need to change",
+                  instance=instance)
+        return olddowntime
+
+    LOG.info("Increasing downtime to %(downtime)d ms "
+             "after %(waittime)d sec elapsed time",
+             {"downtime": thisstep[1],
+              "waittime": thisstep[0]},
+             instance=instance)
+
+    try:
+        guest.migrate_configure_max_downtime(thisstep[1])
+    except libvirt.libvirtError as e:
+        LOG.warning("Unable to increase max downtime to %(time)d ms: %(e)s",
+                    {"time": thisstep[1], "e": e}, instance=instance)
+    return thisstep[1]
+
+
+def save_stats(instance, migration, info, remaining):
+    """Save migration stats to the database
+
+    :param instance: a nova.objects.Instance
+    :param migration: a nova.objects.Migration
+    :param info: a nova.virt.libvirt.guest.JobInfo
+    :param remaining: percentage data remaining to transfer
+
+    Update the migration and instance objects with
+    the latest available migration stats
+    """
+
+    # The fully detailed stats
+    migration.memory_total = info.memory_total
+    migration.memory_processed = info.memory_processed
+    migration.memory_remaining = info.memory_remaining
+    migration.disk_total = info.disk_total
+    migration.disk_processed = info.disk_processed
+    migration.disk_remaining = info.disk_remaining
+    migration.save()
+
+    # The coarse % completion stats
+    instance.progress = 100 - remaining
+    instance.save()
+
+
+def trigger_postcopy_switch(guest, instance, migration):
+    try:
+        guest.migrate_start_postcopy()
+    except libvirt.libvirtError as e:
+        LOG.warning("Failed to switch to post-copy live migration: %s",
+                    e, instance=instance)
+    else:
+        # NOTE(ltomas): Change the migration status to indicate that
+        # it is in post-copy active mode, i.e., the VM at
+        # destination is the active one
+        LOG.info("Switching to post-copy migration mode",
+                 instance=instance)
+        migration.status = 'running (post-copy)'
+        migration.save()
+
+
+def run_tasks(guest, instance, active_migrations, on_migration_failure,
+              migration, is_post_copy_enabled):
+    """Run any pending migration tasks
+
+    :param guest: a nova.virt.libvirt.guest.Guest
+    :param instance: a nova.objects.Instance
+    :param active_migrations: dict of active migrations
+    :param on_migration_failure: queue of recovery tasks
+    :param migration: a nova.objects.Migration
+    :param is_post_copy_enabled: True if post-copy can be used
+
+    Run any pending migration tasks queued against the
+    provided instance object. The active migrations dict
+    should use instance UUIDs for keys and a queue of
+    tasks as the values.
+
+    Currently the valid tasks that can be requested
+    are "pause" and "force-complete". Other tasks will
+    be ignored.
+    """
+
+    tasks = active_migrations.get(instance.uuid, deque())
+    while tasks:
+        task = tasks.popleft()
+        if task == 'force-complete':
+            if migration.status == 'running (post-copy)':
+                LOG.warning("Live-migration %s already switched "
+                            "to post-copy mode.",
+                            instance=instance)
+            elif is_post_copy_enabled:
+                trigger_postcopy_switch(guest, instance, migration)
+            else:
+                try:
+                    guest.pause()
+                    on_migration_failure.append("unpause")
+                except Exception as e:
+                    LOG.warning("Failed to pause instance during "
+                                "live-migration %s",
+                                e, instance=instance)
+        else:
+            LOG.warning("Unknown migration task '%(task)s'",
+                        {"task": task}, instance=instance)
+
+
+def run_recover_tasks(host, guest, instance, on_migration_failure):
+    """Run any pending migration recovery tasks
+
+    :param host: a nova.virt.libvirt.host.Host
+    :param guest: a nova.virt.libvirt.guest.Guest
+    :param instance: a nova.objects.Instance
+    :param on_migration_failure: queue of recovery tasks
+
+    Run any recovery tasks provided in the on_migration_failure
+    queue.
+
+    Currently the only valid task that can be requested
+    is "unpause". Other tasks will be ignored
+    """
+
+    while on_migration_failure:
+        task = on_migration_failure.popleft()
+        # NOTE(tdurakov): there is still possibility to leave
+        # instance paused in case of live-migration failure.
+        # This check guarantee that instance will be resumed
+        # in this case
+        if task == 'unpause':
+            try:
+                state = guest.get_power_state(host)
+                if state == power_state.PAUSED:
+                    guest.resume()
+            except Exception as e:
+                LOG.warning("Failed to resume paused instance "
+                            "before live-migration rollback %s",
+                            e, instance=instance)
+        else:
+            LOG.warning("Unknown migration task '%(task)s'",
+                        {"task": task}, instance=instance)
+
+
+def downtime_steps(data_gb):
+    '''Calculate downtime value steps and time between increases.
+
+    :param data_gb: total GB of RAM and disk to transfer
+
+    This looks at the total downtime steps and upper bound
+    downtime value and uses a linear function.
+
+    For example, with 10 steps, 30 second step delay, 3 GB
+    of RAM and 400ms target maximum downtime, the downtime will
+    be increased every 90 seconds in the following progression:
+
+    -   0 seconds -> set downtime to  40ms
+    -  90 seconds -> set downtime to  76ms
+    - 180 seconds -> set downtime to 112ms
+    - 270 seconds -> set downtime to 148ms
+    - 360 seconds -> set downtime to 184ms
+    - 450 seconds -> set downtime to 220ms
+    - 540 seconds -> set downtime to 256ms
+    - 630 seconds -> set downtime to 292ms
+    - 720 seconds -> set downtime to 328ms
+    - 810 seconds -> set downtime to 364ms
+    - 900 seconds -> set downtime to 400ms
+
+    This allows the guest a good chance to complete migration
+    with a small downtime value.
+    '''
+    downtime = CONF.libvirt.live_migration_downtime
+    steps = CONF.libvirt.live_migration_downtime_steps
+    delay = CONF.libvirt.live_migration_downtime_delay
+
+    delay = int(delay * data_gb)
+
+    base = downtime / steps
+    offset = (downtime - base) / steps
+
+    for i in range(steps + 1):
+        yield (int(delay * i), int(base + offset * i))

--- a/chef/cookbooks/bcpc/files/default/nova/migration.py
+++ b/chef/cookbooks/bcpc/files/default/nova/migration.py
@@ -282,12 +282,13 @@ def _update_volume_xml(xml_doc, migrate_data, get_volume_config):
 def _rewrite_ceph_monitor_hosts(xml_doc):
     """Rewrite monitor addresses for RBD volumes in the domain configuration
 
-    Extract monitor addresses from ceph.conf and overwrite whatever monitor
-    addresses associated with RBD volumes for the domain with these ones.
+    Extract monitor addresses from migration.conf and overwrite whatever
+    monitor addresses associated with RBD volumes for the domain with these
+    ones.
     """
     mons = []
     try:
-        with open('/etc/ceph/ceph.conf', 'r') as config_file:
+        with open('/etc/ceph/migration.conf', 'r') as config_file:
             config = ConfigParser()
             config.read_file(config_file)
             mons = [h.strip() for h in config['global']['mon host'].split(',')]

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -391,3 +391,17 @@ execute 'make sure cinder-volume comes up' do
   command 'systemctl start cinder-volume'
   not_if 'systemctl status cinder-volume'
 end
+
+# Add feature to source monitor addresses for volume attachments using values
+# from ceph.conf instead the monmap to faciliate Ceph monitor migration
+# exercises
+cookbook_file '/usr/lib/python3/dist-packages/cinder/volume/drivers/rbd.py' do
+  source 'cinder/rbd.py'
+  notifies :run, 'execute[py3compile-cinder]', :immediately
+  notifies :restart, 'service[cinder-volume]', :delayed
+end
+
+execute 'py3compile-cinder' do
+  action :nothing
+  command 'py3compile -p python3-cinder'
+end

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -393,8 +393,16 @@ execute 'make sure cinder-volume comes up' do
 end
 
 # Add feature to source monitor addresses for volume attachments using values
-# from ceph.conf instead the monmap to faciliate Ceph monitor migration
+# from migration.conf instead the monmap to faciliate Ceph monitor migration
 # exercises
+template '/etc/ceph/migration.conf' do
+  action node['bcpc']['ceph']['mon-migration']['enabled'] ? :create : :delete
+  source 'ceph/migration.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+
 cookbook_file '/usr/lib/python3/dist-packages/cinder/volume/drivers/rbd.py' do
   source 'cinder/rbd.py'
   notifies :run, 'execute[py3compile-cinder]', :immediately

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -260,7 +260,7 @@ cookbook_file '/usr/lib/python3/dist-packages/nova/virt/libvirt/vif.py' do
 end
 
 # Add feature to rewrite monitor addresses in the domain XML using values from
-# ceph.conf instead to faciliate Ceph monitor migration exercises
+# migration.conf instead to faciliate Ceph monitor migration exercises
 cookbook_file '/usr/lib/python3/dist-packages/nova/virt/libvirt/migration.py' do
   source 'nova/migration.py'
   notifies :run, 'execute[py3compile-nova]', :immediately
@@ -272,6 +272,14 @@ cookbook_file '/usr/lib/python3/dist-packages/nova/virt/block_device.py' do
   source 'nova/block_device.py'
   notifies :run, 'execute[py3compile-nova]', :immediately
   notifies :restart, 'service[nova-compute]', :delayed
+end
+
+template '/etc/ceph/migration.conf' do
+  action node['bcpc']['ceph']['mon-migration']['enabled'] ? :create : :delete
+  source 'ceph/migration.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
 end
 
 execute 'py3compile-nova' do

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -259,6 +259,21 @@ cookbook_file '/usr/lib/python3/dist-packages/nova/virt/libvirt/vif.py' do
   notifies :restart, 'service[nova-compute]', :delayed
 end
 
+# Add feature to rewrite monitor addresses in the domain XML using values from
+# ceph.conf instead to faciliate Ceph monitor migration exercises
+cookbook_file '/usr/lib/python3/dist-packages/nova/virt/libvirt/migration.py' do
+  source 'nova/migration.py'
+  notifies :run, 'execute[py3compile-nova]', :immediately
+  notifies :restart, 'service[nova-compute]', :delayed
+end
+
+# Do the same for nova.block_device_mappings when refreshing connection_info
+cookbook_file '/usr/lib/python3/dist-packages/nova/virt/block_device.py' do
+  source 'nova/block_device.py'
+  notifies :run, 'execute[py3compile-nova]', :immediately
+  notifies :restart, 'service[nova-compute]', :delayed
+end
+
 execute 'py3compile-nova' do
   action :nothing
   command 'py3compile -p python3-nova'

--- a/chef/cookbooks/bcpc/templates/default/ceph/migration.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/migration.conf.erb
@@ -1,0 +1,2 @@
+[global]
+mon host = <%= node['bcpc']['ceph']['mon-migration']['hosts'].join(',') %>


### PR DESCRIPTION
Add feature to assist migration of `ceph-mons`
    
This PR adds a feature to the Nova migration code to
overwrite `ceph-mon` addresses in the domain's XML
specification with those specified in the general section
of a `/etc/ceph/migration.conf` configuration file.
    
It does the same for newly created and refreshed Nova
block device mappings and Cinder attachments as well.
    
Together, this assists the IP address migration of `ceph-mon`
nodes, especially for VMs which have a long uptime, by
allowing an operator to reconfigure the set of `ceph-mon`
IPs via a single live-migration of each VM in the cluster.