### PR TITLE
RDTIBCC-4482: NUMA driver tuning

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -85,6 +85,7 @@
     enabled: no
     state: stopped
   with_items:
+    - irqbalance
     - iscsid
     - lxcfs
     - lxd
@@ -102,6 +103,7 @@
     - accounts-daemon
     - atd
     - fwupd
+    - irqbalance
     - multipathd.socket
     - multipathd
     - packagekit


### PR DESCRIPTION
Hardware NICs with adequate RX/TX queue counts and which
have RSS properly configured ahead of time in accordance
with the application or to the NUMA topology of the system
can realize degraded performance when `irqbalance` runs.

This is because `irqbalance` configures IRQ affinity in
accordance to system state at a point in time, which may
be at odds with how the application or system's optimal
configuration.

In our testing, we have realized 10-20% additional
performance in applications such as Ceph by specifically
configuring IRQ affinity in an optimal manner ahead of
time.