### PR TITLE
Nova update interval

### DIFF
--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -58,9 +58,6 @@ default['bcpc']['nova']['compute']['limits']['nofile']['hard'] = 4096
 # frequency of syncing power states between hypervisor and database
 default['bcpc']['nova']['sync_power_state_interval'] = 600
 
-# frequency of updating compute resources
-default['bcpc']['nova']['update_resources_interval'] = 3600
-
 # automatically restart guests that were running when hypervisor was rebooted
 default['bcpc']['nova']['resume_guests_state_on_host_boot'] = false
 

--- a/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova-compute.conf.erb
@@ -4,7 +4,6 @@
 [DEFAULT]
 compute_driver = libvirt.LibvirtDriver
 enable_new_services = false
-update_resources_interval = <%= node['bcpc']['nova']['update_resources_interval'] %>
 
 [libvirt]
 virt_type = <%= @virt_type %>


### PR DESCRIPTION
Setting the resource update interval back to default (60s). Reverting changes from https://github.com/bloomberg/chef-bcpc/pull/2130

Reasons for lowering the value:
	1. Live migration operations don't update the resources of the destination host on migration event. The only trigger is the periodic task. Migrations in the span of the configured interval will favor the same host - 3600s is too large.
	2. Nova scheduler uses the CPU idle percentage to compute the weight for a host. The idle value is updated by the same periodic task. No other operation (spawn, migrate) will update the idle percentage for an already running VM.

This is an incremental change, optimal value might be different than 60s. Once a fix that updates the resources on live migration events is merged, this value can be increased back to reduce `ceph df` calls. The goal is to flag this bug and upstream the fix.

