### PR TITLE
ceph: Default to autoscaler to warn

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -103,6 +103,10 @@ default['bcpc']['ceph']['bluestore_fsck_quick_fix_threads'] = 1
 # instances from being able to access their root file system after a crash.
 default['bcpc']['ceph']['rbd_default_features'] = 33
 
+# Disable automated autoscaler changes on new pools by default, but still
+# raise a health warning when PGs are deemed undersized.
+default['bcpc']['ceph']['osd_pool_default_pg_autoscale_mode'] = 'warn'
+
 # ceph mgr,mon,osd service installation flags
 default['bcpc']['ceph']['mgr']['enabled'] = true
 default['bcpc']['ceph']['mon']['enabled'] = true

--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -17,6 +17,11 @@ mon osd down out interval = <%= node['bcpc']['ceph']['mon_osd_down_out_interval'
 osd deep scrub interval = <%= @node['bcpc']['ceph']['osd_deep_scrub_interval'] %>
 osd scrub max interval = <%= @node['bcpc']['ceph']['osd_scrub_max_interval'] %>
 
+# Autoscaler control. This allows operators to optionally receive health
+# warnings (or disregard suggestions altogether) when the PGs are deemed under
+# or over-sized, rather than having Ceph act on them automatically.
+osd_pool_default_pg_autoscale_mode = <%= node['bcpc']['ceph']['osd_pool_default_pg_autoscale_mode'] %>
+
 [mon]
 auth allow insecure global id reclaim = <%= node['bcpc']['ceph']['mon_auth_allow_insecure_global_id_reclaim'] %>
 mon compact on start = true


### PR DESCRIPTION
Two unresolved issues in Octopus make automated PG changes
potentially harmful (OSDs can segfault due to race
conditions in omap pinning, or hit a condition that causes
them to balloon in memory consumption and takeout the
host).

For this reason, provide control over the default
autoscaler action and disable any automated changes for
now.

Pertinent upstream issues which may arise:
  * https://tracker.ceph.com/issues/53729
  * https://tracker.ceph.com/issues/56382