### PR TITLE
Improve support for the vagrant-vbguest plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ pip install PyYaml ansible netaddr pyOpenSSL cryptography>=3.0
 To create a virtualbox build (the default):
 
 ```shell
+vagrant plugin install vagrant-vbguest
 make generate-chef-databags
 make create-packer-box
 make create all

--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -104,6 +104,15 @@ Vagrant.configure('2') do |config|
         vb.customize ['modifyvm', :id, '--uartmode2', 'disconnected']
         vb.customize ['modifyvm', :id, '--vram', '16']
 
+        # If the vagrant-vbguest plugin is installed, alter the plugin's default
+        # kernel module check as described in the following issue:
+        #   https://github.com/dotless-de/vagrant-vbguest/issues/421
+        # Otherwise, vbox guest additions are installed every time a machine is
+        # brought up or reloaded.
+        if Vagrant.has_plugin?('vagrant-vbguest')
+          config.vbguest.installer_options = { running_kernel_modules: ['vboxguest'] }
+        end
+
         # add additional hard drives
         if hw_profile.key?('ext_disks')
 

--- a/virtual/network/Vagrantfile
+++ b/virtual/network/Vagrantfile
@@ -45,6 +45,17 @@ def sspine_name(plane, sspine)
 end
 
 Vagrant.configure(2) do |config|
+  config.vm.provider 'virtualbox' do
+    # If the vagrant-vbguest plugin is installed, alter the plugin's default
+    # kernel module check as described in the following issue:
+    #   https://github.com/dotless-de/vagrant-vbguest/issues/421
+    # Otherwise, vbox guest additions are installed every time a machine is
+    # brought up or reloaded.
+    if Vagrant.has_plugin?('vagrant-vbguest')
+      config.vbguest.installer_options = { running_kernel_modules: ['vboxguest'] }
+    end
+  end
+
   if ENV.key?('BCC_DEPLOY_NETWORK_VM')
     config.vm.define 'network' do |node|
       config.vm.provider 'virtualbox' do |vb|


### PR DESCRIPTION
Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
As per https://github.com/dotless-de/vagrant-vbguest/issues/421, `vagrant-vbguest` sometimes does not correctly determine whether or not guest additions is actually running on a guest system. This PR updates the vagrant files with the best known workaround, as well as updates the README with instructions to install `vagrant-vbguest`.

**Testing performed**
Several internal jenkins-pipelines have been run to ensure that multiple topologies can be launched, and that this does not cause a regression in libvirt builds.