### PR TITLE
configure-sshd: Converge libvirt/physical config

### DIFF
--- a/ansible/playbooks/roles/common/templates/ssh/sshd_config.j2
+++ b/ansible/playbooks/roles/common/templates/ssh/sshd_config.j2
@@ -18,13 +18,13 @@ Protocol 2
 # What ports, IPs and protocols we listen for
 Port 22
 {% if ansible_virtualization_type == 'virtualbox' %}
-ListenAddress {{ virtualbox['nat_ip'] }}
-{% elif libvirt_kvm_guest %}
-ListenAddress {{ ansible_eth0.ipv4.address }}
+{% set mgmt_address = virtualbox['nat_ip'] %}
+{% else %}
+{% set mgmt_address = hostvars[inventory_hostname]['ansible_host'] %}
 {% endif %}
-ListenAddress {{ interfaces['service']['ip'] }}
-{% for transit in transit_interfaces -%}
-ListenAddress {{ transit['ip'] | ipaddr('address') }}
+{% set addresses = [{"ip": mgmt_address}, interfaces['service']] + transit_interfaces %}
+{% for address in addresses | map(attribute='ip') | list | unique %}
+ListenAddress {{ address | ipaddr('address') }}
 {% endfor %}
 
 # Logging


### PR DESCRIPTION
Previously, we configure virtualbox/libvirt/bare metal
slightly differently. This commit converges the
configuration of libvirt/bare metal, and also supports
the case where ansible_host != the service IP.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>