### PR TITLE
ceph: Allow mon_max_pg_per_osd tuning

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -20,6 +20,11 @@ default['bcpc']['ceph']['mon_auth_allow_insecure_global_id_reclaim'] = false
 # more threads if they are available.
 default['bcpc']['ceph']['mon_cpu_threads'] = 16
 
+# When raising pg(p)_num and size on large deployments, one may also need
+# to raise mon_max_pg_per_osd to allow OSDs to recover under certain
+# conditions.
+default['bcpc']['ceph']['mon_max_pg_per_osd'] = 450
+
 # The maximum value of pg_num and pgp_num for any given pool.
 default['bcpc']['ceph']['mon_max_pool_pg_num'] = 131072
 

--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -26,6 +26,7 @@ osd_pool_default_pg_autoscale_mode = <%= node['bcpc']['ceph']['osd_pool_default_
 auth allow insecure global id reclaim = <%= node['bcpc']['ceph']['mon_auth_allow_insecure_global_id_reclaim'] %>
 mon compact on start = true
 mon cpu threads = <%= node['bcpc']['ceph']['mon_cpu_threads'] %>
+mon max pg per osd = <%= node['bcpc']['ceph']['mon_max_pg_per_osd'] %>
 mon max pool pg num = <%= node['bcpc']['ceph']['mon_max_pool_pg_num'] %>
 mon mgr beacon grace = <%= node['bcpc']['ceph']['mon_mgr_beacon_grace'] %>
 mgr tick period = <%= node['bcpc']['ceph']['mgr_tick_period'] %>


### PR DESCRIPTION
Similar to #2070, but `mon_max_pg_per_osd` tuning.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>