### PR TITLE
RDTIBCC-4882 - fixed fixture import error

### DIFF
--- a/chef/cookbooks/bcpc/recipes/rally.rb
+++ b/chef/cookbooks/bcpc/recipes/rally.rb
@@ -96,6 +96,7 @@ execute 'install rally in virtualenv' do
     pip install -U pip
     pip install -U 'pyOpenSSL<23.0.0'
     pip install 'SQLAlchemy<2.0.0'
+    pip install fixtures
     pip install \
       rally-openstack==#{rally_openstack_version} rally==#{rally_version}
   EOH


### PR DESCRIPTION
### Issue: Jenkins build failed with import error when running rally recipe.


Stacktrace
```
 STDOUT: 
[2023-11-11T02:49:49.705Z]     STDERR: Traceback (most recent call last):
[2023-11-11T02:49:49.705Z]       File "/usr/local/lib/rally/bin/rally", line 5, in <module>
[2023-11-11T02:49:49.705Z]         from rally.cli.main import main
[2023-11-11T02:49:49.705Z]       File "/usr/local/lib/rally/lib/python3.8/site-packages/rally/cli/main.py", line 20, in <module>
[2023-11-11T02:49:49.705Z]         from rally.cli import cliutils
[2023-11-11T02:49:49.705Z]       File "/usr/local/lib/rally/lib/python3.8/site-packages/rally/cli/cliutils.py", line 28, in <module>
[2023-11-11T02:49:49.705Z]         from rally import api
[2023-11-11T02:49:49.705Z]       File "/usr/local/lib/rally/lib/python3.8/site-packages/rally/api.py", line 28, in <module>
[2023-11-11T02:49:49.705Z]         from rally.common import cfg
[2023-11-11T02:49:49.705Z]       File "/usr/local/lib/rally/lib/python3.8/site-packages/rally/common/cfg.py", line 19, in <module>
[2023-11-11T02:49:49.705Z]         from oslo_config import fixture  # noqa
[2023-11-11T02:49:49.705Z]       File "/usr/lib/python3/dist-packages/oslo_config/fixture.py", line 18, in <module>
[2023-11-11T02:49:49.705Z]         import fixtures
[2023-11-11T02:49:49.705Z]     ModuleNotFoundError: No module named 'fixtures'
```

### Test
After the fix, the error is not present any longer when running jenkins.