### PR TITLE
Add a playbook task to format NVMes on a host

### DIFF
--- a/ansible/playbooks/roles/common/filter_plugins/util.py
+++ b/ansible/playbooks/roles/common/filter_plugins/util.py
@@ -145,9 +145,13 @@ def optimal_nvme_lbaf(a, *args, **kw):
     for index, lbaf in enumerate(lbafs):
         lbaf['index'] = index
 
-    # Order LBAFs by RP (relative performance), then MS (metadata size)
-    # We want the best-performing LBAF with the least amount of metadata
-    ordered_lbafs = sorted(lbafs, key=lambda lbaf: (lbaf['rp'], lbaf['ms']))
+    # Order LBAFs by largest sector size, then RP (relative performance), and
+    # finally smallest MS (metadata size). We want the largest sector size
+    # possible that is best-performing and which has the least metadata.
+    def lbaf_filter(lbaf):
+        return (-lbaf['ds'], -lbaf['rp'], lbaf['ms'])
+
+    ordered_lbafs = sorted(lbafs, key=lbaf_filter)
 
     # Return the "best" LBAF index given the above criteria
     return ordered_lbafs[0]['index']

--- a/ansible/playbooks/roles/common/tasks/format-nvmes.yml
+++ b/ansible/playbooks/roles/common/tasks/format-nvmes.yml
@@ -1,0 +1,18 @@
+- name: Derive a list of NVMe block devices
+  ansible.builtin.find:
+    paths: /sys/block
+    patterns: '^nvme\d+n\d+$'
+    use_regex: yes
+    recurse: no
+    file_type: link
+  register: found_nvmes
+
+- name: Set a fact corresponding to a list of NVMe block devices
+  set_fact:
+    nvme_block_devices: "{{ found_nvmes['files'] | map(attribute='path') | map('regex_replace', '^/sys/block', '/dev') }}"
+
+- name: Format the NVMes
+  include_tasks: format-nvme.yml
+  loop: "{{ nvme_block_devices }}"
+  loop_control:
+    loop_var: block_device

--- a/ansible/playbooks/roles/common/tasks/main.yml
+++ b/ansible/playbooks/roles/common/tasks/main.yml
@@ -29,3 +29,7 @@
 - import_tasks: configure-node.yml
   become: true
   tags: [never,configure-node]
+
+- import_tasks: format-nvmes.yml
+  become: true
+  tags: [never,format-nvmes]


### PR DESCRIPTION
Different vendors use different LBAFs; for Ceph, we want
to automatically select the optimal LBAF and have a way
to format the drives using automation.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>