### PR TITLE
Set internal project & user id for image-volume cache

### DIFF
--- a/chef/cookbooks/bcpc/attributes/cinder.rb
+++ b/chef/cookbooks/bcpc/attributes/cinder.rb
@@ -30,3 +30,5 @@ default['bcpc']['cinder']['ceph']['pool']['size'] = 3
 # altername backends
 default['bcpc']['cinder']['alternate_backends']['enabled'] = false
 default['bcpc']['cinder']['alternate_backends']['backends'] = []
+default['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_project_id'] = nil
+default['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_user_id'] = nil

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -270,6 +270,7 @@ template '/etc/cinder/cinder.conf' do
     rmqnodes: rmqnodes(all: true),
     alternate_backends: cinder_config.alternate_backends,
     scheduler_default_filters: cinder_config.filters,
+    init_cloud: init_cloud?,
     cinder_internal_tenant_project_id: lazy { cinder_internal_tenant_project_id },
     cinder_internal_tenant_user_id: lazy { cinder_internal_tenant_user_id }
   )

--- a/chef/cookbooks/bcpc/recipes/cinder.rb
+++ b/chef/cookbooks/bcpc/recipes/cinder.rb
@@ -210,7 +210,7 @@ if zone_config.enabled?
   end
 end
 
-if zone_config.alternate_backends_enabled?
+if !init_cloud? && zone_config.alternate_backends_enabled?
   cinder_internal_tenant_project_id = ''
   internal_project = node['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_project'] || ''
   ruby_block 'collect Cinder internal project uuid' do

--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -22,7 +22,7 @@ enable_v3_api = true
 <% if @scheduler_default_filters.any? %>
 scheduler_default_filters = <%= @scheduler_default_filters.join(',') %>
 <% end %>
-<% if @alternate_backends_enabled%>
+<% if !@init_cloud && @alternate_backends_enabled %>
 cinder_internal_tenant_project_id = <%= @cinder_internal_tenant_project_id %>
 cinder_internal_tenant_user_id = <%= @cinder_internal_tenant_user_id %>
 <% end %>

--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -22,6 +22,10 @@ enable_v3_api = true
 <% if @scheduler_default_filters.any? %>
 scheduler_default_filters = <%= @scheduler_default_filters.join(',') %>
 <% end %>
+<% if @alternate_backends_enabled%>
+cinder_internal_tenant_project_id = <%= node['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_project_id'] %>
+cinder_internal_tenant_user_id = <%= node['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_user_id'] %>
+<% end %>
 
 [backend]
 backend_name = <%= node['hostname'] %>

--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -23,8 +23,8 @@ enable_v3_api = true
 scheduler_default_filters = <%= @scheduler_default_filters.join(',') %>
 <% end %>
 <% if @alternate_backends_enabled%>
-cinder_internal_tenant_project_id = <%= node['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_project_id'] %>
-cinder_internal_tenant_user_id = <%= node['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_user_id'] %>
+cinder_internal_tenant_project_id = <%= @cinder_internal_tenant_project_id %>
+cinder_internal_tenant_user_id = <%= @cinder_internal_tenant_user_id %>
 <% end %>
 
 [backend]


### PR DESCRIPTION
I'd like to enable Cinder [image-volume cache](https://docs.openstack.org/cinder/latest/admin/image-volume-cache.html) for alternate backends, and it is required to set `cinder_internal_tenant_project_id` and `cinder_internal_tenant_user_id` in the default section of cinder configurations.


**Testing performed**
Tested on a physical test cluster that has alternate Cinder backends enabled. 

