### PR TITLE
RDTIBCC-4253: Enable the setting of custom routes

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-bgp.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-bgp.yml
@@ -57,3 +57,41 @@
   changed_when: false
   register: result
   until: result.rc == 0
+
+- name: add a custom route
+  block:
+    - name: create custom route systemd unit
+      template:
+        src: bird/bcc-custom-route.service.j2
+        dest: /etc/systemd/system/bcc-custom-route.service
+        mode: 0644
+      register: bcc_custom_route
+
+    - name: apply custom route
+      systemd:
+        daemon_reload: true
+        enabled: true
+        name: bcc-custom-route
+        state: restarted
+      when: bcc_custom_route.changed  # noqa no-handler
+  when: networking.custom_route is defined
+
+- name: delete any custom routes
+  block:
+    - name: check if custom route service exists
+      stat:
+        path: /etc/systemd/system/bcc-custom-route.service
+      register: route_service_file
+
+    - name: remove custom route
+      systemd:
+        name: bcc-custom-route
+        state: stopped
+      when: route_service_file.stat.exists
+
+    - name: delete custom route service
+      file:
+        path: /etc/systemd/system/bcc-custom-route.service
+        state: absent
+      when: route_service_file.stat.exists
+  when: networking.custom_route is not defined

--- a/ansible/playbooks/roles/common/templates/bird/bird.conf.j2
+++ b/ansible/playbooks/roles/common/templates/bird/bird.conf.j2
@@ -11,7 +11,14 @@ filter to_tor {
 
 filter to_kernel {
   krt_prefsrc = {{ interfaces['service']['ip'] }};
+{% if 'default_route_params' in networking %}
+  if net = 0.0.0.0/0 then {
+    {{ networking['default_route_params'] }}
+    accept;
+  }
+{% else %}
   if net = 0.0.0.0/0 then accept;
+{% endif %}
   reject;
 }
 


### PR DESCRIPTION
Certain deployments may require the ability to set custom routes, e.g. use a different MTU for traffic outbound to a given CIDR).

Signed-off-by: Mike Boruta <mboruta1@bloomberg.net>

**Describe your changes**
See commit message

**Testing performed**
Tested on a local cluster both the addition and deletion of custom routes.

**Additional context**
N/A
