### PR TITLE
`fwupd-refresh` service should be disabled

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -103,6 +103,7 @@
     - accounts-daemon
     - atd
     - fwupd
+    - fwupd-refresh
     - irqbalance
     - multipathd.socket
     - multipathd


### PR DESCRIPTION
[RDTIBCC-4730]

When a build is complete, the `fwupd-refresh.service` may report as having failed:

```
  UNIT                  LOAD      ACTIVE SUB    DESCRIPTION
● fwupd-refresh.service not-found failed failed fwupd-refresh.service

LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.

1 loaded units listed.
```

That's because the package that delivers the service has been removed. We should disable the service prior to removing the `fwupd` package.