### PR TITLE
Add a Chef role for `etcdnode`

### DIFF
--- a/ansible/playbooks/configure-common-node.yml
+++ b/ansible/playbooks/configure-common-node.yml
@@ -5,15 +5,14 @@
 #
 # The list of dependencies we resolve in configure-web-server [1] and here [2]:
 #   * [1] etcd requires bcpc::web-server (to obtain packages)
-#   * [2] etcd-proxy (non-headnodes) requires etcd (headnodes)
+#   * [2] etcd-proxy (non-headnodes) requires etcd (etcdnodes)
 #   * [2] calico-felix requires etcd-proxy or etcd-member
 #
 # In the future, we should move Consul, etcd, etc. out of Chef and into
 # Ansible so these dependencies can be resolved more elegantly.
-- hosts: headnodes
+- hosts: "{{ groups.get('etcdnodes', groups.get('headnodes', [])) }}"
   gather_facts: no
   become: yes
-  order: inventory
   tasks:
     - name: provision the first etcd server
       become: true

--- a/ansible/playbooks/etcdnodes.yml
+++ b/ansible/playbooks/etcdnodes.yml
@@ -1,0 +1,6 @@
+- hosts: etcdnodes
+  gather_facts: no
+  serial: "{{ step | default(ansible_play_batch | length) }}"
+  roles:
+    - common
+    - chef-node

--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -64,6 +64,14 @@ chef_roles:
       - recipe[bcpc::rally]
       - recipe[bcpc::rally-deploy]
 
+  - name: etcdnode
+    description: etcd node
+    json_class: Chef::Role
+    chef_type: role
+    run_list:
+      - role[node]
+      - recipe[bcpc::etcd-member]
+
   - name: headnode
     description: cloud infrastructure services
     json_class: Chef::Role
@@ -71,7 +79,6 @@ chef_roles:
     run_list:
       - role[node]
       - recipe[bcpc::haproxy]
-      - recipe[bcpc::etcd-member]
       - recipe[bcpc::memcached]
       - recipe[bcpc::unbound]
       - recipe[bcpc::consul]

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,6 +1,7 @@
 - import_playbook: localhost.yml
 - import_playbook: stubnodes.yml
 - import_playbook: bootstraps.yml
+- import_playbook: etcdnodes.yml
 - import_playbook: headnodes.yml
 - import_playbook: rmqnodes.yml
 - import_playbook: storageheadnodes.yml

--- a/chef/cookbooks/bcpc/recipes/etcd-member.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd-member.rb
@@ -39,9 +39,9 @@ end
 
 begin
   # attempt to register this node with an existing etcd cluster if one exists
-  unless init_cloud?
+  unless init_etcd?
 
-    members = headnodes(exclude: node['hostname'])
+    members = etcdnodes(exclude: node['hostname'])
     endpoints = members.map { |m| "#{m['service_ip']}:2379" }.join(' ')
 
     bash "try to add #{node['hostname']} to existing etcd cluster" do
@@ -94,14 +94,14 @@ end
 initial_cluster = []
 initial_cluster_state = 'existing'
 
-if init_cloud?
+if init_etcd?
   initial_cluster = "#{node['fqdn']}=https://#{node['service_ip']}:2380"
   initial_cluster_state = 'new'
 else
-  headnodes = headnodes(exclude: node['hostname'])
-  headnodes.push(node)
+  etcdnodes = etcdnodes(exclude: node['hostname'])
+  etcdnodes.push(node)
 
-  initial_cluster = headnodes.collect do |h|
+  initial_cluster = etcdnodes.collect do |h|
     "#{h['fqdn']}=https://#{h['service_ip']}:2380"
   end
 

--- a/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd-proxy.rb
@@ -18,15 +18,15 @@
 include_recipe 'bcpc::etcd-packages'
 include_recipe 'bcpc::etcd-ssl'
 
-# Headnodes have etcd-member and don't need etcd-proxy.
-return if headnode?
+# etcdnodes have etcd-member and don't need etcd-proxy.
+return if etcdnode?
 
 service 'etcd'
 
