### PR TITLE
focal/configure-system: Retain `polkit`

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -171,7 +171,6 @@
     - multipathd.socket
     - multipathd
     - packagekit
-    - polkit
     - snapd.socket
     - snapd
     - snapd.seeded
@@ -204,7 +203,6 @@
     - multipath-tools
     - packagekit
     - packagekit-tools
-    - policykit-1
     - snapd
     - ubuntu-advantage-tools
     - update-notifier-common


### PR DESCRIPTION
`configure-system` run against a live Focal hypervisor
will break it, because it tries to remove `policykit-1`,
which `nova-compute` depends on. `polkit` seems essential
and cannot be disabled, so just leave it?

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>