### PR TITLE
Ensure apparmor capabilities patch is present

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -157,6 +157,8 @@ web_server_assets:
   - file_asset: consul
   - file_asset: etcd3gw
   - file_asset: ceph-deploy
+  - file_asset: apparmor
+  - file_asset: libapparmor1
 
 # all web server file assets
 all_web_server_assets: "{{ web_server_assets +
@@ -223,6 +225,20 @@ assets_files:
     url: http://mirrors.kernel.org/ubuntu/pool/universe/c/ceph-deploy/ceph-deploy_2.0.1-0ubuntu1_all.deb
     checksum: sha256:6ecd4769dbe3d65ff114f458f60840b976cb73873f7e825987613f929ffed911
     filename: ceph-deploy_2.0.1-0ubuntu1_all.deb
+    environment: "{{ internet_proxy | default({}) }}"
+
+  # Remove this until when we have a new tested baseline
+  # https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1964636
+  - name: apparmor
+    url: http://mirrors.kernel.org/ubuntu/pool/main/a/apparmor/apparmor_2.13.3-7ubuntu5.2_amd64.deb
+    checksum: sha256:a377c3ac00ea9d008f55299ff97e88d7199ea127c2f70195ba506c8273cfa7c9
+    filename: apparmor_2.13.3-7ubuntu5.2_amd64.deb
+    environment: "{{ internet_proxy | default({}) }}"
+
+  - name: libapparmor1
+    url: http://mirrors.kernel.org/ubuntu/pool/main/a/apparmor/libapparmor1_2.13.3-7ubuntu5.2_amd64.deb
+    checksum: sha256:ada0314841a62b200c96228b25ad0bfb7c4d6bf23906d4467ce2d8afb9f31606
+    filename: libapparmor1_2.13.3-7ubuntu5.2_amd64.deb
     environment: "{{ internet_proxy | default({}) }}"
 
 # all file assets

--- a/ansible/playbooks/roles/common/defaults/main/chef.yml
+++ b/ansible/playbooks/roles/common/defaults/main/chef.yml
@@ -114,6 +114,7 @@ chef_roles:
     run_list:
       - recipe[bcpc::default]
       - recipe[bcpc::ssl]
+      - recipe[bcpc::apparmor]
       - recipe[bcpc::cloud-archive]
       - recipe[bcpc::postfix]
       - recipe[bcpc::common-packages]

--- a/chef/cookbooks/bcpc/attributes/apparmor.rb
+++ b/chef/cookbooks/bcpc/attributes/apparmor.rb
@@ -1,0 +1,13 @@
+###############################################################################
+# apparmor
+###############################################################################
+
+apparmor_package = 'apparmor_2.13.3-7ubuntu5.2_amd64.deb'
+default['bcpc']['apparmor']['apparmor']['file'] = apparmor_package
+default['bcpc']['apparmor']['apparmor']['source'] = "#{default['bcpc']['web_server']['url']}/#{apparmor_package}"
+default['bcpc']['apparmor']['apparmor']['checksum'] = 'a377c3ac00ea9d008f55299ff97e88d7199ea127c2f70195ba506c8273cfa7c9'
+
+libapparmor1_package = 'libapparmor1_2.13.3-7ubuntu5.2_amd64.deb'
+default['bcpc']['apparmor']['libapparmor1']['file'] = libapparmor1_package
+default['bcpc']['apparmor']['libapparmor1']['source'] = "#{default['bcpc']['web_server']['url']}/#{libapparmor1_package}"
+default['bcpc']['apparmor']['libapparmor1']['checksum'] = 'ada0314841a62b200c96228b25ad0bfb7c4d6bf23906d4467ce2d8afb9f31606'

--- a/chef/cookbooks/bcpc/recipes/apparmor.rb
+++ b/chef/cookbooks/bcpc/recipes/apparmor.rb
@@ -1,0 +1,54 @@
+# Cookbook:: bcpc
+# Recipe:: apparmor
+#
+# Copyright:: 2023 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The apparmor capabilities parsing bug only applies to Focal
+if platform?('ubuntu') && node['platform_version'] == '20.04'
+  libapparmor1_package = node['bcpc']['apparmor']['libapparmor1']['file']
+  libapparmor1_save_path = "#{Chef::Config[:file_cache_path]}/#{libapparmor1_package}"
+  libapparmor1_file_url = node['bcpc']['apparmor']['libapparmor1']['source']
+  libapparmor1_checksum = node['bcpc']['apparmor']['libapparmor1']['checksum']
+
+  apparmor_package = node['bcpc']['apparmor']['apparmor']['file']
+  apparmor_save_path = "#{Chef::Config[:file_cache_path]}/#{apparmor_package}"
+  apparmor_file_url = node['bcpc']['apparmor']['apparmor']['source']
+  apparmor_checksum = node['bcpc']['apparmor']['apparmor']['checksum']
+
+  remote_file libapparmor1_save_path do
+    source libapparmor1_file_url
+    checksum libapparmor1_checksum
+    notifies :run, 'execute[install libapparmor1]', :immediately
+  end
+
+  remote_file apparmor_save_path do
+    source apparmor_file_url
+    checksum apparmor_checksum
+    notifies :run, 'execute[install apparmor]', :immediately
+  end
+
+  execute 'install libapparmor1' do
+    action :nothing
+    command "dpkg -i #{Chef::Config[:file_cache_path]}/#{libapparmor1_package}"
+  end
+
+  execute 'install apparmor' do
+    action :nothing
+    command "dpkg -i #{Chef::Config[:file_cache_path]}/#{apparmor_package}"
+    notifies :restart, 'service[apparmor]', :immediately
+  end
+end
+
+service 'apparmor'


### PR DESCRIPTION
Upstream bug:
https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1964636

Focal UCA delivers a new libvirt package which adds
apparmor policy containing capabilities that the apparmor
which ships with Focal does not know about, resulting in
a parse error.

Until we can ensure that the upstream packages we consume
contain the "fixed" version of apparmor from focal-updates,
install them out-of-band as needed.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>