-headnodes = headnodes(all: true)
+etcdnodes = etcdnodes(all: true)
 
-etcd_endpoints = headnodes.collect do |headnode|
-  "https://#{headnode['service_ip']}:2379"
+etcd_endpoints = etcdnodes.collect do |etcdnode|
+  "https://#{etcdnode['service_ip']}:2379"
 end
 
 template '/etc/systemd/system/etcd.service' do

--- a/chef/cookbooks/bcpc/recipes/etcd-ssl.rb
+++ b/chef/cookbooks/bcpc/recipes/etcd-ssl.rb
@@ -39,16 +39,26 @@ file node['bcpc']['etcd']['ca']['crt']['filepath'] do
   group 'etcd'
 end
 
+if etcdnode?
+  # server (root) certs
+  %w(crt key).each do |pem|
+    file node['bcpc']['etcd']['server'][pem]['filepath'] do
+      content Base64.decode64(config['etcd']['ssl']['server'][pem])
+      mode '0640'
+      owner 'root'
+      group 'etcd'
+    end
+  end
+end
+
 if headnode?
-  # server (root) and read-write client ssl certs
-  %w(server client-rw).each do |type|
-    %w(crt key).each do |pem|
-      file node['bcpc']['etcd'][type][pem]['filepath'] do
-        content Base64.decode64(config['etcd']['ssl'][type][pem])
-        mode '0640'
-        owner 'root'
-        group 'etcd'
-      end
+  # read-write client ssl certs
+  %w(crt key).each do |pem|
+    file node['bcpc']['etcd']['client-rw'][pem]['filepath'] do
+      content Base64.decode64(config['etcd']['ssl']['client-rw'][pem])
+      mode '0640'
+      owner 'root'
+      group 'etcd'
     end
   end
 else

--- a/virtual/bin/lib/bcc_chef_databags.py
+++ b/virtual/bin/lib/bcc_chef_databags.py
@@ -172,8 +172,11 @@ class EtcdSSL:
             if client == 'server':
                 alt_names = ','.join([
                     'IP:10.65.0.2',
+                    'IP:10.65.0.4',
                     'IP:10.65.0.16',
+                    'IP:10.65.0.18',
                     'IP:10.65.0.32',
+                    'IP:10.65.0.34',
                     'IP:127.0.0.1'
                 ]).encode()
 

--- a/virtual/topology/1h1w1e.yml
+++ b/virtual/topology/1h1w1e.yml
@@ -47,7 +47,6 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
-        - role[etcdnode]
         - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]
@@ -79,3 +78,28 @@ nodes:
         - role[storagenode]
         - role[worknode]
       zone: dev
+
+  - host: r1n3
+    group: etcdnodes
+    hardware_profile: headnode
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.4
+        transit:
+          - ip: 10.121.84.5/27
+            mac: '08:00:27:00:00:16'
+            neighbor:
+              ip: 10.121.84.1
+              asn: 4200858701
+              name: management1
+          - ip: 10.121.88.5/27
+            mac: '08:00:27:00:00:17'
+            neighbor:
+              ip: 10.121.88.1
+              asn: 4200858702
+              name: management4
+      run_list:
+        - role[etcdnode]

--- a/virtual/topology/1h1w1e1r1c1s.yml
+++ b/virtual/topology/1h1w1e1r1c1s.yml
@@ -77,8 +77,8 @@ nodes:
       zone: dev
 
   - host: r1n3
-    group: storagenodes
-    hardware_profile: worknode
+    group: etcdnodes
+    hardware_profile: headnode
     host_vars:
       bgp:
         asn: 4200858801
@@ -99,7 +99,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
-        - role[storagenode]
+        - role[etcdnode]
 
   - host: r1n4
     group: rmqnodes
@@ -150,3 +150,28 @@ nodes:
               name: management4
       run_list:
         - role[storageheadnode]
