### PR TITLE
Add cinder QoS policy support

### DIFF
--- a/ansible/group_vars/all/chef_environment.yml.example
+++ b/ansible/group_vars/all/chef_environment.yml.example
@@ -27,6 +27,28 @@ chef_environment:
         ceph:
           pool:
             size: 2
+        qos:
+          enabled: true
+          volume_types:
+            - name: ceph
+              limits:
+                # for fixed iops per volume
+                read_iops_sec: 1000000
+                write_iops_sec: 1000000
+                total_iops_sec:
+                # for burst iops per volume
+                read_iops_sec_max:
+                write_iops_sec_max:
+                # for fixed bandwidth per volume
+                read_bytes_sec:
+                write_bytes_sec:
+                total_bytes_sec:
+                # for burst bandwidth per volume
+                read_bytes_sec_max:
+                write_bytes_sec_max:
+                total_bytes_sec_max:
+                # for burst bucket size:
+                size_iops_sec:
       cloud:
         domain: "{{ cloud_domain }}"
         fqdn: "{{ cloud_fqdn }}"

--- a/ansible/group_vars/all/chef_environment.yml.example
+++ b/ansible/group_vars/all/chef_environment.yml.example
@@ -33,22 +33,19 @@ chef_environment:
             - name: ceph
               limits:
                 # for fixed iops per volume
-                read_iops_sec: 1000000
-                write_iops_sec: 1000000
-                total_iops_sec:
+                read_iops_sec: 2000
+                write_iops_sec: 1000
                 # for burst iops per volume
-                read_iops_sec_max:
-                write_iops_sec_max:
+                read_iops_sec_max: 4000
+                write_iops_sec_max: 2000
                 # for fixed bandwidth per volume
-                read_bytes_sec:
-                write_bytes_sec:
-                total_bytes_sec:
+                read_bytes_sec: 1000000000
+                write_bytes_sec: 500000000
                 # for burst bandwidth per volume
-                read_bytes_sec_max:
-                write_bytes_sec_max:
-                total_bytes_sec_max:
+                read_bytes_sec_max: 2000000000
+                write_bytes_sec_max: 1000000000
                 # for burst bucket size:
-                size_iops_sec:
+                size_iops_sec: 4096
       cloud:
         domain: "{{ cloud_domain }}"
         fqdn: "{{ cloud_fqdn }}"

--- a/chef/cookbooks/bcpc/attributes/cinder.rb
+++ b/chef/cookbooks/bcpc/attributes/cinder.rb
@@ -19,6 +19,7 @@ default['bcpc']['cinder']['quota'] = {
   'snapshots' => 10,
   'gigabytes' => 1000,
 }
+default['bcpc']['cinder']['qos']['enabled'] = false
 
 # ceph (rbd)
 default['bcpc']['cinder']['ceph']['user'] = 'cinder'

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -371,3 +371,77 @@ cinder_config.backends.each do |backend|
     not_if { node.run_state['os_vol_type_props'].dig(backend_name, 'volume_backend_name') == backend_name }
   end
 end
+
+# cinder qos 
+node['bcpc']['cinder']['qos']['volume_types'].each do |volume_type|
+
+  # create a qos
+  execute "create qos" do
+    # construct openstack command based on the qos attributes
+    qos_name = "#{volume_type['name']}-qos"
+    qos_create_opts = []
+
+    # Iterate over each key and value in the limits
+    # construct openstack argument
+    # add it to qos_create_opts
+    volume_type.fetch('limits', []).each do |key, value|
+      qos_create_opts.push("--property #{key}=#{value}")
+    end
+
+    # execute the openstack command
+    environment os_adminrc
+    retries 3
+    command <<-DOC
+      openstack volume qos create \
+        #{qos_create_opts.join(' ')} \
+        #{qos_name}
+    DOC
+    only_if { node['bcpc']['cinder']['qos']['enabled'] }
+  end
+
+  # associate qos to the volume type
+  execute "associate qos to the volume type #{volume_type['name']}" do
+    qos_name = "#{volume_type['name']}-qos"
+
+    environment os_adminrc
+    retries 3
+    command <<-DOC
+      openstack volume qos associate \
+        #{qos_name} \
+        #{volume_type['name']}
+    DOC
+    only_if { node['bcpc']['cinder']['qos']['enabled'] }
+  end
+
+  # disassociate the qos from the volume type
+  execute "disassociate qos from the volume type #{volume_type['name']}" do
+    qos_name = "#{volume_type['name']}-qos"
+
+    environment os_adminrc
+    retries 3
+    command <<-DOC
+      openstack volume qos disassociate \
+        --volume-type #{volume_type['name']} \
+        #{qos_name}
+    DOC
+    not_if { node['bcpc']['cinder']['qos']['enabled'] }
+    only_if <<-DOC
+      openstack volume qos show #{qos_name}
+    DOC
+  end
+
+  # delete the qos
+  execute "delete the qos" do
+    qos_name = "#{volume_type['name']}-qos"
+
+    environment os_adminrc
+    retries 3
+    command <<-DOC
+      openstack volume qos delete #{qos_name}
+    DOC
+    not_if { node['bcpc']['cinder']['qos']['enabled'] }
+    only_if <<-DOC
+      openstack volume qos show #{qos_name}
+    DOC
+  end
+end

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -372,7 +372,7 @@ cinder_config.backends.each do |backend|
   end
 end
 
-# cinder qos 
+# cinder qos
 node['bcpc']['cinder']['qos']['volume_types'].each do |volume_type|
   ruby_block "create a qos policy for the volume type #{volume_type['name']}" do
     block do
