### PR TITLE
Enabling compute services should occur at the end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ all : \
 	configure-ceph \
 	add-cloud-images \
 	register-compute-nodes \
-	enable-compute-service \
 	configure-host-aggregates \
 	configure-licenses \
+	enable-compute-service \
 	print-success-banner
 
 create: create-virtual-network create-virtual-hosts


### PR DESCRIPTION
Practically, this doesn't really matter but in theory enabling compute services when the aggregates and licensing aren't in place could result in failures.