+
+  - host: r1n6
+    group: storagenodes
+    hardware_profile: worknode
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.7
+        transit:
+          - ip: 10.121.84.8/27
+            mac: '08:00:27:00:00:1c'
+            neighbor:
+              ip: 10.121.84.1
+              asn: 4200858701
+              name: management1
+          - ip: 10.121.88.8/27
+            mac: '08:00:27:00:00:1d'
+            neighbor:
+              ip: 10.121.88.1
+              asn: 4200858702
+              name: management4
+      run_list:
+        - role[storagenode]

--- a/virtual/topology/1h1w1r.yml
+++ b/virtual/topology/1h1w1r.yml
@@ -47,6 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
+        - role[etcdnode]
         - role[storageheadnode]
         - role[headnode]
 

--- a/virtual/topology/1h1w1s.yml
+++ b/virtual/topology/1h1w1s.yml
@@ -47,6 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
+        - role[etcdnode]
         - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]

--- a/virtual/topology/1h2w.yml
+++ b/virtual/topology/1h2w.yml
@@ -47,6 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
+        - role[etcdnode]
         - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]

--- a/virtual/topology/3h3w.yml
+++ b/virtual/topology/3h3w.yml
@@ -47,6 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
+        - role[etcdnode]
         - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]
@@ -102,6 +103,7 @@ nodes:
               asn: 4200858704
               name: management5
       run_list:
+        - role[etcdnode]
         - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]
@@ -157,6 +159,7 @@ nodes:
               asn: 4200858706
               name: management6
       run_list:
+        - role[etcdnode]
         - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]

--- a/virtual/topology/3h3w3e.yml
+++ b/virtual/topology/3h3w3e.yml
@@ -47,7 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
-        - role[etcdnode]
+        - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]
 
@@ -80,7 +80,7 @@ nodes:
       zone: dev
 
   - host: r1n3
-    group: rmqnodes
+    group: etcdnodes
     hardware_profile: headnode
     host_vars:
       bgp:
@@ -102,7 +102,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
-        - role[rmqnode]
+        - role[etcdnode]
 
   - host: r2n1
     group: headnodes
@@ -127,7 +127,7 @@ nodes:
               asn: 4200858704
               name: management5
       run_list:
-        - role[etcdnode]
+        - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]
 
@@ -160,7 +160,7 @@ nodes:
       zone: dev
 
   - host: r2n3
-    group: rmqnodes
+    group: etcdnodes
     hardware_profile: headnode
     host_vars:
       bgp:
@@ -182,7 +182,7 @@ nodes:
               asn: 4200858704
               name: management5
       run_list:
-        - role[rmqnode]
+        - role[etcdnode]
 
   - host: r3n1
     group: headnodes
@@ -207,7 +207,7 @@ nodes:
               asn: 4200858706
               name: management6
       run_list:
-        - role[etcdnode]
+        - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]
 
@@ -240,7 +240,7 @@ nodes:
       zone: dev
 
   - host: r3n3
-    group: rmqnodes
+    group: etcdnodes
     hardware_profile: headnode
     host_vars:
       bgp:
@@ -262,4 +262,4 @@ nodes:
               asn: 4200858706
               name: management6
       run_list:
-        - role[rmqnode]
+        - role[etcdnode]

--- a/virtual/topology/3h3w3e3r3c3s.yml
+++ b/virtual/topology/3h3w3e3r3c3s.yml
@@ -77,8 +77,8 @@ nodes:
       zone: dev
 
   - host: r1n3
-    group: storagenodes
-    hardware_profile: worknode
+    group: etcdnodes
+    hardware_profile: headnode
     host_vars:
       bgp:
         asn: 4200858801
@@ -99,7 +99,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
-        - role[storagenode]
+        - role[etcdnode]
 
   - host: r1n4
     group: rmqnodes
@@ -150,6 +150,32 @@ nodes:
               name: management4
       run_list:
         - role[storageheadnode]
+
+  - host: r1n6
+    group: storagenodes
+    hardware_profile: worknode
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.7
+        transit:
+          - ip: 10.121.84.8/27
+            mac: '08:00:27:00:00:1c'
+            neighbor:
+              ip: 10.121.84.1
+              asn: 4200858701
+              name: management1
+          - ip: 10.121.88.8/27
+            mac: '08:00:27:00:00:1d'
+            neighbor:
+              ip: 10.121.88.1
+              asn: 4200858702
+              name: management4
+      run_list:
+        - role[storagenode]
+
 
   - host: r2n1
     group: headnodes
