### PR TITLE
RDTIBCC-4728: Graceful apache2 log rotation

### DIFF
--- a/chef/cookbooks/bcpc/attributes/apache2.rb
+++ b/chef/cookbooks/bcpc/attributes/apache2.rb
@@ -14,7 +14,7 @@
 #     splay_minutes.
 default['bcpc']['apache2']['logrotation']['start_hour'] = 22
 default['bcpc']['apache2']['logrotation']['start_minute'] = 0
-default['bcpc']['apache2']['logrotation']['splay_minutes'] = 1
+default['bcpc']['apache2']['logrotation']['splay_minutes'] = 2
 
 # Explicitly disable HTTP keep-alive for now.  As part of log rotation (or
 # when a "systemctl reload apache2" is run), a graceful restart is triggered

--- a/chef/cookbooks/bcpc/files/default/apache2/set-haproxy-backends
+++ b/chef/cookbooks/bcpc/files/default/apache2/set-haproxy-backends
@@ -1,0 +1,10 @@
+#!/bin/dash
+
+if [ $# -ne 2 ]; then
+    echo "Usage: ${0} <drain|maint|ready> <server>"
+    echo "Set all backends of <server> to state <drain|maint|ready>"
+fi
+
+for backend in `echo 'show servers state' | socat stdio /var/run/haproxy/haproxy.asok | awk "/${2}/ {print \\$2}"`; do
+    echo "set server ${backend}/${2} state ${1}" | socat stdio /var/run/haproxy/haproxy.asok
+done


### PR DESCRIPTION
To avoid HTTP failures when we rotate logs daily, drain
backends in HAproxy one minute prior to log rotation and
resume backends in HAproxy one minute after log rotation.

Change the default splay to 2 minutes, so we have e.g.:

21:59: first headnode begins drain
20:00: first headnode rotates
20:01: first headnode resumes, second headnode begins drain
20:02: second headnode rotates
...

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>