### PR TITLE
`neutron-server`: Avoid spurious build failures

### DIFF
--- a/chef/cookbooks/bcpc/files/default/neutron/override.conf
+++ b/chef/cookbooks/bcpc/files/default/neutron/override.conf
@@ -1,0 +1,6 @@
+[Unit]
+StartLimitIntervalSec=20s
+StartLimitBurst=10
+
+[Service]
+RestartSec=3s

--- a/chef/cookbooks/bcpc/recipes/neutron-head.rb
+++ b/chef/cookbooks/bcpc/recipes/neutron-head.rb
@@ -178,6 +178,22 @@ if platform?('ubuntu') && node['platform_version'] == '18.04'
   end
 end
 
+# neutron-server can fail to restart during bootstrap; add a throttle to
+# reduce intervals between starts from 100ms to 3sec to avoid failures.
+execute 'reload systemd' do
+  action :nothing
+  command 'systemctl daemon-reload'
+end
+
+directory '/etc/systemd/system/neutron-server.service.d' do
+  action :create
+end
+
+cookbook_file '/etc/systemd/system/neutron-server.service.d/override.conf' do
+  source 'neutron/override.conf'
+  notifies :run, 'execute[reload systemd]', :immediately
+end
+
 service 'neutron-server'
 
 #


### PR DESCRIPTION
Under Focal, `neutron-server` is observed to sometimes
fail to start cleanly the first few runs (exits with a
non-zero code). In response to this, `systemd` attempts to
the process itself a few times before signaling an error
upwards.

Unfortunately, during some builds, it is observed that
start/retry burst limits (configurable via the [Unit]
StartLimitIntervalSec and StartLimitBurst parameters)
are being violated, which ultimately causes `systemd` to
raise an error upwards, and which subsequently causes
`chef-client` to fail.

Thus, bump the service restart interval upwards and
double the default burst limits (as StartLimitIntervalSec
must be > StartLimitBurst * RestartSec to avoid restarting
the service indefinitely in the event of a true failure).

This improves the success rate of Focal builds.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>