### PR TITLE
Small adjustment to the SolarFlare scope to improve performance and reduce TCP retransmissions

### DIFF
--- a/ansible/playbooks/roles/common/templates/sysctl/bcpc.conf.j2
+++ b/ansible/playbooks/roles/common/templates/sysctl/bcpc.conf.j2
@@ -52,6 +52,13 @@ net.ipv4.tcp_retries2 = 8
 vm.swappiness = 0
 vm.min_free_kbytes = 135168
 
+# Update TCP congestion to mitigate impact of TCP retransmissions
+# Using 'fq' over 'fq_codel' here as bbr requires it for TCP pacing,
+# 'fq_codel' is generally better for forwarding/routers which aren't
+# the source originating the traffic.
+net.core.default_qdisc=fq
+net.ipv4.tcp_congestion_control=bbr
+
 # Customized parameters
 {% set sysctl_parameters = vars | dict2items | selectattr('key', 'match', '^system_parameters_') | list | items2dict -%}
 {% if sysctl_parameters | length > 0 -%}


### PR DESCRIPTION
After a battery of tests with/without `sfboot` from the `sfutil` package with no significant change in the TCP retransmission scope, I pivoted to using a different TCP congestion algorithm, which markedly changed the TCP retransmission rate in a positive way. This PR represents the 2-line change needed to implement that. 