### PR TITLE
Optionally allow use of an internet proxy

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -173,41 +173,49 @@ assets_files:
     url: https://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
     checksum: sha256:932fcae93574e242dc3d772d5235061747dfe537668443a1f0567d893614b464
     filename: cirros-0.5.2-x86_64-disk.img
+    environment: "{{ internet_proxy | default({}) }}"
 
   - name: etcd
     url: https://github.com/etcd-io/etcd/releases/download/v3.3.10/etcd-v3.3.10-linux-amd64.tar.gz
     checksum: sha256:1620a59150ec0a0124a65540e23891243feb2d9a628092fb1edcc23974724a45
     filename: etcd-v3.3.10-linux-amd64.tar.gz
+    environment: "{{ internet_proxy | default({}) }}"
 
   - name: calicoctl
     url: https://github.com/projectcalico/calico/releases/download/v3.22.5/calicoctl-linux-amd64
     checksum: sha256:ba75fa65be0e97555b37282e1ab469ad933866eed164b40513e835279bea7348
     filename: calicoctl
+    environment: "{{ internet_proxy | default({}) }}"
 
   - name: consul
     url: https://releases.hashicorp.com/consul/1.7.2/consul_1.7.2_linux_amd64.zip
     checksum: sha256:5ab689cad175c08a226a5c41d16392bc7dd30ceaaf90788411542a756773e698
     filename: consul_1.7.2_linux_amd64.zip
+    environment: "{{ internet_proxy | default({}) }}"
 
   - name: chef_client
     url: http://downloads.cinc.sh/files/stable/cinc/15.6.10/ubuntu/18.04/cinc_15.6.10-1_amd64.deb
     checksum: sha256:08099c5a971001db92db92b06a81a816bd4f7006d2a261d1cda2c2ec46d8e235
     filename: cinc_15.6.10-1_amd64.deb
+    environment: "{{ internet_proxy | default({}) }}"
 
   - name: chef_server
     url: https://packages.chef.io/files/stable/chef-server/12.17.33/ubuntu/16.04/chef-server-core_12.17.33-1_amd64.deb
     checksum: sha256:2800962092ead67747ed2cd2087b0e254eb5e1a1b169cdc162c384598e4caed5
     filename: chef-server-core_12.17.33-1_amd64.deb
+    environment: "{{ internet_proxy | default({}) }}"
 
   - name: logrotate
     url: https://supermarket.chef.io/cookbooks/logrotate/versions/2.2.0/download
     checksum: sha256:f9385a488ec0ee02bfd680ac5aac012000006e4168f97bbf06b5b28373a1d1aa
     filename: logrotate-2.2.0.tar.gz
+    environment: "{{ internet_proxy | default({}) }}"
 
   - name: etcd3gw
     url: https://files.pythonhosted.org/packages/3b/1a/155c139adcf50c382f7ff8eb5a00b5aa725ee8ea438ec2b8109dfe67be9b/etcd3gw-0.2.6.tar.gz
     checksum: sha256:4a765a382ae18ebd4fccbc1388d1ac5226db0540bccd1f081052600df89145fd
     filename: etcd3gw-0.2.6.tar.gz
+    environment: "{{ internet_proxy | default({}) }}"
 
   # ceph-deploy has been deprecated and is unavailable in Jammy
   # We are really due to move off of ceph-deploy, but for now...
@@ -215,6 +223,7 @@ assets_files:
     url: http://mirrors.kernel.org/ubuntu/pool/universe/c/ceph-deploy/ceph-deploy_2.0.1-0ubuntu1_all.deb
     checksum: sha256:6ecd4769dbe3d65ff114f458f60840b976cb73873f7e825987613f929ffed911
     filename: ceph-deploy_2.0.1-0ubuntu1_all.deb
+    environment: "{{ internet_proxy | default({}) }}"
 
 # all file assets
 all_file_assets: "{{ assets_files + additional_assets_files | default([]) }}"


### PR DESCRIPTION
When downloading file assets, it may be desirable to use an
internet proxy. Allow one to be specified via the
`overrides.yml` if desired.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>