### PR TITLE
Add ability to set MTU of Calico OpenStack nets

### DIFF
--- a/chef/cookbooks/bcpc/files/default/neutron/datamodel_v3.py
+++ b/chef/cookbooks/bcpc/files/default/neutron/datamodel_v3.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+import uuid
+
+from networking_calico.compat import log
+from networking_calico import datamodel_v2
+from networking_calico import etcdv3
+from networking_calico.timestamp import timestamp_now
+
+# Particular JSON key strings.
+CLUSTER_GUID = 'clusterGUID'
+CLUSTER_TYPE = 'clusterType'
+DATASTORE_READY = 'datastoreReady'
+ENDPOINT_REPORTING_ENABLED = 'endpointReportingEnabled'
+INTERFACE_PREFIX = 'interfacePrefix'
+
+# Annotation keys.
+ANN_KEY_PREFIX = 'openstack.projectcalico.org/'
+ANN_KEY_FQDN = ANN_KEY_PREFIX + 'fqdn'
+ANN_KEY_NETWORK_ID = ANN_KEY_PREFIX + 'network-id'
+ANN_KEY_NETWORK_MTU = ANN_KEY_PREFIX + 'network-mtu'
+
+# Namespace constants.
+NO_REGION_NAMESPACE = 'openstack'
+REGION_NAMESPACE_PREFIX = 'openstack-'
+NOT_NAMESPACED = None
+
+
+LOG = log.getLogger(__name__)
+
+
+def put(resource_kind, namespace, name, spec, annotations={}, labels=None,
+        mod_revision=None):
+    """Write a Calico v3 resource to etcdv3.
+
+    - resource_kind (string): E.g. WorkloadEndpoint, Profile, etc.
+
+    - name (string): The resource's name.  This is used to form its etcd key,
+      and also goes in its .Metadata.Name field.
+
+    - namespace (string): The namespace to put the resource in.
+
+    - spec (dict): Resource spec, as a dict with keys as specified by the
+      'json:' comments in the relevant golang struct definition (for example,
+      https://github.com/projectcalico/libcalico-go/blob/master/
+      lib/apis/v3/workloadendpoint.go#L38).
+
+    - annotations (dict): Annotations to set on the resource.  These are merged
+      with existing annotations; i.e. existing annotations with other keys are
+      unchanged, and existing annotations with the same keys are overwritten by
+      these new values.
+
+    - mod_revision: If 0 (a number), indicates that the write should only
+      proceed if it _creates_ the resource.  Else, if etcdv3.MUST_UPDATE,
+      indicates that the write should only proceed if it _does not create_ the
+      resource.  Else, if not None, must be a number encoded as a string,
+      e.g. "12345", and indicates that the write should only proceed if
+      replacing an existing value with that mod_revision.
+
+    Returns True if the write happened successfully; False if not.
+    """
+    key = _build_key(resource_kind, namespace, name)
+    value = None
+    try:
+        # Get the existing resource so we can persist its metadata.
+        value, _ = _get_with_metadata(resource_kind, namespace, name)
+    except etcdv3.KeyNotFound:
+        pass
+    except ValueError:
+        LOG.warning("etcd value not valid JSON, so ignoring")
+    if value is None:
+        # Build basic resource structure.
+        value = {
+            'kind': resource_kind,
+            'apiVersion': 'projectcalico.org/v3',
+            'metadata': {
+                'name': name,
+            },
+        }
+    # Ensure namespace set, for a namespaced resource.
+    if _is_namespaced(resource_kind):
+        assert namespace is not None
+        value['metadata']['namespace'] = namespace
+    # Ensure that there is a creation timestamp.
+    if 'creationTimestamp' not in value['metadata']:
+        value['metadata']['creationTimestamp'] = timestamp_now()
+    # Ensure that there is a UID.
+    if 'uid' not in value['metadata']:
+        value['metadata']['uid'] = str(uuid.uuid4())
+    # Set annotations and labels if specified.  (We previously used to merge
+    # here, instead of overwriting, but (a) for annotations there is actually
+    # no use case for that, because we only use annotations on endpoints for
+    # which Neutron is the sole source of truth; and (b) for the use case where
+    # labels are used to represent security group membership it is crucial that
+    # we overwrite and don't merge; otherwise a VM could never be removed from
+    # a security group.)
+    if annotations:
+        value['metadata']['annotations'] = annotations
+    if labels:
+        value['metadata']['labels'] = labels
+    # Set the new spec (overriding whatever may already be there).
+    value['spec'] = spec
+    return etcdv3.put(key, json.dumps(value), mod_revision=mod_revision)
+
+
+def get(resource_kind, name):
+    """Read spec of a non-namespaced Calico v3 resource from etcdv3.
+
+    - resource_kind (string): E.g. ClusterInformation.
+
+    - name (string): The resource's name, which is used to form its etcd key.
+
+    Returns (spec, mod_revision) where
+
+    - spec is the resource spec as a dict with keys as specified by the 'json:'
+      comments in the relevant golang struct definition (for example,
+      https://github.com/projectcalico/libcalico-go/blob/master/
+      lib/apis/v3/clusterinfo.go#L39).
+
+    - mod_revision is the etcdv3 revision at which the resource was last
+      modified.
+
+    Raises etcdv3.KeyNotFound if there is no resource with that kind and name.
+    """
+    value, mod_revision = _get_with_metadata(resource_kind,
+                                             NOT_NAMESPACED,
+                                             name)
+    return value['spec'], mod_revision
+
+
+def delete_legacy(resource_kind, name_prefix=''):
+    key = _build_key(resource_kind, NO_REGION_NAMESPACE, name_prefix)
+    etcdv3.delete_prefix(key)
+
+
+def get_all(resource_kind, namespace,
+            with_labels_and_annotations=False, revision=None):
+    """Read all Calico v3 resources of a certain kind from etcdv3.
+
+    - resource_kind (string): E.g. WorkloadEndpoint, Profile, etc.
+
+    - namespace (string): The namespace to get resources for.
+
+    - with_labels_and_annotations: If True, indicates to return the labels and
+      annotations for each resource as well as the spec.
+
+    - revision: if specified, the get is performed at the given revision
+      as a snapshot.
+
+    Returns a list of tuples (name, spec, mod_revision) or (name, (spec,
+    labels, annotations), mod_revision), one for each resource of the specified
+    kind, in which:
+
+    - name is the resource's name (a string)
+
+    - spec is a dict with keys as specified by the 'json:' comments in the
+      relevant golang struct definition (for example,
+      https://github.com/projectcalico/libcalico-go/blob/master/
+      lib/apis/v3/workloadendpoint.go#L38).
+
+    - labels is a dict containing the resource's labels
+
+    - annotations is a dict containing the resource's annotations
+
+    - mod_revision is the revision at which that resource was last modified (an
+      integer represented as a string).
+    """
+    prefix = _build_key(resource_kind, namespace, '')
+    results = etcdv3.get_prefix(prefix, revision=revision)
+    tuples = []
+    for result in results:
+        key, value, mod_revision = result
+        name = key.split('/')[-1]
+
+        # Decode the value.
+        spec = labels = annotations = None
+        try:
+            value_dict = json.loads(value)
+            LOG.debug("value dict: %s", value_dict)
+            spec = value_dict['spec']
+            labels = value_dict['metadata'].get('labels', {})
+            annotations = value_dict['metadata'].get('annotations', {})
+        except ValueError:
+            # When the value is not valid JSON, we still return a tuple for
+            # this key, with spec, labels and annotations all as None.  This is
+            # so that the caller can correctly differentiate between
+            # overwriting an existing value (which => a transaction with
+            # specified mod_revision) and creating a key that did not exist
+            # before (=> a transaction with version 0).
+            LOG.warning("etcd value not valid JSON (%s)", value)
+
+        if with_labels_and_annotations:
+            t = (name, (spec, labels, annotations), mod_revision)
+        else:
+            t = (name, spec, mod_revision)
+        tuples.append(t)
+    return tuples
+
+
+def delete(resource_kind, namespace, name, mod_revision=None):
+    """Delete a Calico v3 resource from etcdv3.
+
+    - resource_kind (string): E.g. WorkloadEndpoint, Profile, etc.
+
+    - namespace (string): The namespace to delete the resource in.
+
+    - name (string): The resource's name, which is used to form its etcd key.
+
+    Returns True if the deletion was successful; False if not.
+    """
+    key = _build_key(resource_kind, namespace, name)
+    return etcdv3.delete(key, mod_revision=mod_revision)
+
+
+SANITIZE_LABEL_MAX_LENGTH = 63
+
+
+def sanitize_label_name_value(name, max_length):
+    """Sanitize a label name or value.
+
+    By converting unsupported characters to '_' and ensuring that the first and
+    last characters are alphanumeric, and that the length is within a specified
+    maximum length.
+    """
+    name = re.sub('[^-_.A-Za-z0-9]', '_', name[:max_length])
+    # Ensure that the first character is alphanumeric, by deleting leading
+    # characters that are not alphanumeric.
+    m = re.match('^([^A-Za-z0-9]+)', name)
+    if m:
+        name = name[m.end(1):]
+    # Ensure that the last character is alphanumeric, by deleting trailing
+    # characters that are not alphanumeric.
+    m = re.match('.*?([^A-Za-z0-9]+)$', name)
+    if m:
+        name = name[:m.start(1)]
+
+    return name
+
+
+def _is_namespaced(resource_kind):
+    if resource_kind == "WorkloadEndpoint":
+        return True
+    if resource_kind == "NetworkPolicy":
+        return True
+    return False
+
+
+def _plural(resource_kind):
+    if resource_kind == "NetworkPolicy":
+        return "NetworkPolicies"
+    if resource_kind == "GlobalNetworkPolicy":
+        return "GlobalNetworkPolicies"
+    return resource_kind + "s"
+
+
+def get_namespace(region_string):
+    if region_string is not None and region_string != datamodel_v2.NO_REGION:
+        return REGION_NAMESPACE_PREFIX + region_string
+    else:
+        return NO_REGION_NAMESPACE
+
+
+def _build_key(resource_kind, namespace, name):
+    kind_plural = _plural(resource_kind).lower()
+    if _is_namespaced(resource_kind):
+        assert namespace is not None
+        return "/calico/resources/v3/projectcalico.org/%s/%s/%s" % (
+            kind_plural, namespace, name
+        )
+    else:
+        return "/calico/resources/v3/projectcalico.org/%s/%s" % (
+            kind_plural, name
+        )
+
+
+def _get_with_metadata(resource_kind, namespace, name):
+    # Note: 'with_metadata' here means including the Calico data model
+    # metadata, as well as the etcdv3 mod_revision.
+    key = _build_key(resource_kind, namespace, name)
+    value_as_string, mod_revision = etcdv3.get(key)
+    value = json.loads(value_as_string)
+    return value, mod_revision

