### PR TITLE
nova: Remove deprecated RetryFilter

### DIFF
--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -77,7 +77,6 @@ default['bcpc']['nova']['metadata']['cache_expiration'] = 60
 # Nova scheduler default filters
 default['bcpc']['nova']['scheduler_default_filters'] = %w(
   AggregateInstanceExtraSpecsFilter
-  RetryFilter
   AvailabilityZoneFilter
   ComputeFilter
   ComputeCapabilitiesFilter


### PR DESCRIPTION
From the Ussuri documentation, we should not use this anymore:
https://docs.openstack.org/nova/ussuri/user/filter-scheduler.html

RetryFilter - DEPRECATED; filters hosts that have been
attempted for scheduling. Only passes hosts that have not
been previously attempted.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>