### PR TITLE
RDTIBCC-4741: Add workaround for Lunar kernels

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -186,6 +186,25 @@
     # HWE kernel-specific tools are pulled in by {{ version }}-generic metapackages.
     - "linux-tools-{{ kernel_version }}-{{ 'generic' if kernel_variant != 'lowlatency' else 'lowlatency' }}"
 
+# bpftool workaround for Jammy systems running Lunar and later kernels:
+# Calico 3.26 BPF objects only interop with bpftool linked against libbpf < 1.0
+# Lunar kernel tools ship with a bpftool linked against libbpf 1.1, so...
+- name: Configure older version of bpftool
+  block:
+    - name: Install a version of kernel tools that ships with Jammy kernels
+      apt:
+        name: linux-tools-5.15.0-83-generic
+
+    - name: Symlink the bpftool shim directly to the one from the Jammy kernel
+      file:
+        src: /usr/lib/linux-tools/5.15.0-83-generic/bpftool
+        dest: /usr/sbin/bpftool
+        owner: root
+        group: root
+        state: link
+        force: true
+  when: kernel_variant == 'generic-hwe-22.04-edge'
+
 # Install kexec-tools
 - name: Install kexec-tools
   apt:

--- a/virtual/vagrantbox.json
+++ b/virtual/vagrantbox.json
@@ -10,7 +10,7 @@
   "storagenodes": {
       "vagrant_box": "bcc-ubuntu-22.04",
       "vagrant_box_version": "0"
-  }
+  },
   "worknodes": {
       "vagrant_box": "bcc-ubuntu-22.04",
       "vagrant_box_version": "0"


### PR DESCRIPTION
Calico (Felix) 3.26 BPF objects only work with `bpftool`
linked against libbpf < 1.0. This is because the BPF ELF
files contain sections that libbpf >= 1.0 dropped support
for. As a result, Felix cannot load the eBPF that it
requires in order to operate.

Unfortunately, Canonical statically links libbpf into
`bpftool`, so there is no tomfoolery with dynamic linkers
to be had.

Thus, until Tigera addresses the deprecated/legacy map
sections in their BPF file, just continue to use `bpftool`
from the "mainline" Jammy kernels.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>