### PR TITLE
Calico with MTU fixes

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -178,8 +178,8 @@ assets_files:
     filename: etcd-v3.3.10-linux-amd64.tar.gz
 
   - name: calicoctl
-    url: https://github.com/projectcalico/calico/releases/download/v3.22.2/calicoctl-linux-amd64
-    checksum: sha256:2608fe464b50019e4ade388142f194463e351013ec81da21b111307411865a81
+    url: https://github.com/projectcalico/calico/releases/download/v3.22.5/calicoctl-linux-amd64
+    checksum: sha256:ba75fa65be0e97555b37282e1ab469ad933866eed164b40513e835279bea7348
     filename: calicoctl
 
   - name: consul

--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -12,7 +12,7 @@ default['bcpc']['calico']['calicoctl']['remote']['file'] = 'calicoctl'
 default['bcpc']['calico']['calicoctl']['remote']['source'] =
  "#{default['bcpc']['web_server']['url']}/calicoctl"
 default['bcpc']['calico']['calicoctl']['remote']['checksum'] =
- '2608fe464b50019e4ade388142f194463e351013ec81da21b111307411865a81'
+ 'ba75fa65be0e97555b37282e1ab469ad933866eed164b40513e835279bea7348'
 
 # calico-felix
 default['bcpc']['calico']['felix']['failsafe']['inbound'] = [

--- a/chef/cookbooks/bcpc/files/default/nova/migration.py
+++ b/chef/cookbooks/bcpc/files/default/nova/migration.py
@@ -449,13 +449,13 @@ def _update_vif_xml(xml_doc, migrate_data, get_vif_config):
             interface_dev.set(attr_name, attr_value)
         # Insert sub-elements.
         for index, dest_interface_subelem in enumerate(dest_interface_elem):
-            # NOTE(mnaser): If we don't have an MTU, don't define one, else
-            #               the live migration will crash.
-            if dest_interface_subelem.tag == 'mtu' and mtu is None:
+            # Ensure that the MTU does not change during a live-migration.
+            if dest_interface_subelem.tag == 'mtu':
                 continue
             interface_dev.insert(index, dest_interface_subelem)
-        # And finally re-insert the hw address.
+        # And finally re-insert the hw address and the original MTU.
         interface_dev.insert(index + 1, address)
+        interface_dev.insert(index + 2, mtu)
 
     return xml_doc
 

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -261,6 +261,9 @@ end
 
 # Add feature to rewrite monitor addresses in the domain XML using values from
 # migration.conf instead to faciliate Ceph monitor migration exercises
+#
+# Also, ensure that the MTU is not changed during a live-migration.
+# https://bugs.launchpad.net/nova/+bug/1984009
 cookbook_file '/usr/lib/python3/dist-packages/nova/virt/libvirt/migration.py' do
   source 'nova/migration.py'
   notifies :run, 'execute[py3compile-nova]', :immediately


### PR DESCRIPTION
Currently, setting the MTU of a cloud does not really work:

  * The MTU observed in the DHCP offer will always be 1500,
    regardless of how the OpenStack network is configured.

  * Live-migrations break for any VMs which were born on
    an OpenStack network with one MTU, but which was since
    changed to another.

This PR addresses both issues (see commit messages for
details).