--- a/chef/cookbooks/bcpc/files/default/neutron/dhcp_agent.py
+++ b/chef/cookbooks/bcpc/files/default/neutron/dhcp_agent.py
@@ -1,0 +1,724 @@
+# Copyright 2012 OpenStack Foundation
+# Copyright 2015 Metaswitch Networks
+# Copyright 2016, 2018 Tigera, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import logging
+import netaddr
+import os
+import socket
+import sys
+
+import eventlet
+eventlet.monkey_patch()
+
+from neutron.agent.dhcp.agent import DhcpAgent
+from neutron.agent.dhcp_agent import register_options
+from neutron.agent.linux import dhcp
+from neutron.common import config as common_config
+try:
+    from neutron.conf.agent import common as config
+except ImportError:
+    # Neutron code prior to 7f23ccc (15th March 2017).
+    from neutron.agent.common import config
+
+from networking_calico.agent.linux.dhcp import DnsmasqRouted
+from networking_calico.common import config as calico_config
+from networking_calico.common import mkdir_p
+from networking_calico.compat import cfg
+from networking_calico.compat import constants
+from networking_calico.compat import DHCPV6_STATEFUL
+from networking_calico import datamodel_v1
+from networking_calico import datamodel_v2
+from networking_calico import datamodel_v3
+from networking_calico import etcdutils
+
+from etcd3gw.exceptions import Etcd3Exception
+
+LOG = logging.getLogger(__name__)
+
+NETWORK_ID = 'calico'
+
+
+class FakePlugin(object):
+    """Fake plugin class.
+
+    This class exists to support various calls that
+    neutron.agent.linux.dhcp.Dnsmasq makes to what it thinks is the Neutron
+    database (aka the plugin).
+
+    The calls are create_dhcp_port, update_dhcp_port and release_dhcp_port, and
+    the docstring for each corresponding method below indicates how they are
+    called.
+
+    However, update_dhcp_port is never called in the Calico setup, because it
+    is only used when there is a change to the set of Neutron-allocated IP
+    addresses that are associated with the DHCP port.  In the Calico setup, we
+    use gateway IPs on the DHCP port instead of any new Neutron allocations,
+    hence the situation just described can never happen.  Therefore we don't
+    provide any code for update_dhcp_port.
+
+    Because this class doesn't speak to the real Neutron database, it follows
+    that the DHCP interface that we create on each compute host does not show
+    up as a port in the Neutron database.  That doesn't matter, because we
+    don't allocate a unique IP for each DHCP port, and hence don't consume any
+    IPs that the Neutron database ought to know about.
+
+    """
+
+    def create_dhcp_port(self, port):
+        """Support the following DHCP DeviceManager calls.
+
+        dhcp_port = self.plugin.create_dhcp_port({'port': port_dict})
+        """
+        LOG.debug("create_dhcp_port: %s", port)
+        port['port']['id'] = port['port']['network_id']
+
+        # The following MAC address will be assigned to the Linux dummy
+        # interface that
+        # networking_calico.agent.linux.interface.RoutedInterfaceDriver
+        # creates.  Therefore it will never actually be used or involved in the
+        # sending or receiving of any real data.  Hence it should not matter
+        # that we use a hardcoded value here, and the same value on every
+        # networking-calico compute host.  The '2' bit of the first byte means
+        # 'locally administered', which makes sense for a hardcoded value like
+        # this and distinguishes it from the space of managed MAC addresses.
+        port['port']['mac_address'] = '02:00:00:00:00:00'
+        port['port']['device_owner'] = constants.DEVICE_OWNER_DHCP
+        return dhcp.DictModel(port['port'])
+
+    def release_dhcp_port(self, network_id, device_id):
+        """Support the following DHCP DeviceManager calls.
+
+        self.plugin.release_dhcp_port(network.id,
+                                      self.get_device_id(network))
+        """
+        LOG.debug("release_dhcp_port: %s %s", network_id, device_id)
+
+    get_networks = None
+
+
+def empty_network(network_id=NETWORK_ID,
+                  network_mtu=constants.DEFAULT_NETWORK_MTU):
+    """Construct and return an empty network model."""
+    return make_net_model({"id": network_id,
+                           "subnets": [],
+                           "ports": [],
+                           "tenant_id": "calico",
+                           "mtu": network_mtu})
+
+
+def copy_network(source_net):
+    """Construct and return a copy of an existing network model."""
+    return make_net_model({"id": source_net.id,
+                           "subnets": source_net.subnets,
+                           "ports": source_net.ports,
+                           "tenant_id": source_net.tenant_id,
+                           "mtu": source_net.mtu})
+
+
+def make_net_model(net_spec):
+    try:
+        net_model = dhcp.NetModel(False, net_spec)
+    except TypeError:
+        # use_namespace option was removed during Mitaka cycle.
+        net_model = dhcp.NetModel(net_spec)
+        net_model._ns_name = None
+
+    return net_model
+
+
+def split_endpoint_name(name):
+    parts = name.replace('--', '#').split('-')
+    return tuple([p.replace('#', '-') for p in parts])
+
+
+class CalicoEtcdWatcher(etcdutils.EtcdWatcher):
+
+    def __init__(self, agent, hostname):
+        self.region_string = calico_config.get_region_string()
+        workload_endpoint_prefix = datamodel_v3._build_key(
+            "WorkloadEndpoint",
+            datamodel_v3.get_namespace(self.region_string),
+            "",
+        )
+        this_host_prefix = (workload_endpoint_prefix +
+                            hostname.replace('-', '--') +
+                            "-openstack-")
+
+        super(CalicoEtcdWatcher, self).__init__(this_host_prefix)
+        self.agent = agent
+        self.hostname = hostname
+        self.suppress_dnsmasq_updates = False
+
+        # Register the etcd paths that we need to watch.
+        self.register_path(workload_endpoint_prefix + "<name>",
+                           on_set=self.on_endpoint_set,
+                           on_del=self.on_endpoint_delete)
+
+        # Networks for which Dnsmasq needs updating.
+        self.dirty_networks = set()
+
+        # Also watch the etcd subnet trees: both the new region-aware
+        # one, and the old pre-region one, so as to support a VM
+        # renewing its DHCP lease while an upgrade is still in
+        # progress.  When something in that subtree changes, the
+        # subnet watcher will tell _this_ watcher to resync.
+        self.v1_subnet_watcher = SubnetWatcher(self, datamodel_v1.SUBNET_DIR)
+        self.subnet_watcher = SubnetWatcher(
+            self,
+            datamodel_v2.subnet_dir(self.region_string))
+
+        # Cache of the ports that we've asked Dnsmasq to handle, for each
+        # network ID.
+        self._last_dnsmasq_ports = {}
+        self._last_dnsmasq_mtu = {}
+
+        # Cache of current local endpoint IDs.
+        self.local_endpoint_ids = set()
+
+    def start(self):
+        eventlet.spawn(self.v1_subnet_watcher.start)
+        eventlet.spawn(self.subnet_watcher.start)
+        super(CalicoEtcdWatcher, self).start()
+
+    def on_endpoint_set(self, response, name):
+        """Handler for endpoint creations and updates.
+
+        Endpoint data is, for example:
+
+        { 'interfaceName': port['interface_name'],
+          'mac': port['mac_address'],
+          'profiles': port['security_groups'],
+          'ipNetworks': ['10.28.0.2/32', '2001:db8:1::2/128'],
+          'ipv4Gateway': '10.28.0.1',
+          'ipv6Gateway': '2001:db8:1::1' }
+
+        Port properties needed by DHCP code are:
+
+        { 'id': <unique ID>,
+          'network_id': <network ID>,
+          'device_owner': 'calico',
+          'device_id': <Linux interface name>,
+          'fixed_ips': [ { 'subnet_id': <subnet ID>,
+                           'ip_address': '10.28.0.2' } ],
+          'mac_address: <MAC address>,
+          'extra_dhcp_opts': ... (optional) }
+
+        Network properties are:
+
+        { 'subnets': [ <subnet object> ],
+          'id': <network ID>,
+          'namespace': None,
+          'ports: [ <port object> ],
+          'tenant_id': ? }
+
+        Subnet properties are:
+
+        { 'network_id': <network ID>,
+          'enable_dhcp': True,
+          'ip_version': 4 or 6,
+          'cidr': '10.28.0.0/24',
+          'dns_nameservers': [],
+          'id': <subnet ID>,
+          'gateway_ip': <gateway IP address>,
+          'host_routes': [],
+          'ipv6_address_mode': 'dhcpv6-stateful' | 'dhcpv6-stateless',
+          'ipv6_ra_mode': 'dhcpv6-stateful' | 'dhcpv6-stateless' }
+        """
+        try:
+            hostname, orchestrator, workload_id, endpoint_id = \
+                split_endpoint_name(name)
+        except ValueError:
+            # For some reason this endpoint's name does not have the expected
+            # form.  Ignore it.
+            LOG.warning("Unexpected form for endpoint name: %s", name)
+            return
+
+        if hostname != self.hostname:
+            LOG.info("Endpoint not on this node: %s", name)
+            return
+
+        # Get the endpoint spec.
+        endpoint = etcdutils.safe_decode_json(response.value, 'endpoint')
+        if not (isinstance(endpoint, dict) and
+                'spec' in endpoint and
+                isinstance(endpoint['spec'], dict) and
+                'interfaceName' in endpoint['spec'] and
+                'ipNetworks' in endpoint['spec'] and
+                'mac' in endpoint['spec']):
+            # Endpoint data is invalid; treat as deletion.
+            LOG.warning("Invalid endpoint data: %s => %s",
+                        response.value, endpoint)
+            self.on_endpoint_delete(None, name)
+            return
+        annotations = endpoint.get('metadata', {}).get('annotations', {})
+        endpoint = endpoint['spec']
+
+        # If the endpoint has no ipNetworks, treat as deletion.  This happens
+        # when a resync from the mechanism driver overlaps with a port/VM being
+        # deleted.
+        if not endpoint['ipNetworks']:
+            LOG.info("Endpoint has no ipNetworks: %s", endpoint)
+            self.on_endpoint_delete(None, name)
+            return
+
+        # Construct NetModel port equivalent of Calico's endpoint data.
+        fixed_ips = []
+        dns_assignments = []
+        fqdn = annotations.get(datamodel_v3.ANN_KEY_FQDN)
+        network_id = annotations.get(datamodel_v3.ANN_KEY_NETWORK_ID)
+        # The MTU annotation was retroactively added to the datamodel after the
+        # spec existed. To ensure that we do not break users who have endpoints
+        # in etcd without the MTU annotation, fallback to the previous default.
+        network_mtu = int(annotations.get(datamodel_v3.ANN_KEY_NETWORK_MTU,
+                                          constants.DEFAULT_NETWORK_MTU))
+        allowedIps = [e.split('/')[0] for e in endpoint.get('allowedIps', [])]
+        for addrm in endpoint['ipNetworks']:
+            ip_addr = addrm.split('/')[0]
+            if ip_addr in allowedIps:
+                continue
+            subnet_id = self.subnet_watcher.get_subnet_id_for_addr(
+                ip_addr,
+                network_id
+            ) or self.v1_subnet_watcher.get_subnet_id_for_addr(
+                ip_addr,
+                network_id
+            )
+            if subnet_id is None:
+                LOG.warning("Missing subnet data for one of port's IPs")
+                continue
+
+            fixed_ips.append({'subnet_id': subnet_id,
+                              'ip_address': ip_addr})
+
+            if fqdn:
+                dns_assignments.append({'hostname': fqdn.split('.')[0],
+                                        'ip_address': ip_addr,
+                                        'fqdn': fqdn})
+        if not fixed_ips:
+            LOG.warning("Endpoint has no DHCP-served IPs: %s", endpoint)
+            return
+
+        port = {'id': endpoint_id,
+                'device_owner': 'calico',
+                'device_id': endpoint['interfaceName'],
+                'fixed_ips': fixed_ips,
+                'mac_address': endpoint['mac'],
+                # FIXME: Calico currently does not pass through extra DHCP
+                # options, but it would be nice if it did.  Perhaps we could
+                # use an endpoint annotation, similarly as we do for the FQDN.
+                # https://bugs.launchpad.net/networking-calico/+bug/1553348
+                'extra_dhcp_opts': []}
+        if fqdn:
+            port['dns_assignment'] = dns_assignments
+
+        # Ensure that the cache includes the network and subnets for this port,
+        # and set the port's network ID correctly.
+        try:
+            port['network_id'] = self._ensure_net_and_subnets(port,
+                                                              network_mtu)
+        except SubnetIDNotFound:
+            LOG.warning("Missing data for one of port's subnets")
+            return
+
+        # Report this at INFO level if it is a new port.  Note, we
+        # come through this code periodically for existing ports also,
+        # because of how we watch the etcd DB for changes.
+        if endpoint_id not in self.local_endpoint_ids:
+            LOG.info("New port: %s", port)
+            self.local_endpoint_ids.add(endpoint_id)
+        else:
+            LOG.debug("Refresh already known port: %s", port)
+
+        # Add this port into the NetModel.
+        self.agent.cache.put_port(dhcp.DictModel(port))
+
+        # Schedule updating Dnsmasq.
+        self._update_dnsmasq(port['network_id'])
+
+    def _ensure_net_and_subnets(self, port, network_mtu):
+        """Ensure that the cache has a NetModel and subnets for PORT."""
+
+        # Gather the subnet IDs that we need for this port, and get the
+        # NetModel if we already have it in the cache.
+        needed_subnet_ids = set()
+        net = None
+        for fixed_ip in port['fixed_ips']:
+            subnet_id = fixed_ip.get('subnet_id')
+            if subnet_id:
+                needed_subnet_ids.add(subnet_id)
+                if not net:
+                    net = self.agent.cache.get_network_by_subnet_id(subnet_id)
+        LOG.debug("Needed subnet IDs: %s", needed_subnet_ids)
+        LOG.debug("Existing network model by subnet ID: %s", net)
+
+        # For each subnet that we need, get its data from SubnetWatcher and
+        # hold for adding into the cache.
+        new_subnets = {}
+        for subnet_id in needed_subnet_ids:
+            # Get data for this subnet from the SubnetWatchers.
+            subnet = (self.subnet_watcher.get_subnet(subnet_id) or
+                      self.v1_subnet_watcher.get_subnet(subnet_id))
+            if subnet is None:
+                LOG.warning("No data for subnet %s", subnet_id)
+                raise SubnetIDNotFound()
+            new_subnets[subnet_id] = subnet
+
+        if not net:
+            # We don't already have a NetModel, so look for a cached NetModel
+            # with the right network ID.  (In this case we must have new
+            # subnets to add into the cache, and the cached NetModel must have
+            # subnets other than the ones that we're adding in this iteration;
+            # otherwise we would have already found it when searching by
+            # subnet_id above.)
+            assert new_subnets
+            network_id = list(new_subnets.values())[0]['network_id']
+            net = self.agent.cache.get_network_by_id(network_id)
+            LOG.debug("Existing network model by network ID: %s", net)
+
+        if not net:
+            # We still have no NetModel for the relevant network ID, so create
+            # a new one.  In this case we _must_ be adding new subnets.
+            assert new_subnets
+            net = empty_network(network_id, network_mtu)
+            LOG.debug("New network %s", net)
+        elif new_subnets:
+            # We have a NetModel that was already in the cache and are about to
+            # modify it.  Cache replacement only works if the new NetModel is a
+            # distinct object from the existing one, so make a copy here.
+            net = copy_network(net)
+            LOG.debug("Copied network %s", net)
+
+        if new_subnets:
+            # Add the new subnets into the NetModel.
+            assert net
+            net.subnets = [s for s in net.subnets
+                           if s.id not in new_subnets]
+            net.subnets += list(new_subnets.values())
+
+            # Add (or update) the NetModel in the cache.
+            LOG.debug("Net: %s", net)
+            self._fix_network_cache_port_lookup(net.id)
+
+        # Flush any changes realized out to the NetCache.
+        if new_subnets or network_mtu != net.mtu:
+            net.mtu = network_mtu
+            self.agent.cache.put(net)
+
+        return net.id
+
+    def _fix_network_cache_port_lookup(self, network_id):
+        """Fix NetworkCache before removing or replacing a network.
+
+        neutron.agent.dhcp.agent is bugged in that it adds the DHCP port into
+        the cache without updating the cache's port_lookup dict, but then
+        NetworkCache.remove() barfs if there is a port in network.ports but not
+        in that dict...
+
+        NetworkCache.put() implicitly does a remove() first if there is already
+        a NetModel in the cache with the same ID.  So a put() to update or
+        replace a network also hits this problem.
+
+        This method avoids that problem by ensuring that all of a network's
+        ports are in the port_lookup dict.  A caller should call this
+        immediately before a remove() or a put().
+        """
+
+        # If there is an existing NetModel for this network ID, ensure that all
+        # its ports are in the port_lookup dict.
+        if network_id in self.agent.cache.cache:
+            for port in self.agent.cache.cache[network_id].ports:
+                self.agent.cache.port_lookup[port.id] = network_id
+
+    def _update_dnsmasq(self, network_id):
+        """Start/stop/restart Dnsmasq for NETWORK_ID."""
+
+        # Check whether we should really do the following processing.
+        if self.suppress_dnsmasq_updates:
+            LOG.debug("Don't update dnsmasq yet;"
+                      " must be processing a snapshot")
+            self.dirty_networks.add(network_id)
+            return
+
+        # Get NetModel for that network ID.
+        net = self.agent.cache.get_network_by_id(network_id)
+        LOG.debug("Net: %s", net)
+
+        # Compute the set of ports that we need Dnsmasq to handle for this
+        # network ID.
+        ports_needed = [
+            port for port in net.ports if port.device_id.startswith('tap')
+        ]
+        ports_needed.sort(key=lambda port: port.id)
+
+        # Compare that against what we've last asked Dnsmasq to handle.
+        last_ports = self._last_dnsmasq_ports.get(network_id)
+        last_mtu = self._last_dnsmasq_mtu.get(network_id,
+                                              constants.DEFAULT_NETWORK_MTU)
+        mtu_changing = last_mtu != net.mtu
+        if ports_needed != last_ports or mtu_changing:
+            # Requirements have changed, so start, restart or stop Dnsmasq for
+            # that network ID.
+            if ports_needed or mtu_changing:
+                self.agent.call_driver('restart', net)
+            else:
+                # No ports left, so also remove this network from the cache.
+                self._fix_network_cache_port_lookup(net.id)
+                self.agent.cache.remove(net)
+                self.agent.call_driver('disable', net)
+
+            # Remember what we've asked Dnsmasq for.
+            self._last_dnsmasq_ports[network_id] = ports_needed
+            self._last_dnsmasq_mtu[network_id] = net.mtu
+
+    def on_endpoint_delete(self, response_ignored, name):
+        """Handler for endpoint deletion."""
+        try:
+            hostname, orchestrator, workload_id, endpoint_id = \
+                split_endpoint_name(name)
+        except ValueError:
+            # For some reason this endpoint's name does not have the expected
+            # form.  Ignore it.
+            LOG.warning("Unexpected form for endpoint name: %s", name)
+            return
+
+        # Remove endpoint ID from our cache.  Note, it might not be
+        # there because we haven't checked whether the endpoint just
+        # deleted is a local one; hence 'discard' instead of 'remove'.
+        self.local_endpoint_ids.discard(endpoint_id)
+
+        # Find the corresponding port in the DHCP agent's cache.
+        port = self.agent.cache.get_port_by_id(endpoint_id)
+        if port:
+            LOG.debug("deleted port: %s", port)
+            self.agent.cache.remove_port(port)
+            self._update_dnsmasq(port.network_id)
+
+    def _pre_snapshot_hook(self):
+        """Called when a new snapshot is about to be read from etcdv3."""
+
+        # Add all current networks to the dirty set, so that we will stop their
+        # Dnsmasqs if no longer needed.  Also remove all port and subnet
+        # information.
+        LOG.debug("Reset cache for new snapshot")
+        for network_id in list(self.agent.cache.get_network_ids()):
+            self.dirty_networks.add(network_id)
+            self._fix_network_cache_port_lookup(network_id)
+            self.agent.cache.put(empty_network(network_id))
+
+        # Suppress Dnsmasq updates until we've processed the whole snapshot.
+        self.suppress_dnsmasq_updates = True
+        return None
+
+    def _post_snapshot_hook(self, _):
+        LOG.debug("End of new snapshot")
+
+        # Now do Dnsmasq updates.
+        self.suppress_dnsmasq_updates = False
+        for network_id in self.dirty_networks:
+            self._update_dnsmasq(network_id)
+        self.dirty_networks = set()
+
+
+class SubnetIDNotFound(Exception):
+    pass
+
+
+class SubnetWatcher(etcdutils.EtcdWatcher):
+
+    def __init__(self, endpoint_watcher, path):
+        super(SubnetWatcher, self).__init__(path)
+        self.endpoint_watcher = endpoint_watcher
+        self.register_path(path + "/<subnet_id>",
+                           on_set=self.on_subnet_set,
+                           on_del=self.on_subnet_del)
+        self.subnets_by_id = {}
+
+    def start(self):
+        # Catch and report any exceptions that escape here.
+        try:
+            super(SubnetWatcher, self).start()
+        except Etcd3Exception as e3e:
+            LOG.exception("Etcd3Exception in SubnetWatcher.start():\n%s",
+                          e3e.detail_text)
+            raise
+        except:                 # noqa
+            LOG.exception("Exception in SubnetWatcher.start()")
+            raise
+        finally:
+            # As this thread is exiting, arrange for the agent as a whole to
+            # exit.
+            self.endpoint_watcher.stop()
+
+    def on_subnet_set(self, response, subnet_id):
+        """Handler for subnet creations and updates."""
+        LOG.debug("Subnet %s created or updated", subnet_id)
+        subnet_data = etcdutils.safe_decode_json(response.value, 'subnet')
+
+        if subnet_data is None:
+            LOG.warning("Invalid subnet data %s", response.value)
+            return
+
+        if not (isinstance(subnet_data, dict) and
+                'cidr' in subnet_data and
+                'gateway_ip' in subnet_data):
+            LOG.warning("Invalid subnet data: %s", subnet_data)
+            return
+
+        self.subnets_by_id[subnet_id] = subnet_data
+        return
+
+    def on_subnet_del(self, response, subnet_id):
+        """Handler for subnet deletions."""
+        LOG.info("Subnet %s deleted", subnet_id)
+        if subnet_id in self.subnets_by_id:
+            del self.subnets_by_id[subnet_id]
+        return
+
+    def get_subnet_id_for_addr(self, ip_str, network_id):
+        ip_addr = netaddr.IPAddress(ip_str)
+        for subnet_id, subnet_data in self.subnets_by_id.items():
+            # If we know we're looking within a given Neutron network, only
+            # consider this subnet if it belongs to that network.
+            if network_id and subnet_data['network_id'] != network_id:
+                continue
+            if ip_addr in netaddr.IPNetwork(subnet_data['cidr']):
+                return subnet_id
+        return None
+
+    def get_subnet(self, subnet_id):
+        """Get data for the specified subnet."""
+        LOG.debug("Get subnet %s", subnet_id)
+
+        if subnet_id not in self.subnets_by_id:
+            return None
+
+        data = self.subnets_by_id[subnet_id]
+        LOG.debug("Subnet data: %s", data)
+
+        # Convert to form expected by NetModel.
+        ip_version = 6 if ':' in data['cidr'] else 4
+        subnet = {'enable_dhcp': True,
+                  'ip_version': ip_version,
+                  'cidr': data['cidr'],
+                  'dns_nameservers': data.get('dns_servers') or [],
+                  'id': subnet_id,
+                  'gateway_ip': data['gateway_ip'],
+                  'host_routes': data.get('host_routes', []),
+                  'network_id': data.get('network_id', NETWORK_ID)}
+        if ip_version == 6:
+            subnet['ipv6_address_mode'] = DHCPV6_STATEFUL
+            subnet['ipv6_ra_mode'] = DHCPV6_STATEFUL
+
+        return dhcp.DictModel(subnet)
+
+
+class CalicoDhcpAgent(DhcpAgent):
+    """Calico DHCP agent.
+
+    This DHCP agent subclasses and overrides the standard Neutron DHCP
+    agent so as to be driven by etcd endpoint data - instead of by
+    Neutron RPC network, subnet and port messages - and so as not to
+    provide any agent status reporting back to the Neutron server.
+    This is because we have observed that the RPC exchanges between
+    DHCP agents and the Neutron server will exhaust the latter once
+    there are more than a few hundred agents running.
+    """
+    def __init__(self):
+        try:
+            hostname = cfg.CONF.host
+        except AttributeError:
+            # We get AttributeError (or an exception derived from that) if that
+            # config option does not exist, in an old enough Neutron release.
+            hostname = socket.gethostname()
+        super(CalicoDhcpAgent, self).__init__(host=hostname)
+
+        # Override settings that Calico's DHCP agent use requires.
+        self.conf.set_override('enable_isolated_metadata', False)
+        try:
+            self.conf.set_override('use_namespaces', False)
+        except cfg.NoSuchOptError:
+            # Option removed in Mitaka, with the behaviour of the reference
+            # DHCP agent code being hardcoded to assume that it should always
+            # _use_ a namespace - which unfortunately is wrong for Calico
+            # usage.  We compensate for this through a combination of the
+            # make_net_model code above, and subclassing and overriding
+            # particular DHCP agent methods so that they don't do
+            # namespace-specific actions.
+            pass
+        self.conf.set_override(
+            'interface_driver',
+            'networking_calico.agent.linux.interface.RoutedInterfaceDriver'
+        )
+
+        # Override the DHCP driver class - networking-calico's
+        # DnsmasqRouted class.
+        self.dhcp_driver_cls = DnsmasqRouted
+
+        # Override the RPC plugin (i.e. proxy to the Neutron database)
+        # with a fake plugin.  The DHCP driver code calls when it
+        # wants to tell Neutron that it is creating, updating or
+        # releasing the DHCP port.
+        self.plugin_rpc = FakePlugin()
+
+        # Watch etcd for any endpoint changes for this host.
+        self.etcd = CalicoEtcdWatcher(self, hostname)
+
+    def run(self):
+        """Run the EtcdWatcher loop."""
+        self.etcd.start()
+
+
+def setup_logging():
+    config.setup_logging()
+
+    # logging is set up as it is done for neutron agent, so
+    # in order to log additionally to file we simply need to add
+    # file handler to root logger
+    root_logger = logging.getLogger()
+
+    # FIXME(aroma-x) - move logging settings to configuration
+    # file in future
+    log_file = '/var/log/neutron/dhcp-agent.log'
+    log_format = ('%(asctime)s [%(thread)d] (%(levelname)s) '
+                  '%(module)s: %(message)s')
+    log_level = logging.DEBUG
+
+    # Ensure that log file directory exists.
+    mkdir_p(os.path.dirname(log_file))
+
+    fh = logging.FileHandler(log_file)
+    fh.setLevel(log_level)
+    fh.setFormatter(logging.Formatter(log_format))
+
+    root_logger.addHandler(fh)
+
+
+def main():
+    register_options(cfg.CONF)
+    calico_config.register_options(cfg.CONF)
+    common_config.init(sys.argv[1:])
+    setup_logging()
+    try:
+        # Neutron agent code has been migrating from rootwrap to privsep.
+        # Initialize the privsep system if it is available.
+        config.setup_privsep()
+    except Exception as e:
+        # But don't worry if it isn't; that means we are running with older
+        # Neutron code.
+        LOG.info("Couldn't setup_privsep(): %r", e)
+    agent = CalicoDhcpAgent()
+    agent.run()