@@ -204,8 +230,8 @@ nodes:
       zone: dev
 
   - host: r2n3
-    group: storagenodes
-    hardware_profile: worknode
+    group: etcdnodes
+    hardware_profile: headnode
     host_vars:
       bgp:
         asn: 4200858801
@@ -226,7 +252,7 @@ nodes:
               asn: 4200858704
               name: management5
       run_list:
-        - role[storagenode]
+        - role[etcdnode]
 
   - host: r2n4
     group: rmqnodes
@@ -277,6 +303,31 @@ nodes:
               name: management5
       run_list:
         - role[storageheadnode]
+
+  - host: r2n6
+    group: storagenodes
+    hardware_profile: worknode
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.21
+        transit:
+          - ip: 10.121.85.8/27
+            mac: '08:00:27:00:00:2a'
+            neighbor:
+              ip: 10.121.85.1
+              asn: 4200858703
+              name: management2
+          - ip: 10.121.89.8/27
+            mac: '08:00:27:00:00:2b'
+            neighbor:
+              ip: 10.121.89.1
+              asn: 4200858704
+              name: management5
+      run_list:
+        - role[storagenode]
 
   - host: r3n1
     group: headnodes
@@ -331,8 +382,8 @@ nodes:
       zone: dev
 
   - host: r3n3
-    group: storagenodes
-    hardware_profile: worknode
+    group: etcdnodes
+    hardware_profile: headnode
     host_vars:
       bgp:
         asn: 4200858801
@@ -353,7 +404,7 @@ nodes:
               asn: 4200858706
               name: management6
       run_list:
-        - role[storagenode]
+        - role[etcdnode]
 
   - host: r3n4
     group: rmqnodes
@@ -404,3 +455,28 @@ nodes:
               name: management6
       run_list:
         - role[storageheadnode]
+
+  - host: r3n6
+    group: storagenodes
+    hardware_profile: worknode
+    host_vars:
+      bgp:
+        asn: 4200858801
+      interfaces:
+        service:
+          ip: 10.65.0.37
+        transit:
+          - ip: 10.121.86.8/27
+            mac: '08:00:27:00:00:3a'
+            neighbor:
+              ip: 10.121.86.1
+              asn: 4200858705
+              name: management3
+          - ip: 10.121.90.8/27
+            mac: '08:00:27:00:00:3b'
+            neighbor:
+              ip: 10.121.90.1
+              asn: 4200858706
+              name: management6
+      run_list:
+        - role[storagenode]

--- a/virtual/topology/3h6w.yml
+++ b/virtual/topology/3h6w.yml
@@ -47,6 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
+        - role[etcdnode]
         - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]
@@ -130,6 +131,7 @@ nodes:
               asn: 4200858704
               name: management5
       run_list:
+        - role[etcdnode]
         - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]
@@ -213,6 +215,7 @@ nodes:
               asn: 4200858706
               name: management6
       run_list:
+        - role[etcdnode]
         - role[rmqnode]
         - role[storageheadnode]
         - role[headnode]

--- a/virtual/topology/3h6w3s3r3c.yml
+++ b/virtual/topology/3h6w3s3r3c.yml
@@ -47,6 +47,7 @@ nodes:
               asn: 4200858702
               name: management4
       run_list:
+        - role[etcdnode]
         - role[headnode]
 
   - host: r1n2
@@ -201,6 +202,7 @@ nodes:
               asn: 4200858704
               name: management5
       run_list:
+        - role[etcdnode]
         - role[headnode]
 
   - host: r2n2
@@ -355,6 +357,7 @@ nodes:
               asn: 4200858706
               name: management6
       run_list:
+        - role[etcdnode]
         - role[headnode]
 
   - host: r3n2


### PR DESCRIPTION
Add a `etcdnode` role to Chef for the purposes of allowing
dedicated `etcd`-style server nodes to be built.