### PR TITLE
ceph: Allow mon_max_pool_pg_num tuning

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -20,6 +20,9 @@ default['bcpc']['ceph']['mon_auth_allow_insecure_global_id_reclaim'] = false
 # more threads if they are available.
 default['bcpc']['ceph']['mon_cpu_threads'] = 16
 
+# The maximum value of pg_num and pgp_num for any given pool.
+default['bcpc']['ceph']['mon_max_pool_pg_num'] = 131072
+
 # Max time between consecutive beacons before marking a mgr as failed.
 # And how long between mgr beacons to the mons.
 # The defaults are too small for large clusters with lots of PGs; it is

--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -26,6 +26,7 @@ osd_pool_default_pg_autoscale_mode = <%= node['bcpc']['ceph']['osd_pool_default_
 auth allow insecure global id reclaim = <%= node['bcpc']['ceph']['mon_auth_allow_insecure_global_id_reclaim'] %>
 mon compact on start = true
 mon cpu threads = <%= node['bcpc']['ceph']['mon_cpu_threads'] %>
+mon max pool pg num = <%= node['bcpc']['ceph']['mon_max_pool_pg_num'] %>
 mon mgr beacon grace = <%= node['bcpc']['ceph']['mon_mgr_beacon_grace'] %>
 mgr tick period = <%= node['bcpc']['ceph']['mgr_tick_period'] %>
 


### PR DESCRIPTION
Allow `mon_max_pool_pg_num` to be tuned, and raise the default from 64k to 128k.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>