### PR TITLE
Format NVMe drives faster under Jammy and later

### DIFF
--- a/ansible/playbooks/roles/common/tasks/format-nvme.yml
+++ b/ansible/playbooks/roles/common/tasks/format-nvme.yml
@@ -19,7 +19,7 @@
     optimal_lbaf: "{{ nvme_id_ns.lbafs | optimal_nvme_lbaf }}"
 
 - name: Format the NVMe namespace
-  command: "nvme format --lbaf={{ optimal_lbaf }} --ses=1 {{ block_device }}"
+  command: "nvme format {{ '' if ansible_distribution_release in ['bionic', 'focal'] else '--force' }} --lbaf={{ optimal_lbaf }} --ses=1 {{ block_device }}"
   register: nvme_format_result
   changed_when: nvme_format_result.rc == 0
   become: yes


### PR DESCRIPTION
Ubuntu Jammy packaged a version of `nvme-cli` which now
provides this warning when formatting the drive:
```
$ sudo nvme format -l 1 --namespace-id=1 --ses=1 /dev/nvme0n1
You are about to format nvme0n1, namespace 0x1.
Namespace nvme0n1 has parent controller(s):nvme0

WARNING: Format may irrevocably delete this device's data.
You have 10 seconds to press Ctrl-C to cancel this operation.

Use the force [--force|-f] option to suppress this warning.
```

As we are formatting NVMes from an automated context
(Ansible), we should provide this flag to avoid waiting
10 seconds everytime a host is rebuilt, etc.