### PR TITLE
ceph/quincy: Continue using WPQ queue for OSDs

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -85,6 +85,10 @@ bluestore_allocator = bitmap
 # it stays on regardless of what upstream does.
 bluefs buffered io = true
 
+# In preparation for Quincy, we are remaining on the WPQ scheduler until we
+# have landed on the new release and tested mClock sufficiently.
+osd op queue = wpq
+
 <% @rbd_users.each do |user| %>
 <%= "[client.#{user}]" %>
 rbd cache = true


### PR DESCRIPTION
Octopus introduced the mClock scheduler, and Quincy makes
it the default. We have not tested this feature though.

Until we land on Quincy and have more time to test it,
remain on WPQ.