### PR TITLE
RDTIBCC-4885: nova-compute: Delay restart

### DIFF
--- a/chef/cookbooks/bcpc/recipes/nova-compute.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-compute.rb
@@ -228,7 +228,7 @@ template '/etc/nova/nova.conf' do
     vip: node['bcpc']['cloud']['vip']
   )
   notifies :restart, 'service[nova-compute]', :immediately
-  notifies :restart, 'service[nova-api-metadata]', :immediately
+  notifies :restart, 'service[nova-api-metadata]', :delayed
 end
 
 flags = node['cpu']['0']['flags'] & %w(svm vmx)


### PR DESCRIPTION
Other bits of the `chef-client` run are liable to update
`nova.conf`. In order to prevent `nova-api-metadata` from
loading a transient `nova.conf` configuration, defer the
restart of `nova-api-metadata` to the end of the client
run.