### PR TITLE
RDTIBCC-4728: Fix keystone healthcheck failures

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
@@ -2,7 +2,7 @@
 
 # Keystone domain name which contains heat template-defined users. If
 # `stack_user_domain_id` option is set, this option is ignored. (string value)
-stack_user_domain_name = Default
+stack_user_domain_name = heat
 
 # Keystone username, a user with roles sufficient to manage users and projects
 # in the stack_user_domain. (string value)


### PR DESCRIPTION
heat.conf declares the heat_domain_admin to be in "Default"
domain, but the user is created by Chef in the "heat"
domain in the Heat recipe.

Change the configuration to reflect this, which ultimately
prevents Heat from trying to lookup a user that does not
exist (thus tripping alarms).

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>