### PR TITLE
RDTIBCC-4741: Start building worknodes with Jammy

### DIFF
--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -256,10 +256,13 @@ cookbook_file '/usr/lib/python3/dist-packages/nova/virt/libvirt/migration.py' do
 end
 
 # (rendition of): https://review.opendev.org/c/openstack/nova/+/852002
-cookbook_file '/usr/lib/python3/dist-packages/nova/virt/libvirt/guest.py' do
-  source 'nova/guest.py'
-  notifies :run, 'execute[py3compile-nova]', :immediately
-  notifies :restart, 'service[nova-compute]', :delayed
+# Fixed in qemu as of 1:4.2-3ubuntu6.25 in Focal, 1:6.2+dfsg-2ubuntu6.7 in Jammy
+if ['18.04', '20.04'].include?(node['platform_version'])
+  cookbook_file '/usr/lib/python3/dist-packages/nova/virt/libvirt/guest.py' do
+    source 'nova/guest.py'
+    notifies :run, 'execute[py3compile-nova]', :immediately
+    notifies :restart, 'service[nova-compute]', :delayed
+  end
 end
 
 execute 'py3compile-nova' do

--- a/virtual/vagrantbox.json
+++ b/virtual/vagrantbox.json
@@ -11,4 +11,8 @@
       "vagrant_box": "bcc-ubuntu-22.04",
       "vagrant_box_version": "0"
   }
+  "worknodes": {
+      "vagrant_box": "bcc-ubuntu-22.04",
+      "vagrant_box_version": "0"
+  }
 }


### PR DESCRIPTION
Push worknodes towards Jammy. This opens the door
to the generic-hwe-22.04-edge kernel.

The impetus for aggressively shifting the Jammy compute
nodes to the generic-hwe-22.04-edge series at this time
is to benefit from the Call Depth Tracking mitigation for
Spectre V2-RSB mitigation that landed in Jammy as part of
the Lunar 6.2 kernel trickling its way down. IBRS has been
very expensive to mitigate thus far in a virtualization
context.

This also paves the road for OpenStack Caracal in 04/24.