### PR TITLE
rabbitmq: Remove deprecated `node_health_check`, fix broker restarts

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rabbitmq.rb
+++ b/chef/cookbooks/bcpc/recipes/rabbitmq.rb
@@ -56,24 +56,24 @@ end
 
 template '/etc/rabbitmq/rabbitmq.conf.d/bcpc.conf' do
   source 'rabbitmq/bcpc.conf.erb'
-  notifies :restart, 'service[rabbitmq-server]', :delayed
+  notifies :restart, 'service[rabbitmq-server]', :immediately
 end
 
 template '/etc/default/rabbitmq-server' do
   source 'rabbitmq/default.erb'
-  notifies :restart, 'service[rabbitmq-server]', :delayed
+  notifies :restart, 'service[rabbitmq-server]', :immediately
 end
 
 file '/var/lib/rabbitmq/.erlang.cookie' do
   mode '400'
   content config['rabbit']['cookie']
-  notifies :restart, 'service[rabbitmq-server]', :delayed
+  notifies :restart, 'service[rabbitmq-server]', :immediately
 end
 
 execute 'enable rabbitmq web mgmt' do
   command '/usr/sbin/rabbitmq-plugins enable rabbitmq_management'
   not_if '/usr/sbin/rabbitmq-plugins list -m -e | grep "^rabbitmq_management$"'
-  notifies :restart, 'service[rabbitmq-server]', :delayed
+  notifies :restart, 'service[rabbitmq-server]', :immediately
 end
 
 template '/etc/rabbitmq/rabbitmq.config' do


### PR DESCRIPTION
Also, add `set -o pipefail` - how did this work, before?