### PR TITLE
configure-hardware: Avoid dependency problem

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-hardware.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-hardware.yml
@@ -30,7 +30,7 @@
                                | map(attribute='path')
                                | map('basename')
                                | map('regex_replace', '\\.ko$', '')
-                               | list }}"
+                               | list | sort }}"
 
 - name: Disable EDAC controllers
   block:


### PR DESCRIPTION
On AMD nodes, there are sometimes two modules which are
loaded for EDAC: amd64_edac and edac_mce_amd. Only, there
is one catch: the second relies on the first.

When we try to remove modules as part of the Ansible run,
we need to remove the amd64_edac module first, or the
Ansible run will error out as the removal of edac_mce_amd
will fail with "module in use".

Sorting the list alphabetically adds determinism that works
for both these nodes, and the Intel nodes.