### PR TITLE
ceph: Fix max PG/OSD tunable

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -12,6 +12,7 @@ rbd default features = <%= node['bcpc']['ceph']['rbd_default_features'] %>
 osd crush initial weight = <%= node['bcpc']['ceph']['osd_crush_initial_weight'] %>
 admin socket mode = 0775
 mon osd down out interval = <%= node['bcpc']['ceph']['mon_osd_down_out_interval'] %>
+mon max pg per osd = <%= node['bcpc']['ceph']['mon_max_pg_per_osd'] %>
 
 # settings to throttle OSD scrubbing visible to both mgrs and OSDs
 osd deep scrub interval = <%= @node['bcpc']['ceph']['osd_deep_scrub_interval'] %>
@@ -26,7 +27,6 @@ osd_pool_default_pg_autoscale_mode = <%= node['bcpc']['ceph']['osd_pool_default_
 auth allow insecure global id reclaim = <%= node['bcpc']['ceph']['mon_auth_allow_insecure_global_id_reclaim'] %>
 mon compact on start = true
 mon cpu threads = <%= node['bcpc']['ceph']['mon_cpu_threads'] %>
-mon max pg per osd = <%= node['bcpc']['ceph']['mon_max_pg_per_osd'] %>
 mon max pool pg num = <%= node['bcpc']['ceph']['mon_max_pool_pg_num'] %>
 mon mgr beacon grace = <%= node['bcpc']['ceph']['mon_mgr_beacon_grace'] %>
 mgr tick period = <%= node['bcpc']['ceph']['mgr_tick_period'] %>


### PR DESCRIPTION
The max PG/OSD tunable is referenced in (at least) also
mgr and OSD code. The mgrs perform healthchecks and appear
to call into PGMap::get_health_checks, here:
https://github.com/ceph/ceph/blob/8e07fbd2eac1a8dde37a1c3cc36228c1f68f8391/src/mgr/DaemonServer.cc#L2593

Even though the definition of such function lives under
the mon directory of source code, here:
https://github.com/ceph/ceph/blob/3215a9d5333907ceb549083da629eab7378bcc7e/src/mon/PGMap.cc#L2370

The OSDs also use this variable, here, and will stop
backfilling once the PGs/OSD exceed mon_max_pg_per_osd *
osd_max_pg_per_osd_hard_ratio, as seen here:
https://github.com/ceph/ceph/blob/a968c6d0247d2ce1d2a19ab504baa5845ba2de3b/src/osd/OSD.cc#L5154

Thus, despite the variable is prefixed with a mon_ that
suggests it needs to be placed under [mon] config, it
really needs to be set globally. This commit does that.