### PR TITLE
`calico-work`: remove `systemd` override logic

### DIFF
--- a/chef/cookbooks/bcpc/recipes/calico-work.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-work.rb
@@ -27,20 +27,6 @@ end
 
 service 'calico-dhcp-agent'
 
-execute 'reload systemd' do
-  action :nothing
-  command 'systemctl daemon-reload'
-end
-
-cookbook_file '/etc/systemd/system/calico-dhcp-agent.service.d/custom.conf' do
-  action :delete
-  notifies :run, 'execute[reload systemd]', :immediately
-end
-
-directory '/etc/systemd/system/calico-dhcp-agent.service.d' do
-  action :delete
-end
-
 # these neutron services are installed/enabled by calico packages
 # these services are superseded by nova-metadata-agent and calico-dhcp-agent
 # so we don't need them to be enabled/running


### PR DESCRIPTION
At one point in time, we needed to add some `systemd`
override logic, but that's been removed for at least a
couple releases now.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>