### PR TITLE
nova: Fix availability-zone scheduling in Yoga

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -160,6 +160,7 @@ enable_isolated_aggregate_filtering = true
 <% unless node['bcpc']['openstack']['services']['workers'].nil? %>
 workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% end%>
+query_placement_for_availability_zone = false
 
 <% if @is_headnode -%>
 [filter_scheduler]


### PR DESCRIPTION
As the name suggests, query_placement_for_availability_zone
queries placement for availability zone filtering (instead
of doing it within Nova, as in prior releases). This is
default on as of Xena.

Unfortunately, we either have not configured this
correctly, or it's not working in larger deployments, as
I observed the following:

This works, of course:
openstack server create --min 1 --max 1 \\
    --network dev --image cirros --flavor dev-generic1.tiny \\
    --wait put-me-anywhere

But this only works with this PR applied:
openstack server create --min 1 --max 1 \\
    --network dev --image cirros --flavor dev-generic1.tiny \\
    --availability-zone dev-1 --wait put-me-in-az-1

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>