--- a/chef/cookbooks/bcpc/files/default/neutron/endpoints.py
+++ b/chef/cookbooks/bcpc/files/default/neutron/endpoints.py
@@ -1,0 +1,445 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from neutron.db import models_v2
+try:
+    from neutron.db.models.l3 import FloatingIP
+except ImportError:
+    # Ocata and earlier.
+    from neutron.db.l3_db import FloatingIP
+
+from networking_calico.common import config as calico_config
+from networking_calico.compat import cfg
+from networking_calico.compat import constants
+from networking_calico.compat import log
+from networking_calico.compat import n_exc
+from networking_calico import datamodel_v3
+from networking_calico import etcdv3
+from networking_calico.plugins.ml2.drivers.calico.policy import \
+    SG_LABEL_PREFIX
+from networking_calico.plugins.ml2.drivers.calico.policy import \
+    SG_NAME_LABEL_PREFIX
+from networking_calico.plugins.ml2.drivers.calico.policy import \
+    SG_NAME_MAX_LENGTH
+from networking_calico.plugins.ml2.drivers.calico.syncer import ResourceGone
+from networking_calico.plugins.ml2.drivers.calico.syncer import ResourceSyncer
+
+
+LOG = log.getLogger(__name__)
+
+
+# The Calico WorkloadEndpoint that represents an OpenStack VM gets a pair of
+# labels to indicate the project (aka tenant) that the VM belongs to.  The
+# label names are as follows, and the label values are the actual project ID
+# and name at the time of VM creation.
+#
+# (OpenStack allows a project's name to be updated subsequently; if that
+# happens, it is unspecified whether or not we reflect that by updating labels
+# of existing WorkloadEndpoints.  In practice the project name label will
+# probably change when the WorkloadEndpoint is next rewritten for some other
+# reason.  Deployments that use these labels are recommended not to change
+# project names post-creation.)
+PROJECT_ID_LABEL_NAME = 'projectcalico.org/openstack-project-id'
+PROJECT_NAME_LABEL_NAME = 'projectcalico.org/openstack-project-name'
+PROJECT_NAME_MAX_LENGTH = datamodel_v3.SANITIZE_LABEL_MAX_LENGTH
+PROJECT_PARENT_ID_LABEL_NAME = 'projectcalico.org/openstack-project-parent-id'
+
+# Note: Calico requires a label value to be an empty string, or to consist of
+# alphanumeric characters, '-', '_' or '.', starting and ending with an
+# alphanumeric character.  If a project name does not already meet that, we
+# substitute problem characters so that it does.
+
+# Calico-specific keys in the port dict for storing information that
+# we want to include in WorkloadEndpoints.
+PORT_KEY_PROJ_DATA = 'calico-project-data'
+PORT_KEY_SG_NAMES = 'calico-sg-names'
+
+
+class WorkloadEndpointSyncer(ResourceSyncer):
+
+    def __init__(self, db, txn_from_context, policy_syncer, keystone_client):
+        super(WorkloadEndpointSyncer, self).__init__(db,
+                                                     txn_from_context,
+                                                     "WorkloadEndpoint")
+        self.policy_syncer = policy_syncer
+        self.keystone = keystone_client
+        self.proj_data_cache = {}
+        self.region_string = calico_config.get_region_string()
+        self.namespace = datamodel_v3.get_namespace(self.region_string)
+
+    def delete_legacy_etcd_data(self):
+        if self.namespace != datamodel_v3.NO_REGION_NAMESPACE:
+            datamodel_v3.delete_legacy(self.resource_kind, '')
+
+    # The following methods differ from those for other resources because for
+    # endpoints we need to read, compare and write labels and annotations as
+    # well as spec.
+
+    def get_all_from_etcd(self):
+        return datamodel_v3.get_all(self.resource_kind,
+                                    self.namespace,
+                                    with_labels_and_annotations=True)
+
+    def etcd_write_data_matches_existing(self, write_data, existing):
+        rspec, rlabels, rannotations = existing
+        wspec, wlabels, wannotations = write_data
+        return (rspec == wspec and
+                rlabels == wlabels and
+                rannotations == wannotations)
+
+    def create_in_etcd(self, name, write_data):
+        spec, labels, annotations = write_data
+        return datamodel_v3.put(self.resource_kind,
+                                self.namespace,
+                                name,
+                                spec,
+                                labels=labels,
+                                annotations=annotations,
+                                mod_revision=0)
+
+    def update_in_etcd(self, name, write_data, mod_revision=etcdv3.MUST_UPDATE):
+        spec, labels, annotations = write_data
+        return datamodel_v3.put(self.resource_kind,
+                                self.namespace,
+                                name,
+                                spec,
+                                labels=labels,
+                                annotations=annotations,
+                                mod_revision=mod_revision)
+
+    def delete_from_etcd(self, name, mod_revision):
+        return datamodel_v3.delete(self.resource_kind,
+                                   self.namespace,
+                                   name,
+                                   mod_revision=mod_revision)
+
+    def get_all_from_neutron(self, context):
+        # TODO(lukasa): We could reduce the amount of data we load from Neutron
+        # here by filtering in the get_ports call.
+        return dict((endpoint_name(port), port)
+                    for port in self.db.get_ports(context)
+                    if _port_is_endpoint_port(port))
+
+    def neutron_to_etcd_write_data(self, port, context, reread=False):
+        if reread:
+            try:
+                port = self.db.get_port(context, port['id'])
+            except n_exc.PortNotFound:
+                raise ResourceGone()
+        port = self.add_extra_port_information(context, port)
+        return (endpoint_spec(port),
+                endpoint_labels(port, self.namespace),
+                endpoint_annotations(port))
+
+    def write_endpoint(self, port, context, must_update=False):
+        # Reread the current port. This protects against concurrent writes
+        # breaking our state.
+        port = self.db.get_port(context, port['id'])
+
+        # Fill out other information we need on the port.
+        port = self.add_extra_port_information(context, port)
+
+        # Write the security policies for this port.
+        self.policy_syncer.write_sgs_to_etcd(port['security_groups'], context)
+
+        # Implementation note: we could arguably avoid holding the transaction
+        # for this length and instead release it here, then use atomic CAS. The
+        # problem there is that we potentially have to repeatedly respin and
+        # regain the transaction. Let's not do that for now, and performance
+        # test to see if it's a problem later.
+        mod_revision = etcdv3.MUST_UPDATE if must_update else None
+        datamodel_v3.put("WorkloadEndpoint",
+                         self.namespace,
+                         endpoint_name(port),
+                         endpoint_spec(port),
+                         labels=endpoint_labels(port, self.namespace),
+                         annotations=endpoint_annotations(port),
+                         mod_revision=mod_revision)
+
+    def delete_endpoint(self, port):
+        return datamodel_v3.delete("WorkloadEndpoint",
+                                   self.namespace,
+                                   endpoint_name(port))
+
+    def add_port_interface_name(self, port):
+        port['interface_name'] = 'tap' + port['id'][:11]
+
+    def get_security_groups_for_port(self, context, port):
+        """Checks which security groups apply for a given port.
+
+        Frustratingly, the port dict provided to us when we call get_port may
+        actually be out of date, and I don't know why. This change ensures that
+        we get the most recent information.
+        """
+        filters = {'port_id': [port['id']]}
+        bindings = self.db._get_port_security_group_bindings(
+            context, filters=filters
+        )
+        return [binding['security_group_id'] for binding in bindings]
+
+    def get_fixed_ips_for_port(self, context, port):
+        """Obtains a complete list of fixed IPs for a port.
+
+        Much like with security groups, for some insane reason we're given an
+        out of date port dictionary when we call get_port. This forces an
+        explicit query of the IPAllocation table to get the right data out of
+        Neutron.
+        """
+        return [
+            {'subnet_id': ip['subnet_id'], 'ip_address': ip['ip_address']}
+            for ip in context.session.query(
+                models_v2.IPAllocation
+            ).filter_by(
+                port_id=port['id']
+            )
+        ]
+
+    def get_floating_ips_for_port(self, context, port):
+        """Obtains a list of floating IPs for a port."""
+        return [
+            {'int_ip': ip['fixed_ip_address'],
+             'ext_ip': ip['floating_ip_address']}
+            for ip in context.session.query(
+                FloatingIP
+            ).filter_by(
+                fixed_port_id=port['id']
+            )
+        ]
+
+    def add_extra_port_information(self, context, port):
+        """add_extra_port_information
+
+        Gets extra information for a port that is needed before sending it to
+        etcd.
+        """
+        network = self.db.get_network(context, port['network_id'])
+        port['mtu'] = network.get('mtu', constants.DEFAULT_NETWORK_MTU)
+        port['fixed_ips'] = self.get_fixed_ips_for_port(
+            context, port
+        )
+        port['floating_ips'] = self.get_floating_ips_for_port(
+            context, port
+        )
+        port['security_groups'] = self.get_security_groups_for_port(
+            context, port
+        )
+        self.add_port_gateways(port, context)
+        self.add_port_interface_name(port)
+        self.add_port_project_data(port, context)
+        self.add_port_sg_names(port, context)
+
+        return port
+
+    def add_port_gateways(self, port, context):
+        """add_port_gateways
+
+        Determine the gateway IP addresses for a given port's IP addresses, and
+        adds them to the port dict.
+
+        This method assumes it's being called from within a database
+        transaction and does not take out another one.
+        """
+        for ip in port['fixed_ips']:
+            subnet = self.db.get_subnet(context, ip['subnet_id'])
+            ip['gateway'] = subnet['gateway_ip']
+
+    def add_port_sg_names(self, port, context):
+        """add_port_sg_names
+
+        Determine and store the name of each security group that a port uses.
+
+        This method assumes it's being called from within a database
+        transaction and does not take out another one.
+        """
+        # Oddly, get_security_groups normally tries to create the default SG
+        # for the current tenant, and that can hit a
+        # NeutronDbObjectDuplicateEntry exception - presumably if there's a
+        # race with multiple servers or threads trying to do this at the same
+        # time.  Adding "default_sg=True" here suppresses that creation
+        # attempt.
+        port[PORT_KEY_SG_NAMES] = {}
+        filters = {'id': port['security_groups']}
+        for sg in self.db.get_security_groups(context, filters=filters,
+                                              default_sg=True):
+            sg_name = datamodel_v3.sanitize_label_name_value(
+                sg['name'],
+                SG_NAME_MAX_LENGTH
+            )
+            port[PORT_KEY_SG_NAMES][sg['id']] = sg_name
+
+    def add_port_project_data(self, port, context):
+        """add_port_project_data
+
+        Determine the OpenStack project name and parent ID for a given
+        port's project/tenant ID, and add it as
+        port['calico-project-data'].
+        """
+        proj_id = port.get('project_id', port.get('tenant_id'))
+        if proj_id is None:
+            LOG.warning("Port with no project ID: %r", port)
+            return
+
+        # If we've already cached the corresponding project data, we're done.
+        proj_data = self.proj_data_cache.get(proj_id)
+        if proj_data is not None:
+            LOG.debug("Project data %r was cached", proj_data)
+            port[PORT_KEY_PROJ_DATA] = proj_data
+            return
+
+        # Flush the cache if it has reached its maximum allowed size.
+        if len(self.proj_data_cache) >= cfg.CONF.calico.project_name_cache_max:
+            self.proj_data_cache = {}
+
+        # Not cached, so look up the port's project in the Keystone DB.
+        try:
+            wanted_data = None
+            for proj in self.keystone.projects.list():
+                if proj.id not in self.proj_data_cache:
+                    LOG.info("Got project name %r from Keystone", proj.name)
+                    proj_name = datamodel_v3.sanitize_label_name_value(
+                        proj.name, PROJECT_NAME_MAX_LENGTH
+                    )
+                    self.proj_data_cache[proj.id] = (proj_name, proj.parent_id)
+                    if proj.id == proj_id:
+                        wanted_data = self.proj_data_cache[proj.id]
+            if wanted_data is not None:
+                port[PORT_KEY_PROJ_DATA] = wanted_data
+            return
+        except Exception:
+            # Probably don't have right credentials for that lookup.
+            LOG.exception("Failed to query Keystone DB")
+
+
+def endpoint_name(port):
+    def escape_dashes(s):
+        return s.replace("-", "--")
+    return "%s-openstack-%s-%s" % (
+        escape_dashes(port['binding:host_id']),
+        escape_dashes(port['device_id']),
+        escape_dashes(port['id']),
+    )
+
+
+def endpoint_labels(port, namespace):
+    labels = {}
+    for sg_id in port['security_groups']:
+        sg_name = port.get(PORT_KEY_SG_NAMES, {}).get(sg_id, '')
+        labels[SG_LABEL_PREFIX + sg_id] = sg_name
+        if sg_name:
+            labels[SG_NAME_LABEL_PREFIX + sg_name] = sg_id
+    labels['projectcalico.org/namespace'] = namespace
+    labels['projectcalico.org/orchestrator'] = 'openstack'
+
+    proj_id = port.get('project_id', port.get('tenant_id'))
+    if proj_id is not None:
+        labels[PROJECT_ID_LABEL_NAME] = proj_id
+    if PORT_KEY_PROJ_DATA in port:
+        name, parent_id = port[PORT_KEY_PROJ_DATA]
+        labels[PROJECT_NAME_LABEL_NAME] = name
+        labels[PROJECT_PARENT_ID_LABEL_NAME] = parent_id
+
+    return labels
+
+
+# Represent a Neutron port as a Calico v3 WorkloadEndpoint spec.
+def endpoint_spec(port):
+    """endpoint_spec
+
+    Generate JSON WorkloadEndpointSpec for the given Neutron port.
+    """
+
+    # Construct the simpler spec data.
+    data = {
+        'orchestrator': 'openstack',
+        'workload': port['device_id'],
+        'node': port['binding:host_id'],
+        'endpoint': port['id'],
+        'interfaceName': port['interface_name'],
+        'mac': port['mac_address'],
+    }
+
+    # Collect IPv4 and IPv6 addresses.  On the way, also set the corresponding
+    # gateway fields.  If there is more than one IPv4 or IPv6 gateway, the last
+    # one (in port['fixed_ips']) wins.
+    ip_nets = []
+    for ip in port['fixed_ips']:
+        if ':' in ip['ip_address']:
+            ip_nets.append(ip['ip_address'] + '/128')
+            if ip['gateway'] is not None:
+                data['ipv6Gateway'] = ip['gateway']
+        else:
+            ip_nets.append(ip['ip_address'] + '/32')
+            if ip['gateway'] is not None:
+                data['ipv4Gateway'] = ip['gateway']
+
+    # we need to store allowedIPs twice, because
+    # dhcp agent creates dhcp record only for fixed IP
+    # but felix have to create route for both (fixed and allowed ips)
+    allowed_ips = []
+    for aap in port.get('allowed_address_pairs', []):
+        ip_addr = str(aap['ip_address'])
+        if ':' in ip_addr:
+            ip_nets.append(ip_addr + '/128')
+            allowed_ips.append(ip_addr + '/128')
+        else:
+            ip_nets.append(ip_addr + '/32')
+            allowed_ips.append(ip_addr + '/32')
+
+    data['ipNetworks'] = ip_nets
+    data['allowedIps'] = allowed_ips
+
+    ip_nats = []
+    for ip in port['floating_ips']:
+        ip_nats.append({
+            'internalIP': ip['int_ip'],
+            'externalIP': ip['ext_ip'],
+        })
+    if ip_nats:
+        data['ipNATs'] = ip_nats
+
+    # Return that data.
+    return data
+
+
+def endpoint_annotations(port):
+    annotations = {
+        datamodel_v3.ANN_KEY_NETWORK_ID: port['network_id'],
+        datamodel_v3.ANN_KEY_NETWORK_MTU: str(port['mtu']),
+    }
+
+    # If the port has a DNS assignment, represent that as an FQDN annotation.
+    dns_assignment = port.get('dns_assignment')
+    if dns_assignment:
+        # Note: the Neutron server generates a list of assignment entries, one
+        # for each fixed IP, but all with the same FQDN, for slightly
+        # historical reasons.  We're fine getting the FQDN from the first
+        # entry.
+        annotations[datamodel_v3.ANN_KEY_FQDN] = dns_assignment[0]['fqdn']
+
+    return annotations
+
+
+def _port_is_endpoint_port(port):
+    # Return True if port is a VM port.
+    if port['device_owner'].startswith('compute:'):
+        return True
+
+    # Also return True if port is for a Kuryr container.
+    if port['device_owner'].startswith('kuryr:container'):
+        return True
+
+    # Otherwise log and return False.
+    LOG.debug("Not a VM port: %s" % port)
+    return False