@@ -383,7 +383,7 @@ node['bcpc']['cinder']['qos']['volume_types'].each do |volume_type|
       volume_type.fetch('limits', []).each do |key, value|
         qos_create_opts.push("--property #{key}=#{value}")
       end
-    
+
       Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
       cmd = "openstack volume qos show #{qos_name}"
       cmd_out = shell_out(cmd, env: os_adminrc)
@@ -394,7 +394,7 @@ node['bcpc']['cinder']['qos']['volume_types'].each do |volume_type|
           #{qos_name}"
         cmd_out = shell_out(cmd, env: os_adminrc)
 
-        raise "unable to create a qos policy" if cmd_out.error?
+        raise 'unable to create a qos policy' if cmd_out.error?
       end
 
       # associate the qos policy to the volume type
@@ -403,7 +403,7 @@ node['bcpc']['cinder']['qos']['volume_types'].each do |volume_type|
         #{volume_type['name']}"
       cmd_out = shell_out(cmd, env: os_adminrc)
 
-      raise "unable to associate the qos policy" if cmd_out.error?
+      raise 'unable to associate the qos policy' if cmd_out.error?
     end
 
     only_if { node['bcpc']['cinder']['qos']['enabled'] }
@@ -420,13 +420,13 @@ node['bcpc']['cinder']['qos']['volume_types'].each do |volume_type|
         #{qos_name}"
       cmd_out = shell_out(cmd, env: os_adminrc)
 
-      raise "unable to disassociate the qos policy" if cmd_out.error?
+      raise 'unable to disassociate the qos policy' if cmd_out.error?
 
       # delete the qos policy
       cmd = "openstack volume qos delete #{qos_name}"
       cmd_out = shell_out(cmd, env: os_adminrc)
 
-      raise "unable to delete the qos policy" if cmd_out.error?
+      raise 'unable to delete the qos policy' if cmd_out.error?
     end
 
     not_if { node['bcpc']['cinder']['qos']['enabled'] }

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -375,40 +375,37 @@ end
 # cinder qos
 node['bcpc']['cinder']['qos']['volume_types'].each do |volume_type|
   ruby_block "create a qos policy for the volume type #{volume_type['name']}" do
+    qos_name = "#{volume_type['name']}-qos"
     block do
-      qos_name = "#{volume_type['name']}-qos"
-      
       Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
-      # check if the qos policy already exists
-      cmd = "openstack volume qos show #{qos_name}"
+
+      # create a qos policy
+      qos_create_opts = []
+
+      volume_type.fetch('limits', []).each do |key, value|
+        qos_create_opts.push("--property #{key}=#{value}")
+      end
+
+      cmd = "openstack volume qos create \
+        #{qos_create_opts.join(' ')} \
+        #{qos_name}"
       cmd_out = shell_out(cmd, env: os_adminrc)
 
-      if cmd_out.error?
-        # create a qos policy
-        qos_create_opts = []
+      raise 'unable to create a qos policy' if cmd_out.error?
 
-        volume_type.fetch('limits', []).each do |key, value|
-          qos_create_opts.push("--property #{key}=#{value}")
-        end
+      # associate the qos policy to the volume type
+      cmd = "openstack volume qos associate \
+        #{qos_name} \
+        #{volume_type['name']}"
+      cmd_out = shell_out(cmd, env: os_adminrc)
 
-        cmd = "openstack volume qos create \
-          #{qos_create_opts.join(' ')} \
-          #{qos_name}"
-        cmd_out = shell_out(cmd, env: os_adminrc)
-
-        raise 'unable to create a qos policy' if cmd_out.error?
-
-        # associate the qos policy to the volume type
-        cmd = "openstack volume qos associate \
-          #{qos_name} \
-          #{volume_type['name']}"
-        cmd_out = shell_out(cmd, env: os_adminrc)
-
-        raise 'unable to associate the qos policy' if cmd_out.error?
-      end
+      raise 'unable to associate the qos policy' if cmd_out.error?
     end
 
     only_if { node['bcpc']['cinder']['qos']['enabled'] }
+    not_if <<-DOC
+      openstack volume qos show#{qos_name}
+    DOC
   end
 
   ruby_block "delete the qos policy on the volume type #{volume_type['name']}" do


### PR DESCRIPTION
Add chef automation to create or delete a cinder qos policy with the specified parameters 

**Describe your changes**
Add a new section in cinder.rb to create or delete a qos policy based on the attributes defined in chef_environment

**Testing performed**

- qos enabled -> successfully create a qos policy and associate it with the volume type defined in chef_environment

- qos disabled -> qos policy is disassociated from the volume type and deleted

- chef-client cinder recipe twice when qos is disabled -> qos is deleted after the first run and second run completed successfully without error 

- chef-client cinder recipe twice when qos is enabled -> both runs completed successfully and only one qos is created

- failed to execute the command to create a qos policy -> raise an exception and exit with error 

- run cinder recipe second time after failing to create a qos policy -> run finished with a policy being created and associated with the volume type

- failed to execute the command to associate the qos policy -> raise an exception and exit with error after the policy is created

- run cinder recipe second time after failing to associate the policy to the volume type -> run completes successfully, no new policy is created and current policy is associated with the volume type

- failed to execute the command to disassociate a qos policy -> raise an exception and exit with error 

- run cinder recipe second time after failing to disassociate the policy -> disassociate and delete the policy successfully. Run completed without errors. 

- failed to execute the command to delete a qos policy -> raise an exception and exit with error after disassociate the policy

- run cinder recipe second time after failing to delete the policy -> run complete successfully with qos policy being deleted. 



