### PR TITLE
yoga: Fix noVNC console proxy

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -178,9 +178,9 @@ novncproxy_host = <%= node['service_ip'] %>
 <% else %>
 [vnc]
 enabled = true
-vncserver_listen = 0.0.0.0
-vncserver_proxyclient_address = <%= node['service_ip'] %>
-novncproxy_base_url = <%= "https://#{node['bcpc']['cloud']['fqdn']}:6080/vnc_auto.html" %>
+server_listen = 0.0.0.0
+server_proxyclient_address = <%= node['service_ip'] %>
+novncproxy_base_url = <%= "https://#{node['bcpc']['cloud']['fqdn']}:6080/vnc_lite.html" %>
 <% end %>
 
 [notifications]


### PR DESCRIPTION
A recent version of Yoga removed (after deprecating since
Pike!) the options vncserver_listen and
vncserver_proxyclient_address.

Unfortunately, we were still using them. So, upon upgrading
to Yoga, all VMs had this burned into their libvirt XML:
```
[operations@ts-yoga-test-cloud-r001n11-w ~]$ sudo virsh dumpxml instance-00000006 | grep vnc
<graphics type='vnc' port='5901' autoport='yes' listen='127.0.0.1'>
```

Whereas in Xena and earlier:
```
[operations@ts-xena-test-cloud-r001n12-w ~]$ sudo virsh dumpxml instance-00000005 | grep vnc
<graphics type='vnc' port='5900' autoport='yes' listen='0.0.0.0'>
```

Similarly, the address for the VNC session provided to the
proxy was 127.0.0.1, so the proxy would not connect.

Fix both of these things. While we are at it, also fix the
novncproxy_base_url as it is recommended that noVNC>=1.0.0
use `vnc_lite.html` instead of `vnc_auto.html`.