### PR TITLE
Set default values of `pg[p]_num` to 32

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -5,8 +5,8 @@
 default['bcpc']['ceph']['repo']['enabled'] = false
 default['bcpc']['ceph']['repo']['url'] = ''
 
-default['bcpc']['ceph']['pg_num'] = 8
-default['bcpc']['ceph']['pgp_num'] = 8
+default['bcpc']['ceph']['pg_num'] = 32
+default['bcpc']['ceph']['pgp_num'] = 32
 default['bcpc']['ceph']['osds'] = %w(sdb sdc sdd sde)
 default['bcpc']['ceph']['choose_leaf_type'] = 0
 default['bcpc']['ceph']['osd_scrub_load_threshold'] = 0.5


### PR DESCRIPTION
Signed-off-by: David Comay <dcomay@bloomberg.net>

While doing an upstream build, I noticed that out of the box Ceph is *not* in a `HEALTH_OK` state after the cluster is built in both the `1h1w` and `3h3w` configurations. For the former, the following is the health detail

```
[WRN] POOL_NO_REDUNDANCY: 3 pool(s) have no replicas configured
    pool 'images' has no replicas configured
    pool 'vms' has no replicas configured
    pool 'volumes' has no replicas configured
[WRN] POOL_TOO_FEW_PGS: 3 pools have too few placement groups
    Pool images has 8 placement groups, should have 32
    Pool vms has 8 placement groups, should have 32
    Pool volumes has 8 placement groups, should have 32
```

and in the latter, there's the `POOL_TOO_FEW_PGS` warning. At the very least, we can address that one so the `3h3w` is completely healthy and the `1h1w` only has the lack of redundancy warning.