--- a/chef/cookbooks/bcpc/files/default/nova/migration.py
+++ b/chef/cookbooks/bcpc/files/default/nova/migration.py
@@ -451,7 +451,9 @@ def _update_vif_xml(xml_doc, migrate_data, get_vif_config):
         for index, dest_interface_subelem in enumerate(dest_interface_elem):
             # NOTE(mnaser): If we don't have an MTU, don't define one, else
             #               the live migration will crash.
-            if dest_interface_subelem.tag == 'mtu' and mtu is None:
+            if dest_interface_subelem.tag == 'mtu':
+                if mtu is not None:
+                    interface_dev.insert(index, mtu)
                 continue
             interface_dev.insert(index, dest_interface_subelem)
         # And finally re-insert the hw address.

--- a/chef/cookbooks/bcpc/recipes/calico-work.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-work.rb
@@ -57,6 +57,17 @@ cookbook_file '/usr/local/lib/python3.6/dist-packages/etcd3gw/watch.py' do
   notifies :restart, 'service[calico-dhcp-agent]', :delayed
 end
 
+# Add ability to set MTU: https://github.com/projectcalico/calico/pull/6487
+cookbook_file '/usr/lib/python3.6/dist-packages/networking_calico/datamodel_v3.py' do
+  source 'neutron/datamodel_v3.py'
+  notifies :restart, 'service[calico-dhcp-agent]', :delayed
+end
+
+cookbook_file '/usr/lib/python3.6/dist-packages/networking_calico/agent/dhcp_agent.py' do
+  source 'neutron/dhcp_agent.py'
+  notifies :restart, 'service[calico-dhcp-agent]', :delayed
+end
+
 template '/etc/neutron/neutron.conf' do
   source 'calico/neutron.conf.erb'
   mode '644'

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -541,3 +541,14 @@ bash 'update admin default security group' do
     done
   DOC
 end
