### PR TITLE
horizon: Use same memcached timeouts as elsewhere

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
+++ b/chef/cookbooks/bcpc/templates/default/horizon/local_settings.py.erb
@@ -57,7 +57,8 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 CACHES = {
   'default': {
     'BACKEND' : 'django.core.cache.backends.memcached.MemcachedCache',
-    'LOCATION' : [<%= @headnodes.map{|n| "'#{n['service_ip']}:11211'"}.join(',') %>]
+    'LOCATION' : [<%= @headnodes.map{|n| "'#{n['service_ip']}:11211'"}.join(',') %>],
+    'OPTIONS': {'socket_timeout': 1, 'dead_retry': 60}
   }
 }
 


### PR DESCRIPTION
When a memcached server becomes unavailable (e.g. as part
of a host reboot), the Horizon dashboard got a little
sluggish. As it turns out, the dashboard is using the
default memcached settings, separate from the tuned ones
that `keystone` is using.

After changing the Horizon memcached timeouts to match
that of `keystone`, the dashboard was a lot more peppy when
one of the memcached instances became unavailable.