### PR TITLE
`chrony`: Fix some issues with startup/config

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-chrony.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-chrony.yml
@@ -22,23 +22,34 @@
     recurse: yes
     state: directory
 
-- name: install systemd dependency work-around for chrony
-  copy:
-    content: |
-      [Unit]
-      After=
-      After=network.target network-online.target
-      Wants=network-online.target
-    dest: /etc/systemd/system/chrony.service.d/custom.conf
-    mode: 0644
-  register: chrony_custom
+- name: install service to start monitoring sources after getting a default route
+  block:
+    - name: install the systemd unit
+      copy:
+        content: |
+          [Unit]
+          Description=Wait for default route and bring Chrony sources online
+          After=bird.service chrony.service
+          Requires=chrony.service
 
-- name: reload chrony
-  systemd:
-    name: chrony
-    daemon_reload: yes
-    enabled: yes
-  when: chrony_custom.changed  # noqa no-handler
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/sh -c 'while [ -z "$(/sbin/ip route list default)" ]; do sleep 1; done'
+          ExecStartPost=/usr/bin/chronyc online
+          TimeoutStopSec=1
+
+          [Install]
+          WantedBy=multi-user.target
+        dest: /etc/systemd/system/wait-for-default-route.service
+        mode: 0644
+      register: chrony_custom
+
+    - name: enable the service at reboot
+      service:
+        name: wait-for-default-route
+        daemon_reload: yes
+        enabled: yes
+      when: chrony_custom.changed
 
 - name: restart chrony
   systemd:

--- a/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
+++ b/ansible/playbooks/roles/common/templates/chrony/chrony.conf.j2
@@ -2,7 +2,7 @@
 # information about usuable directives.
 
 {% for server in ntp['servers'] %}
-pool {{server}}
+server {{server}}
 {% endfor %}
 
 # This directive specify the file into which chronyd will store the rate


### PR DESCRIPTION
* `chrony` will persistently leave servers offline if
    they are not routable at startup. Thus, ensure that the
    servers are onlined after we get a default route.
    
* Use `server` instead of `pool` in the configuration, as
    the Ansible configuration suggests we are using that.