### PR TITLE
[RDTIBCCOPT-244] Fix the Return Code of Server Properties API While VM is Active

### DIFF
--- a/chef/cookbooks/bcpc/files/default/nova/server_properties_api.py
+++ b/chef/cookbooks/bcpc/files/default/nova/server_properties_api.py
@@ -78,3 +78,10 @@ class ServerPropertiesController(wsgi.Controller):
         except exception.InstanceNotFound:
             msg = _("Instance could not be found")
             raise exc.HTTPNotFound(explanation=msg)
+        except exception.InstanceIsLocked as e:
+            raise exc.HTTPConflict(explanation=e.format_message())
+        except exception.InstanceInvalidState as state_error:
+            msg = _('update server properties')
+            common.raise_http_conflict_for_instance_invalid_state(state_error,
+                                                                  msg,
+                                                                  server.uuid)


### PR DESCRIPTION
### Why

We need to address a bug we found in integration tests that updating os_type while VM is running returns a 500 internal error instead of a 409 error, which indicates that  the update cannot be done while the VM is running.

### What

Add exception handling codes to the `server_properties_api.py` file to catch the `InstanceInvalidState` exception after the update step and raise a `http_conflict_for_instance_invalid_state` error, i.e. a 409 error. These changes align with what we have in the `server_system_metadata_api.py` file. 

### Test

Cluster: gpw2
Test case: make a put request to set the os_type on a VM while it is in running state.

```
[operations@pw-cloud-r030n02-h ~]$ curl -i -X PUT https://openstack.gpw2.bcc.bloomberg.com:8774/v2.1/servers/f8aef05a-b77b-4335-8b79-fd20ab5ede46/properties/os_type  -H "User-Agent: python-novaclient" -H "Content-Type: application/json"  -H  "X-Auth-Token: gAAAAABlFbqyPpEgzUUy3WceloHiNBHrlxxf3peYhvgCIqtetmtG7Ki-gzsEtEklKP-3KSCS3VwxmkxW8Vorqlc0-n8bRc7WJmI_OwXS3MVO2IgNoxt5bRBJ4Brrin19EsninGfezUaVEKdDYcB02GWijGFRwrFb47LSuaDe2j9NzlGxC3EAmGI" -d '{"properties":{"os_type": null}}'
HTTP/1.1 409 Conflict
openstack-api-version: compute 2.1
x-openstack-nova-api-version: 2.1
vary: OpenStack-API-Version
vary: X-OpenStack-Nova-API-Version
content-type: application/json; charset=UTF-8
content-length: 162
x-openstack-request-id: req-7250a746-c01c-4854-b7b2-7b9c2374022d
x-compute-request-id: req-7250a746-c01c-4854-b7b2-7b9c2374022d
date: Thu, 28 Sep 2023 17:43:33 GMT

{"conflictingRequest": {"code": 409, "message": "Cannot 'update server properties' instance f8aef05a-b77b-4335-8b79-fd20ab5ede46 while it is in vm_state active"}}
```
