### PR TITLE
Allow Jammy-based worknodes to converge and work

### DIFF
--- a/chef/cookbooks/bcpc/recipes/calico-apt.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-apt.rb
@@ -33,7 +33,7 @@ remote_file 'install calicoctl' do
 end
 
 repo = node['bcpc']['calico']['repo']
-codename = node['lsb']['codename'] == 'jammy' ? 'focal' : node['lsb']['codename']
+codename = node['lsb']['codename']
 
 apt_repository 'calico' do
   uri repo['url']

--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -39,6 +39,7 @@ package %w(
   nova-api-metadata
   ovmf
   pm-utils
+  qemu-block-extra
   sysfsutils
 ) do
   options '--no-install-recommends'


### PR DESCRIPTION
We've laid all the groundwork to allow Jammy-based
hypervisors to converge and operate successfully - just
need some additional taps of the wrench within this
PR to bring things full circle.