### PR TITLE
Shoehorn ceph-deploy in when using Jammy

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -155,6 +155,7 @@ web_server_assets:
   - file_asset: calicoctl
   - file_asset: consul
   - file_asset: etcd3gw
+  - file_asset: ceph-deploy
 
 # all web server file assets
 all_web_server_assets: "{{ web_server_assets +
@@ -206,6 +207,13 @@ assets_files:
     url: https://files.pythonhosted.org/packages/3b/1a/155c139adcf50c382f7ff8eb5a00b5aa725ee8ea438ec2b8109dfe67be9b/etcd3gw-0.2.6.tar.gz
     checksum: sha256:4a765a382ae18ebd4fccbc1388d1ac5226db0540bccd1f081052600df89145fd
     filename: etcd3gw-0.2.6.tar.gz
+
+  # ceph-deploy has been deprecated and is unavailable in Jammy
+  # We are really due to move off of ceph-deploy, but for now...
+  - name: ceph-deploy
+    url: http://mirrors.kernel.org/ubuntu/pool/universe/c/ceph-deploy/ceph-deploy_2.0.1-0ubuntu1_all.deb
+    checksum: sha256:6ecd4769dbe3d65ff114f458f60840b976cb73873f7e825987613f929ffed911
+    filename: ceph-deploy_2.0.1-0ubuntu1_all.deb
 
 # all file assets
 all_file_assets: "{{ assets_files + additional_assets_files | default([]) }}"

--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -2,6 +2,11 @@
 # ceph
 ###############################################################################
 
+ceph_deploy_package = 'ceph-deploy_2.0.1-0ubuntu1_all.deb'
+default['bcpc']['ceph']['ceph-deploy']['file'] = ceph_deploy_package
+default['bcpc']['ceph']['ceph-deploy']['source'] = "#{default['bcpc']['web_server']['url']}/#{ceph_deploy_package}"
+default['bcpc']['ceph']['ceph-deploy']['checksum'] = '6ecd4769dbe3d65ff114f458f60840b976cb73873f7e825987613f929ffed911'
+
 default['bcpc']['ceph']['repo']['enabled'] = false
 default['bcpc']['ceph']['repo']['url'] = ''
 

--- a/chef/cookbooks/bcpc/recipes/ceph-packages.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-packages.rb
@@ -22,14 +22,32 @@ apt_repository 'ceph' do
   only_if { node['bcpc']['ceph']['repo']['enabled'] }
 end
 
-package %w(
-  ceph
-  ceph-deploy
-)
+package 'ceph'
+
+# ceph-deploy has been deprecated and is unavailable in Jammy
+if platform?('ubuntu') && node['platform_version'] == '22.04'
+  package = node['bcpc']['ceph']['ceph-deploy']['file']
+  save_path = "#{Chef::Config[:file_cache_path]}/#{package}"
+  file_url = node['bcpc']['ceph']['ceph-deploy']['source']
+  file_checksum = node['bcpc']['ceph']['ceph-deploy']['checksum']
+
+  remote_file save_path do
+    source file_url
+    checksum file_checksum
+    notifies :run, 'execute[install ceph-deploy]', :immediately
+  end
+
+  execute 'install ceph-deploy' do
+    action :nothing
+    command "dpkg -i #{Chef::Config[:file_cache_path]}/#{package}"
+  end
+else
+  package 'ceph-deploy'
+end
 
 # workaround python3.8 deprecation of platform.linux_distribution.
 # ceph-deploy has not been rewired to workaround this, so we do it here.
-if platform?('ubuntu') && node['platform_version'] == '20.04'
+if platform?('ubuntu') && ['20.04', '22.04'].include?(node['platform_version'])
   package 'python3-distro'
 
   cookbook_file '/usr/lib/python3/dist-packages/ceph_deploy/hosts/remotes.py' do


### PR DESCRIPTION
ceph-deploy is deprecated (it has been, for awhile) and
thus no longer ships with Jammy. But as it's just a python
module, carting it from the last release that it shipped
with (Focal) is fine and lets us carry on.