### PR TITLE
[RDTIBCCOPT-114] Remove deprecated Cinder config

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -68,6 +68,5 @@ rbd_flatten_volume_from_snapshot = <%= node['bcpc']['cinder']['rbd_flatten_volum
 rbd_max_clone_depth = <%= node['bcpc']['cinder']['rbd_max_clone_depth'] %>
 rbd_store_chunk_size = 4
 rados_connect_timeout = -1
-glance_api_version = 2
 
 <% end %>


### PR DESCRIPTION
`glance_api_version` has been deprecated and removed since Queens: https://github.com/openstack/cinder/blob/ac31b9e2b3d29f9fb840abc8ead3532e047042cd/releasenotes/notes/use-glance-v2-api-and-deprecate-glance_api_version-1a3b698429cb754e.yaml#L3