### PR TITLE
rabbitmq: Fix Focal breakage introduced in #2097

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rabbitmq.rb
+++ b/chef/cookbooks/bcpc/recipes/rabbitmq.rb
@@ -93,6 +93,11 @@ begin
     end
 
     hosts = hosts.join(' ')
+    healthcheck_path = if ['18.04', '20.04'].include?(node['platform_version'])
+                         '/api/healthchecks/node'
+                       else
+                         '/api/health/checks/alarms'
+                       end
 
     bash 'join rabbitmq cluster' do
       code <<-DOC
@@ -105,7 +110,7 @@ begin
         member=''
 
         for h in #{hosts}; do
-          status=$(curl -su '#{username}:#{password}' "http://${h}:55672/api/health/checks/alarms")
+          status=$(curl -su '#{username}:#{password}' "http://${h}:55672#{healthcheck_path}")
           if echo ${status} | jq -e 'select(.status == "ok")'; then
             member=${h}
             break


### PR DESCRIPTION
The API path used was only supported in RabbitMQ 3.9; we
need to support RabbitMQ 3.8 (conditionally) as well. 3.9
ships with Jammy, and 3.8 is used with Focal and below.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>