### PR TITLE
rally: Pin SQLalchemy dependency

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -94,6 +94,7 @@ execute 'install rally in virtualenv' do
     pip install 'decorator<=4.4.2'
     pip install 'jinja2<3.0.0'
     pip install 'markupsafe==2.0.1'
+    pip install 'SQLAlchemy<2.0.0'
     pip install rally-openstack==#{rally_openstack_version} rally==#{rally_version}
   EOH
   not_if "rally --version | grep rally-openstack | grep #{rally_openstack_version}"


### PR DESCRIPTION
SQLAlchemy 2.0.0 does not work with `rally` in it's current
form. `rally` appears to try calling `begin()` on a
connection when it already exists and has a transaction
pending as part of the `rally db ensure` command. This now
raises an exception and causes the build/CI to fail.

We really need to not use arbitrary versions of packages
in the builds, but for now pin SQLalchemy as to unbreak the
build.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>