### PR TITLE
Begin deprecating 18.04 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,6 @@ To create a libvirt build, first install the following packages and plugins:
 ```shell
 sudo apt-get install build-essential dnsmasq libguestfs-tools libvirt-dev pkg-config qemu-utils
 vagrant plugin install vagrant-libvirt vagrant-mutate
-```
-
-If you are using Ubuntu 18.04, a base Bento box for Vagrant can be added with the following commands:
-
-```shell
-vagrant box add bento/ubuntu-18.04 --box-version 202005.21.0 --provider virtualbox
-vagrant mutate bento/ubuntu-18.04 libvirt
-```
-
-Or if you are using Ubuntu 20.04:
-```shell
 vagrant box add bento/ubuntu-20.04 --box-version 202206.03.0 --provider virtualbox
 vagrant mutate bento/ubuntu-20.04 libvirt
 ```
@@ -170,13 +159,6 @@ reboot your development host (assuming no scripts reset the VAGRANT
 variables).
 
 This would look something like this:
-
-```shell
-$ rm -rf ~/.vagrant.d/boxes/bento-VAGRANTSLASH-ubuntu-18.04/202005.21.0/libvirt/
-$ sudo reboot
-```
-Similarly, to remove the mutated libvirt box built with Ubuntu 20.04,
-the following commands can be used:
 
 ```shell
 $ rm -rf ~/.vagrant.d/boxes/bento-VAGRANTSLASH-ubuntu-20.04/202206.03.0/libvirt/

--- a/virtual/packer/config/variables.json.libvirt.example
+++ b/virtual/packer/config/variables.json.libvirt.example
@@ -3,9 +3,9 @@
   "bcc_apt_url": "",
   "bcc_http_proxy_url": "",
   "bcc_https_proxy_url": "",
-  "kernel_version": "generic-hwe-18.04-edge",
-  "base_box": "bento/ubuntu-18.04",
-  "base_box_version": "202005.21.0",
+  "kernel_version": "generic-hwe-20.04-edge",
+  "base_box": "bento/ubuntu-20.04",
+  "base_box_version": "202206.03.0",
   "base_box_provider": "libvirt",
-  "output_packer_box_name": "bcc-ubuntu-18.04"
+  "output_packer_box_name": "bcc-ubuntu-20.04"
 }

--- a/virtual/packer/config/variables.json.virtualbox.example
+++ b/virtual/packer/config/variables.json.virtualbox.example
@@ -3,9 +3,9 @@
   "bcc_apt_url": "",
   "bcc_http_proxy_url": "",
   "bcc_https_proxy_url": "",
-  "kernel_version": "generic-hwe-18.04-edge",
-  "base_box": "bento/ubuntu-18.04",
-  "base_box_version": "202005.21.0",
+  "kernel_version": "generic-hwe-20.04-edge",
+  "base_box": "bento/ubuntu-20.04",
+  "base_box_version": "202206.03.0",
   "base_box_provider": "virtualbox",
-  "output_packer_box_name": "bcc-ubuntu-18.04"
+  "output_packer_box_name": "bcc-ubuntu-20.04"
 }

--- a/virtual/vagrantbox.json
+++ b/virtual/vagrantbox.json
@@ -1,4 +1,4 @@
 {
-  "vagrant_box": "bcc-ubuntu-18.04",
+  "vagrant_box": "bcc-ubuntu-20.04",
   "vagrant_box_version": "0"
 }

--- a/virtual/vagrantbox.json.18.04.example
+++ b/virtual/vagrantbox.json.18.04.example
@@ -1,0 +1,4 @@
+{
+  "vagrant_box": "bcc-ubuntu-18.04",
+  "vagrant_box_version": "0"
+}

--- a/virtual/vagrantbox.json.20.04.example
+++ b/virtual/vagrantbox.json.20.04.example
@@ -1,4 +1,0 @@
-{
-  "vagrant_box": "bcc-ubuntu-20.04",
-  "vagrant_box_version": "0"
-}


### PR DESCRIPTION
  * Remove mention of 18.04 in the README

  * Make the default Vagrant examples use 20.04. Leave the 18.04 examples in place for now. Once we cleanup all aspects of 18.04 builds, they can be deleted