### PR TITLE
format-nvme: Fix LBA select logic

### DIFF
--- a/ansible/playbooks/roles/common/filter_plugins/util.py
+++ b/ansible/playbooks/roles/common/filter_plugins/util.py
@@ -145,11 +145,11 @@ def optimal_nvme_lbaf(a, *args, **kw):
     for index, lbaf in enumerate(lbafs):
         lbaf['index'] = index
 
-    # Order LBAFs by largest sector size, then RP (relative performance), and
-    # finally smallest MS (metadata size). We want the largest sector size
-    # possible that is best-performing and which has the least metadata.
+    # Order LBAFs by RP (relative performance), then largest sector size, and
+    # finally smallest MS (metadata size). We want the best-performing LBA with
+    # the largest sector size and which has the least amount of metadata.
     def lbaf_filter(lbaf):
-        return (-lbaf['ds'], -lbaf['rp'], lbaf['ms'])
+        return (lbaf['rp'], -lbaf['ds'], lbaf['ms'])
 
     ordered_lbafs = sorted(lbafs, key=lbaf_filter)
 


### PR DESCRIPTION
This section has a bit of back and forth, and after reading
the spec I realized I made an error resulting in a bit of
that.

The spec says:
Relative Performance (RP): This field indicates the relative
performance of the LBA format indicated relative to other
LBA formats supported by the controller. Depending on the
size of the LBA and associated metadata, there may be
performance implications. The performance analysis is based
on better performance on a queue depth 32 with 4 KiB read
workload. The meanings of the values indicated are included
in the following table.

00b - Best Performance
01b - Better Performance
10b - Good Performance
11b - Degraded Performance

So we want the RP value which is the smallest, and then we
can punt to sector size. I've verified this yields the
ostensibly correct result on a large matrix of different
NVMe devices/firmwares.