+
+# Add ability to set MTU: https://github.com/projectcalico/calico/pull/6487
+cookbook_file '/usr/lib/python3.6/dist-packages/networking_calico/datamodel_v3.py' do
+  source 'neutron/datamodel_v3.py'
+  notifies :restart, 'service[neutron-server]', :delayed
+end
+
+cookbook_file '/usr/lib/python3.6/dist-packages/networking_calico/plugins/ml2/drivers/calico/endpoints.py' do
+  source 'neutron/endpoints.py'
+  notifies :restart, 'service[neutron-server]', :delayed
+end

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -261,6 +261,9 @@ end
 
 # Add feature to rewrite monitor addresses in the domain XML using values from
 # migration.conf instead to faciliate Ceph monitor migration exercises
+#
+# Also fix live-migration when the MTU of the network is changed (in which case
+# the instance MTU must remain the same if and when it is defined).
 cookbook_file '/usr/lib/python3/dist-packages/nova/virt/libvirt/migration.py' do
   source 'nova/migration.py'
   notifies :run, 'execute[py3compile-nova]', :immediately


### PR DESCRIPTION
Add an annotation to the etcd datamodel used to describe
WorkloadEndpoints for Calico OpenStack VMs that specifies
the MTU of the OpenStack network.

This effectively adds non-default (>1500) MTU support to
Calico OpenStack.

This also fixes an upstream bug in `nova` where the MTU
element of the interface in the `libvirt` domain XML is not
retained during a live migration, which causes the live-
migration to fail when it otherwise would not.