### PR TITLE
cinder: Major recipe refactoring

### DIFF
--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -121,6 +121,11 @@ begin
 end
 # create cinder volume services and endpoints ends
 
+# Install *only* the base Cinder scaffolding that creates the role account
+# and provides functionality for initializing the database. This gives us
+# a window to configure the services and initialize the database prior to
+# installing the packages which provide unit files (and thus start) the
+# actual Cinder services (cinder-api, cinder-scheduler, cinder-volume).
 package %w(
   cinder-common
   python3-cinder
@@ -213,8 +218,8 @@ template '/etc/cinder/cinder.conf' do
   )
 
   notifies :restart, 'service[cinder-api]', :delayed
-  notifies :restart, 'service[cinder-volume]', :delayed
   notifies :restart, 'service[cinder-scheduler]', :delayed
+  notifies :restart, 'service[cinder-volume]', :delayed
 end
 
 # Ensure the database user is present on ProxySQL

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -121,35 +121,16 @@ begin
 end
 # create cinder volume services and endpoints ends
 
-# cinder package installation and service definition
-package ['cinder-scheduler', 'cinder-volume'] do
-  action :upgrade
-end
+package %w(
+  cinder-common
+  python3-cinder
+)
 
-service 'cinder-api' do
-  service_name 'apache2'
-end
-
-service 'cinder-volume' do
-  retries 10
-  retry_delay 5
-end
-
-service 'cinder-scheduler' do
-  retries 10
-  retry_delay 5
-end
-
-# create policy.d dir for policy overrides
-directory '/etc/cinder/policy.d' do
-  action :create
-end
-
+# create client.*cinder Ceph users and keyrings
 directory '/etc/ceph' do
   action :create
 end
 
-# create client.*cinder Ceph users and keyrings
 cinder_config.ceph_clients.each do |client|
   template "/etc/ceph/ceph.client.#{client['client']}.keyring" do
     source 'cinder/ceph.client.cinder.keyring.erb'
@@ -172,6 +153,68 @@ cinder_config.ceph_clients.each do |client|
       "ceph auth import -i /etc/ceph/ceph.client.#{client['client']}.keyring"
     only_if { storageheadnode? }
   end
+end
+
+# create policy.d dir for policy overrides
+directory '/etc/cinder/policy.d' do
+  action :create
+end
+
+# add AccessList filter and update cinder entry_points.txt
+if zone_config.enabled?
+  cookbook_file '/usr/lib/python3/dist-packages/cinder/scheduler/filters/access_filter.py' do
+    source 'cinder/access_filter.py'
+    notifies :run, 'execute[py3compile-cinder]', :immediately
+  end
+
+  execute 'py3compile-cinder' do
+    action :nothing
+    command 'py3compile -p python3-cinder'
+  end
+
+  bash 'add AccessList filter to cinder' do
+    code <<-EOH
+      entry_points_txt=$(dpkg -L python3-cinder | grep entry_points.txt)
+
+      if [ -z ${entry_points_txt} ]; then
+        echo "entry_points.txt file path could not be found"
+        exit 1
+      fi
+
+      if ! grep AccessFilter ${entry_points_txt}; then
+        # update entry points file using crudini
+        crudini --set ${entry_points_txt} cinder.scheduler.filters \
+          AccessFilter cinder.scheduler.filters.access_filter:AccessFilter
+      fi
+    EOH
+  end
+end
+
+# lay down cinder configuration files
+cookbook_file '/etc/cinder/api-paste.ini' do
+  source 'cinder/api-paste.ini'
+  mode '0640'
+  notifies :restart, 'service[cinder-api]', :delayed
+end
+
+template '/etc/cinder/cinder.conf' do
+  source 'cinder/cinder.conf.erb'
+  mode '0640'
+  owner 'root'
+  group 'cinder'
+
+  variables(
+    db: database,
+    backends: cinder_config.backends,
+    config: config,
+    headnodes: headnodes(all: true),
+    rmqnodes: rmqnodes(all: true),
+    scheduler_default_filters: cinder_config.filters
+  )
+
+  notifies :restart, 'service[cinder-api]', :delayed
+  notifies :restart, 'service[cinder-volume]', :delayed
+  notifies :restart, 'service[cinder-scheduler]', :delayed
 end
 
 # Ensure the database user is present on ProxySQL
