### PR TITLE
RDTIBCC-4807 - fixed destroy packer script issue that is unable to clean img file

### DIFF
--- a/virtual/packer/bin/create-packer-box.sh
+++ b/virtual/packer/bin/create-packer-box.sh
@@ -31,6 +31,11 @@ for OS_RELEASE in $(jq -r '. | keys[]' "${os_config_variables}"); do
     BASE_BOX_PROVIDER=$(jq -r '.base_box_provider' "${config_variables}")
     VAGRANT_CACERT=$(jq -r '.vagrant_cacert' "${config_variables}")
     PACKER_BOX_NAME=$(jq -r '.output_packer_box_name' "${config_variables}")
+
+    # Set the environment variable VAGRANT_DEFAULT_PROVIDER to
+    # match BASE_BOX_PROVIDER on the variables.json file
+    export VAGRANT_DEFAULT_PROVIDER="$BASE_BOX_PROVIDER"
+
     if [ "$BASE_BOX" == "null" ] \
         || [ "$BASE_BOX_VERSION" == "null" ] \
         || [ "$PACKER_BOX_NAME" == "null" ]; then
@@ -68,6 +73,7 @@ for OS_RELEASE in $(jq -r '. | keys[]' "${os_config_variables}"); do
         virsh destroy output-vagrant_source || true
         virsh undefine output-vagrant_source || true
         virsh vol-delete --pool default output-vagrant_source.img || true
+        virsh pool-refresh default
     fi
 
     # create the packer box

--- a/virtual/packer/bin/download-packer-box.sh
+++ b/virtual/packer/bin/download-packer-box.sh
@@ -29,17 +29,19 @@ if [ "$BUCKET" == "null" ]; then
     exit 1
 fi
 
-if [ -z "${VAGRANT_DEFAULT_PROVIDER}" ]; then
-    echo "VAGRANT_DEFAULT_PROVIDER is not defined"
-    exit 1
-fi
 
 for OS_RELEASE in $(jq -r '. | keys[]' "${os_config_variables}"); do
-    OS_RELEASE_AND_PROVIDER="${OS_RELEASE}_${VAGRANT_DEFAULT_PROVIDER}"
-
     # Generate configuration variables for this OS release
     PACKER_BOX_NAME=$(jq -r ".[\"${OS_RELEASE}\"].output_packer_box_name" \
         "${os_config_variables}")
+    BASE_BOX_PROVIDER=$(jq -r ".[\"${OS_RELEASE}\"].base_box_provider" \
+        "${os_config_variables}")
+
+    # Set the environment variable VAGRANT_DEFAULT_PROVIDER to
+    # match BASE_BOX_PROVIDER on the variables.json file
+    export VAGRANT_DEFAULT_PROVIDER="$BASE_BOX_PROVIDER"
+
+    OS_RELEASE_AND_PROVIDER="${OS_RELEASE}_${VAGRANT_DEFAULT_PROVIDER}"
 
     # Download base box from s3 storage
     mkdir -p "output-vagrant-${OS_RELEASE}"

--- a/virtual/packer/bin/upload-packer-box.sh
+++ b/virtual/packer/bin/upload-packer-box.sh
@@ -29,13 +29,14 @@ if [ "$BUCKET" == "null" ]; then
     exit 1
 fi
 
-if [ -z "${VAGRANT_DEFAULT_PROVIDER}" ]; then
-    echo "VAGRANT_DEFAULT_PROVIDER is not defined"
-    exit 1
-fi
-
-
 for OS_RELEASE in $(jq -r '. | keys[]' "${os_config_variables}"); do
+    BASE_BOX_PROVIDER=$(jq -r ".[\"${OS_RELEASE}\"].base_box_provider" \
+        "${os_config_variables}")
+
+    # Set the environment variable VAGRANT_DEFAULT_PROVIDER to
+    # match BASE_BOX_PROVIDER on the variables.json file
+    export VAGRANT_DEFAULT_PROVIDER="$BASE_BOX_PROVIDER"
+
     OS_RELEASE_AND_PROVIDER="${OS_RELEASE}_${VAGRANT_DEFAULT_PROVIDER}"
 
     # Upload base box to s3 storage


### PR DESCRIPTION
**Describe your changes**
When running CI/CD with vagrant builds, we hit an issue that packer box img files were unable to be deleted properly. This PR include the changes to make the environment variable VAGRANT_DEFAULT_PROVIDER to match base_box_provider on the file variables.json as well as use regex to delete the **image_0_xxxxxx_box.img**. After the change, the code should be able to check if the provider is libvirt and then it can run virsh vol-delete properly to clean up any stale img files.

**Testing performed**
This has been tested on jenkins agents machine. Stale img files can be deleted without issue.


