### PR TITLE
Remove build failure weigher config

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -169,7 +169,7 @@ available_filters = <%= available_filter %>
 <% end %>
 enabled_filters = <%= @enabled_filters.join(',') %>
 host_subset_size = <%= node['bcpc']['nova']['scheduler']['host_subset_size'] %>
-weight_classes = nova.scheduler.weights.affinity.ServerGroupSoftAffinityWeigher,nova.scheduler.weights.affinity.ServerGroupSoftAntiAffinityWeigher,nova.scheduler.weights.bcpc_cpu.BCPCCPUWeigher,nova.scheduler.weights.bcpc_ram.BCPCRAMWeigher,nova.scheduler.weights.compute.BuildFailureWeigher,nova.scheduler.weights.cross_cell.CrossCellWeigher,nova.scheduler.weights.disk.DiskWeigher,nova.scheduler.weights.io_ops.IoOpsWeigher,nova.scheduler.weights.metrics.MetricsWeigher,nova.scheduler.weights.pci.PCIWeigher
+weight_classes = nova.scheduler.weights.affinity.ServerGroupSoftAffinityWeigher,nova.scheduler.weights.affinity.ServerGroupSoftAntiAffinityWeigher,nova.scheduler.weights.bcpc_cpu.BCPCCPUWeigher,nova.scheduler.weights.bcpc_ram.BCPCRAMWeigher,nova.scheduler.weights.cross_cell.CrossCellWeigher,nova.scheduler.weights.disk.DiskWeigher,nova.scheduler.weights.io_ops.IoOpsWeigher,nova.scheduler.weights.metrics.MetricsWeigher,nova.scheduler.weights.pci.PCIWeigher
 
 [vnc]
 enabled = true


### PR DESCRIPTION
Turn off scheduler weighting by build failure events to avoid host exclusion after failed builds.

Current weigher only resets the failed builds stat after successfully launching a VM on the host. But as the host will be weighed down by failure, this success event will never happen.
