### PR TITLE
change markupsafe version to 2.0.1

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -93,6 +93,7 @@ execute 'install rally in virtualenv' do
     pip install 'pip>=19.1.1'
     pip install 'decorator<=4.4.2'
     pip install 'jinja2<3.0.0'
+    pip install 'markupsafe==2.0.1'
     pip install rally-openstack==#{rally_openstack_version} rally==#{rally_version}
   EOH
   not_if "rally --version | grep rally-openstack | grep #{rally_openstack_version}"


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*
Focal Jenkins builds failed at the deployment stage due to this  ImportError: cannot import name 'soft_unicode' from 'markupsafe'. This is because rally package requires a specific version of markupsafe to be installed

**Describe your changes**
add pip install markupsafe 2.0.1 before install rally 

**Testing performed**
Jenkens focal build with 1h1w succeeded