@@ -219,7 +262,6 @@ execute 'create cinder database' do
   command "mysql -u #{mysqladmin['username']} < /tmp/cinder-db.sql"
 
   notifies :delete, 'file[/tmp/cinder-db.sql]', :immediately
-  notifies :create, 'template[/etc/cinder/cinder.conf]', :immediately
   notifies :run, 'execute[cinder-manage db sync]', :immediately
 end
 
@@ -229,16 +271,18 @@ execute 'cinder-manage db sync' do
 end
 # create/manage cinder database ends
 
+# configure cinder service starts
+package 'cinder-api'
+
 execute 'disable old cinder config' do
   command 'a2disconf cinder-wsgi'
   only_if 'a2query -c cinder-wsgi'
 end
 
-file '/etc/apache2/conf-available/cinder-wsgi.conf' do
-  action :delete
+service 'cinder-api' do
+  service_name 'apache2'
 end
 
-# configure cinder service starts
 cinder_processes = if !node['bcpc']['cinder']['workers'].nil?
                      node['bcpc']['cinder']['workers']
                    else
@@ -263,70 +307,22 @@ execute 'enable cinder-api' do
   not_if 'a2query -s cinder-api'
 end
 
-template '/etc/cinder/cinder.conf' do
-  source 'cinder/cinder.conf.erb'
-  mode '0640'
-  owner 'root'
-  group 'cinder'
-
-  variables(
-    db: database,
-    backends: cinder_config.backends,
-    config: config,
-    headnodes: headnodes(all: true),
-    rmqnodes: rmqnodes(all: true),
-    scheduler_default_filters: cinder_config.filters
-  )
-
-  notifies :restart, 'service[cinder-volume]', :immediately
-  notifies :restart, 'service[cinder-scheduler]', :immediately
-end
-
-# add AccessList filter and update cinder entry_points.txt
-if zone_config.enabled?
-
-  cookbook_file '/usr/lib/python3/dist-packages/cinder/scheduler/filters/access_filter.py' do
-    source 'cinder/access_filter.py'
-  end
-
-  bash 'add AccessList filter to cinder' do
-    code <<-EOH
-      entry_points_txt=$(dpkg -L python3-cinder | grep entry_points.txt)
-
-      if [ -z ${entry_points_txt} ]; then
-        echo "entry_points.txt file path could not be found"
-        exit 1
-      fi
-
-      if ! grep AccessFilter ${entry_points_txt}; then
-
-        # update entry points file using crudini
-        crudini --set ${entry_points_txt} cinder.scheduler.filters \
-          AccessFilter cinder.scheduler.filters.access_filter:AccessFilter
-
-        # sleep for a brief moment before restarting cinder-scheduler
-        sleep 10
-
-        # restart cinder-scheduler
-        systemctl restart cinder-scheduler
-
-      fi
-    EOH
-  end
-end
-
-cookbook_file '/etc/cinder/api-paste.ini' do
-  source 'cinder/api-paste.ini'
-  mode '0640'
-  notifies :restart, 'service[cinder-api]', :immediately
-end
-# configure cinder service ends
-
 execute 'wait for cinder to come online' do
   environment os_adminrc
   retries 30
   command 'openstack volume service list'
 end
+
+package %w(
+  cinder-scheduler
+  cinder-volume
+) do
+  action :upgrade
+end
+
+service 'cinder-scheduler'
+service 'cinder-volume'
+# configure cinder service ends
 
 ruby_block 'collect openstack volume type list' do
   block do
@@ -369,11 +365,4 @@ cinder_config.backends.each do |backend|
 
     not_if { node.run_state['os_vol_type_props'].dig(backend_name, 'volume_backend_name') == backend_name }
   end
-end
-
-execute 'make sure cinder-volume comes up' do
-  action :nothing
-  retries 30
-  command 'systemctl start cinder-volume'
-  not_if 'systemctl status cinder-volume'
 end


### PR DESCRIPTION
Until now, we witnessed sporadic CI failures, which were
usually due to some issues with `cinder`. As it turned out,
the CI failures were the canary in the coal mine that
pointed out severe issues with respect to the ordering and
inter-dependencies of resources within the `cinder` recipe.

This commit performs significant overhaul to the recipe
in order to avoid issues with cluster bootstrapping by
reordering resources such that configuration is laid down
before services are started.

The proper ordering of resources means that we can also
eliminate a few service bounces and 'immediate' restarts
that were formerly in place to try and hammer everything
together.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>