### PR TITLE
Refine `cookstyle/rubocop` configuration

### DIFF
--- a/.github/scripts/install_linters.sh
+++ b/.github/scripts/install_linters.sh
@@ -41,7 +41,7 @@ function install_linters_linux {
         bashate==2.1.0 \
         hacking==4.1.0
 
-    sudo gem install cookstyle
+    sudo gem install cookstyle -v 7.32.1
 }
 
 main

--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -20,20 +20,23 @@ function main {
     # shellcheck disable=SC1091
     source /tmp/linter_venv/bin/activate
 
-    find . -name "*.sh" -exec shellcheck {} \;
-    find . -name "*.sh" -exec bashate -e E006 {} \;
+    find . -name "*.sh" -print0 | xargs -0 -t shellcheck;
+    find . -name "*.sh" -print0 | xargs -0 -t bashate -e E006;
     find . -name "*.py" \
+        ! -path "./chef/cookbooks/bcpc/files/default/cinder/rbd.py" \
         ! -path "./chef/cookbooks/bcpc/files/default/etcd3gw/watch.py" \
         ! -path \
             "./chef/cookbooks/bcpc/files/default/neutron/external_net_db.py" \
         ! -path "./chef/cookbooks/bcpc/files/default/neutron/model_query.py" \
         ! -path "./chef/cookbooks/bcpc/files/default/nova/api.py" \
+        ! -path "./chef/cookbooks/bcpc/files/default/nova/block_device.py" \
         ! -path "./chef/cookbooks/bcpc/files/default/nova/hardware.py" \
         ! -path "./chef/cookbooks/bcpc/files/default/nova/hw.py" \
+        ! -path "./chef/cookbooks/bcpc/files/default/nova/migration.py" \
         ! -path "./chef/cookbooks/bcpc/files/default/nova/vif.py" \
-        -exec flake8 {} \;
+        -print0 | xargs -0 -t flake8
     ansible-lint -x var-naming ansible/
-    cookstyle --version && cookstyle .
+    cookstyle --version && cookstyle --fail-level A
 }
 
 main

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetChefVersion: 14.13.11


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

Addresses a number of issues including `flake8` and `cookstyle` failures might not result in a failed "check"; and as a result, a number of patched Python files slipped in without being added to the exception list.