### PR TITLE
QoS bug fix: add default values 

### DIFF
--- a/chef/cookbooks/bcpc/attributes/cinder.rb
+++ b/chef/cookbooks/bcpc/attributes/cinder.rb
@@ -20,6 +20,7 @@ default['bcpc']['cinder']['quota'] = {
   'gigabytes' => 1000,
 }
 default['bcpc']['cinder']['qos']['enabled'] = false
+default['bcpc']['cinder']['qos']['volume_types'] = []
 
 # ceph (rbd)
 default['bcpc']['cinder']['ceph']['user'] = 'cinder'


### PR DESCRIPTION
Set the default value of the volume types list to be an empty list. 

**Testing performed**
CI/CD pipeline succeeded
