### PR TITLE
Insert hack to fix suspected race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ all : \
 	configure-web-server \
 	configure-common-node \
 	configure-haproxy \
+	apply-duct-tape \
 	run-chef-client \
 	configure-ceph \
 	add-cloud-images \
@@ -120,6 +121,11 @@ configure-haproxy :
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/site.yml \
 		-t configure-haproxy -f 1 --limit headnodes
+
+apply-duct-tape :
+
+	@echo "Sleeping to avoid suspected race condition?"
+	@sleep 300
 
 run-chef-client : \
 	run-chef-client-bootstraps \


### PR DESCRIPTION
During the HAproxy step. Unfortunately, it looks like
there is now another issue impacting 3h3w builds that
arises during the `bcpc::glance` recipe.

Add a large sleep in before Chef'ing to:
  a) Confirm that there actually is some kind of race-
 condition residing about in the code and

  b) Fix the very bad success rate of builds that is now
 consuming developer time.