### PR TITLE
Change the default for ceph pools to 4 replicas

### DIFF
--- a/chef/cookbooks/bcpc/attributes/cinder.rb
+++ b/chef/cookbooks/bcpc/attributes/cinder.rb
@@ -23,4 +23,4 @@ default['bcpc']['cinder']['quota'] = {
 # ceph (rbd)
 default['bcpc']['cinder']['ceph']['user'] = 'cinder'
 default['bcpc']['cinder']['ceph']['pool']['name'] = 'volumes'
-default['bcpc']['cinder']['ceph']['pool']['size'] = 3
+default['bcpc']['cinder']['ceph']['pool']['size'] = 4


### PR DESCRIPTION
default['bcpc']['cinder']['ceph']['pool']['size'] = 4

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
