### PR TITLE
Revert "Enabling compute services should occur at the end"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ all : \
 	configure-ceph \
 	add-cloud-images \
 	register-compute-nodes \
+	enable-compute-service \
 	configure-host-aggregates \
 	configure-licenses \
-	enable-compute-service \
 	print-success-banner
 
 create: create-virtual-network create-virtual-hosts


### PR DESCRIPTION
This reverts commit ded6a2e7962bfaeb9eee746d8a6d60061c04a6ea.

I haven't been able to track down what I suspect is some sort of race condition that occurs here. I can't reproduce this locally with a `3h3w` and if I login to a failed Rally build, I can create instances just fine. Given we're trying to upgrade to Yoga, I think the best course of action is to revert this as it appears to clear the failed Rally tests.