### PR TITLE
heat: Remove vitrage/zun client installations

### DIFF
--- a/chef/cookbooks/bcpc/recipes/heat.rb
+++ b/chef/cookbooks/bcpc/recipes/heat.rb
@@ -17,9 +17,6 @@
 
 return unless node['bcpc']['heat']['enabled']
 
-package 'python3-vitrageclient'
-package 'python3-zunclient'
-
 region = node['bcpc']['cloud']['region']
 config = data_bag_item(region, 'config')
 


### PR DESCRIPTION
These were only needed in a transient OpenStack release as
a specific version of Heat would not start without them.
That is not the case for Yoga, though.