### PR TITLE
fix a missing space bug

### DIFF
--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -404,7 +404,7 @@ node['bcpc']['cinder']['qos']['volume_types'].each do |volume_type|
 
     only_if { node['bcpc']['cinder']['qos']['enabled'] }
     not_if <<-DOC
-      openstack volume qos show#{qos_name}
+      openstack volume qos show #{qos_name}
     DOC
   end
 


### PR DESCRIPTION
**Describe your changes**
Fixed a bug: missing a space in the qos not_if statement that results the check always fails

**Testing performed**
Tested it on gamma cluster with lightbits volumes
Passed the jenkins test
