### PR TITLE
[RDTIBCC-4541] - Enable script plugin for ansible.

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -13,4 +13,4 @@ retries = 3
 verbose = cyan
 
 [inventory]
-enable_plugins = yaml
+enable_plugins = yaml, script


### PR DESCRIPTION
Adding `script` plugin to `ansible.cfg` file to enable parsing inventory provided by a script.

Change was tested using `ansible-inventory` and `ansible` to retrieve specific hosts, e.g.:

```bash
$ ansible-inventory -i get_inventory.py --list | jq '.<group_name>.hosts[]'
"<1>"
"<2>"
"<3>"
"<4>"

$ ansible -i get_inventory.py <group_name> --list-hosts
  hosts (4):
    <1>
    <2>
    <3>
    <4>
```
