### PR TITLE
Cleanup keystone config

### DIFF
--- a/chef/cookbooks/bcpc/attributes/keystone.rb
+++ b/chef/cookbooks/bcpc/attributes/keystone.rb
@@ -19,24 +19,6 @@ default['bcpc']['keystone']['debug'] = false
 # Set the number of Keystone WSGI processes
 default['bcpc']['keystone']['workers'] = nil
 
-# The driver section below allows either 'sql' or 'ldap' (or 'templated' for catalog)
-# Note that not all drivers may support SQL/LDAP, only tinker if you know what you're getting into
-default['bcpc']['keystone']['drivers']['assignment'] = 'sql'
-default['bcpc']['keystone']['drivers']['catalog'] = 'sql'
-default['bcpc']['keystone']['drivers']['credential'] = 'sql'
-default['bcpc']['keystone']['drivers']['domain_config'] = 'sql'
-default['bcpc']['keystone']['drivers']['endpoint_filter'] = 'sql'
-default['bcpc']['keystone']['drivers']['endpoint_policy'] = 'sql'
-default['bcpc']['keystone']['drivers']['federation'] = 'sql'
-default['bcpc']['keystone']['drivers']['identity'] = 'sql'
-default['bcpc']['keystone']['drivers']['identity_mapping'] = 'sql'
-default['bcpc']['keystone']['drivers']['oauth1'] = 'sql'
-default['bcpc']['keystone']['drivers']['policy'] = 'sql'
-default['bcpc']['keystone']['drivers']['revoke'] = 'sql'
-default['bcpc']['keystone']['drivers']['role'] = 'sql'
-default['bcpc']['keystone']['drivers']['token'] = 'memcache_pool'
-default['bcpc']['keystone']['drivers']['trust'] = 'sql'
-
 # Notifications driver
 default['bcpc']['keystone']['drivers']['notification'] = 'log'
 default['bcpc']['keystone']['notification_format'] = 'cadf'

--- a/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
@@ -6,9 +6,6 @@ notification_opt_out = identity.authenticate.success
 public_endpoint = https://<%= node["bcpc"]['cloud']["fqdn"]%>:5000/
 admin_endpoint = https://<%= node["bcpc"]["cloud"]["fqdn"]%>:35357/
 
-[assignment]
-driver = <%= node['bcpc']['keystone']['drivers']['assignment'] %>
-
 [cache]
 enabled = <%= node['bcpc']['keystone']['enable_caching'] %>
 backend = oslo_cache.memcache_pool
@@ -19,11 +16,7 @@ memcache_socket_timeout = 1
 memcache_pool_connection_get_timeout = 1
 
 [catalog]
-driver = <%= node['bcpc']['keystone']['drivers']['catalog'] %>
 cache_time = 3600
-
-[credential]
-driver = <%= node['bcpc']['keystone']['drivers']['credential'] %>
 
 [database]
 connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>
@@ -31,17 +24,7 @@ max_overflow = <%= node['bcpc']['keystone']['db']['max_overflow'] %>
 max_pool_size = <%= node['bcpc']['keystone']['db']['max_pool_size'] %>
 
 [domain_config]
-driver = <%= node['bcpc']['keystone']['drivers']['domain_config'] %>
 cache_time = 300
-
-[endpoint_filter]
-driver = <%= node['bcpc']['keystone']['drivers']['endpoint_filter'] %>
-
-[endpoint_policy]
-driver = <%= node['bcpc']['keystone']['drivers']['endpoint_policy'] %>
-
-[federation]
-driver = <%= node['bcpc']['keystone']['drivers']['federation'] %>
 
 [fernet_tokens]
 key_repository = /etc/keystone/fernet-keys/
@@ -52,21 +35,12 @@ domain_specific_drivers_enabled = true
 domain_config_dir = /etc/keystone/domains
 cache_time = 600
 
-[identity_mapping]
-driver = <%= node['bcpc']['keystone']['drivers']['identity_mapping'] %>
-
-[oauth1]
-driver = <%= node['bcpc']['keystone']['drivers']['oauth1'] %>
-
 [oslo_messaging_notifications]
 <% if node['bcpc']['keystone']['drivers']['notification'] %>
 driver = <%= node['bcpc']['keystone']['drivers']['notification'] %>
 <% else %>
 driver =
 <% end %>
-
-[policy]
-driver = <%= node['bcpc']['keystone']['drivers']['policy'] %>
 
 [oslo_policy]
 policy_dirs = policy.d

--- a/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/keystone/keystone.conf.erb
@@ -6,6 +6,8 @@ notification_opt_out = identity.authenticate.success
 public_endpoint = https://<%= node["bcpc"]['cloud']["fqdn"]%>:5000/
 admin_endpoint = https://<%= node["bcpc"]["cloud"]["fqdn"]%>:35357/
 
+[assignment]
+
 [cache]
 enabled = <%= node['bcpc']['keystone']['enable_caching'] %>
 backend = oslo_cache.memcache_pool
@@ -18,6 +20,8 @@ memcache_pool_connection_get_timeout = 1
 [catalog]
 cache_time = 3600
 
+[credential]
+
 [database]
 connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>
 max_overflow = <%= node['bcpc']['keystone']['db']['max_overflow'] %>
@@ -25,6 +29,12 @@ max_pool_size = <%= node['bcpc']['keystone']['db']['max_pool_size'] %>
 
 [domain_config]
 cache_time = 300
+
+[endpoint_filter]
+
+[endpoint_policy]
+
+[federation]
 
 [fernet_tokens]
 key_repository = /etc/keystone/fernet-keys/
@@ -35,12 +45,18 @@ domain_specific_drivers_enabled = true
 domain_config_dir = /etc/keystone/domains
 cache_time = 600
 
+[identity_mapping]
+
+[oauth1]
+
 [oslo_messaging_notifications]
 <% if node['bcpc']['keystone']['drivers']['notification'] %>
 driver = <%= node['bcpc']['keystone']['drivers']['notification'] %>
 <% else %>
 driver =
 <% end %>
+
+[policy]
 
 [oslo_policy]
 policy_dirs = policy.d


### PR DESCRIPTION
We wanted to remove `driver=sql`, since the default driver is always `sql` and we don't need to set that explicitly in our automations. 

**Describe your changes**
Removed `driver=sql` but kept the config stanza titles since without them a build will fail

**Testing performed**
The branch passed Jenkins tests 
