### PR TITLE
Adjust patched `ceph-deploy` file to use official upstream change

### DIFF
--- a/.github/scripts/run_linters.sh
+++ b/.github/scripts/run_linters.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright 2022, Bloomberg Finance L.P.
+# Copyright 2023, Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ function main {
     find . -name "*.py" \
         ! -path "./chef/cookbooks/bcpc/files/default/calico/dhcp.py" \
         ! -path "./chef/cookbooks/bcpc/files/default/calico/status.py" \
+        ! -path "./chef/cookbooks/bcpc/files/default/ceph/remotes.py" \
         ! -path "./chef/cookbooks/bcpc/files/default/etcd3gw/watch.py" \
         ! -path \
             "./chef/cookbooks/bcpc/files/default/neutron/external_net_db.py" \

--- a/chef/cookbooks/bcpc/recipes/ceph-packages.rb
+++ b/chef/cookbooks/bcpc/recipes/ceph-packages.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: ceph-packages
 #
-# Copyright:: 2022 Bloomberg Finance L.P.
+# Copyright:: 2023 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,8 +51,7 @@ else
   package 'ceph-deploy'
 end
 
-# workaround python3.8 deprecation of platform.linux_distribution.
-# ceph-deploy has not been rewired to workaround this, so we do it here.
+# https://github.com/ceph/ceph-deploy/pull/496
 if platform?('ubuntu') && ['20.04', '22.04'].include?(node['platform_version'])
   package 'python3-distro'
 


### PR DESCRIPTION
While looking at the patches we were carrying with an eye towards Yoga, I noticed that the `ceph-deploy` issue had been fixed upstream and also our version of the file incorrectly has an Apache license added to it while the underlying component is actually [MIT licensed](https://github.com/ceph/ceph-deploy/blob/master/LICENSE). This PR is to use the upstream patch for Python 3.8 and to reflect the correct license. And since this is effectively the upstreamed file, I added it to the `flake8` exception list and left it as-is.