### PR TITLE
heat: Bump maximum (template) stack depth.

### DIFF
--- a/chef/cookbooks/bcpc/attributes/heat.rb
+++ b/chef/cookbooks/bcpc/attributes/heat.rb
@@ -13,3 +13,8 @@ default['bcpc']['heat']['db']['max_pool_size'] = 64
 # available by default. This provides an override.
 default['bcpc']['heat']['api_workers'] = nil
 default['bcpc']['heat']['engine_workers'] = nil
+
+# Maximum depth allowed when using nested stacks/templates. Currently, this
+# defaults to 5 upstream, which can be exceeded with sufficiently complex
+# templates. Bumping this from 5 to 8 provides sufficient headroom.
+default['bcpc']['heat']['max_nested_stack_depth'] = 8

--- a/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
@@ -25,6 +25,9 @@ num_engine_workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 # (string value)
 transport_url = rabbit://<%= @rmqnodes.map{|n| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{n['service_ip']}:5672" }.join(',') %>
 
+# Maximum depth allowed when using nested stacks/templates.
+max_nested_stack_depth = <%= node['bcpc']['heat']['max_nested_stack_depth'] %>
+
 
 [clients_keystone]
 


### PR DESCRIPTION
Heat templates which are sufficiently complex may need more
levels of nesting than is allowed by the upstream default.
Bump the default from 5 to 8 levels to provide headroom for
such use cases.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>