### PR TITLE
[RDTIBCCOPT-114] Ceph config cleanup

### DIFF
--- a/chef/cookbooks/bcpc/attributes/ceph.rb
+++ b/chef/cookbooks/bcpc/attributes/ceph.rb
@@ -80,11 +80,9 @@ default['bcpc']['ceph']['max_open_files'] = 2048
 # Set tunables for Ceph OSD recovery
 default['bcpc']['ceph']['paxos_propose_interval'] = 1
 default['bcpc']['ceph']['osd_recovery_max_active'] = 1
-default['bcpc']['ceph']['osd_recovery_threads'] = 2
 default['bcpc']['ceph']['osd_recovery_op_priority'] = 1
 default['bcpc']['ceph']['osd_max_backfills'] = 1
-default['bcpc']['ceph']['osd_op_threads'] = 2
-default['bcpc']['ceph']['osd_mon_report_interval_min'] = 5
+default['bcpc']['ceph']['osd_mon_report_interval'] = 5
 default['bcpc']['ceph']['osd_max_scrubs'] = 5
 default['bcpc']['ceph']['osd_deep_scrub_interval'] = 2592000
 default['bcpc']['ceph']['osd_scrub_max_interval'] = 604800

--- a/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/ceph/ceph.conf.erb
@@ -57,15 +57,13 @@ osd scrub end hour = <%= @node['bcpc']['ceph']['osd_scrub_end_hour'] %>
 osd scrub sleep = <%= @node['bcpc']['ceph']['osd_scrub_sleep'] %>
 osd scrub chunk min = <%= @node['bcpc']['ceph']['osd_scrub_chunk_min'] %>
 osd scrub chunk max = <%= @node['bcpc']['ceph']['osd_scrub_chunk_max'] %>
-osd scrub max scrubs = <%= @node['bcpc']['ceph']['osd_max_scrubs'] %>
+osd max scrubs = <%= @node['bcpc']['ceph']['osd_max_scrubs'] %>
 
 # settings to throttle OSD recovery parameters
-osd mon report interval min = <%= @node['bcpc']['ceph']['osd_mon_report_interval_min'] %>
+osd mon report interval = <%= @node['bcpc']['ceph']['osd_mon_report_interval'] %>
 osd recovery max active = <%= @node['bcpc']['ceph']['osd_recovery_max_active'] %>
-osd recovery threads = <%= @node['bcpc']['ceph']['osd_recovery_threads'] %>
 osd recovery op priority = <%= @node['bcpc']['ceph']['osd_recovery_op_priority'] %>
 osd max backfills  = <%= @node['bcpc']['ceph']['osd_max_backfills'] %>
-osd op threads = <%= @node['bcpc']['ceph']['osd_op_threads'] %>
 
 # bluestore tuning
 bluestore rocksdb options = <%= @node['bcpc']['ceph']['bluestore_rocksdb_options'].join(',') %>


### PR DESCRIPTION
Clean up the following deprecated/renamed configs:

- `osd scrub max scrubs` doesn't exist, while `osd max scrubs` seems to be the one we need (see the documentation [here](https://docs.ceph.com/en/octopus/rados/configuration/osd-config-ref/#scrubbing))
- `osd_recovery_threads` cannot be found in the [documentation](https://docs.ceph.com/en/octopus/rados/configuration/osd-config-ref/#recovery) and a grep of `os_recovery_threads` in the source code yields nothing. 
- `osd_op_threads` cannot be found in the [documentation](https://docs.ceph.com/en/octopus/rados/configuration/osd-config-ref/#operations) or the source code either. 
- `osd mon report interval min` was renamed to `osd mon report interval` in mimic: https://docs.ceph.com/en/octopus/releases/mimic/?highlight=osd_mon_report_interval#upgrade-compatibility-notes