### PR TITLE
Mon config changes

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -11,6 +11,11 @@ default['bcpc']['ceph']['osds'] = %w(sdb sdc sdd sde)
 default['bcpc']['ceph']['choose_leaf_type'] = 0
 default['bcpc']['ceph']['osd_scrub_load_threshold'] = 0.5
 
+# With the increase to 4 copies the number of PGs on an osd in machine maint might > 250
+default['bcpc']['ceph']['mon_max_pg_per_osd'] = 450 
+
+
+
 # https://docs.ceph.com/en/latest/security/CVE-2021-20288/
 # By default, new clusters should reclaim global_id for good security posture
 default['bcpc']['ceph']['mon_auth_allow_insecure_global_id_reclaim'] = false

--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -5,8 +5,8 @@
 default['bcpc']['ceph']['repo']['enabled'] = false
 default['bcpc']['ceph']['repo']['url'] = ''
 
-default['bcpc']['ceph']['pg_num'] = 8
-default['bcpc']['ceph']['pgp_num'] = 8
+default['bcpc']['ceph']['pg_num'] = 1024
+default['bcpc']['ceph']['pgp_num'] = 1024
 default['bcpc']['ceph']['osds'] = %w(sdb sdc sdd sde)
 default['bcpc']['ceph']['choose_leaf_type'] = 0
 default['bcpc']['ceph']['osd_scrub_load_threshold'] = 0.5

--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -29,7 +29,7 @@ mon cpu threads = <%= node['bcpc']['ceph']['mon_cpu_threads'] %>
 mon max pool pg num = <%= node['bcpc']['ceph']['mon_max_pool_pg_num'] %>
 mon mgr beacon grace = <%= node['bcpc']['ceph']['mon_mgr_beacon_grace'] %>
 mgr tick period = <%= node['bcpc']['ceph']['mgr_tick_period'] %>
-mon mon max pg per osd = <%= node['bcpc']['ceph']['mon_max_pg_per_osd'] %>
+mon max pg per osd = <%= node['bcpc']['ceph']['mon_max_pg_per_osd'] %>
 
 [mgr]
 mgr stats period = <%= node['bcpc']['ceph']['mgr_stats_period'] %>

--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -29,6 +29,7 @@ mon cpu threads = <%= node['bcpc']['ceph']['mon_cpu_threads'] %>
 mon max pool pg num = <%= node['bcpc']['ceph']['mon_max_pool_pg_num'] %>
 mon mgr beacon grace = <%= node['bcpc']['ceph']['mon_mgr_beacon_grace'] %>
 mgr tick period = <%= node['bcpc']['ceph']['mgr_tick_period'] %>
+mon mon max pg per osd = <%= node['bcpc']['ceph']['mon_max_pg_per_osd'] %>
 
 [mgr]
 mgr stats period = <%= node['bcpc']['ceph']['mgr_stats_period'] %>


### PR DESCRIPTION
With the move to 4 copies the number of PGs/osd in a Maintenance scenario we need to up the max pgs per osd up to 450
mon max pgs per osd = 450

moved the default pg and pgp_num from 8 to 1024