### PR TITLE
Set internal project & user id for image-volume cache (no uuid lookup)

### DIFF
--- a/chef/cookbooks/bcpc/attributes/cinder.rb
+++ b/chef/cookbooks/bcpc/attributes/cinder.rb
@@ -30,3 +30,5 @@ default['bcpc']['cinder']['ceph']['pool']['size'] = 3
 # altername backends
 default['bcpc']['cinder']['alternate_backends']['enabled'] = false
 default['bcpc']['cinder']['alternate_backends']['backends'] = []
+default['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_project_id'] = nil
+default['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_user_id'] = nil

--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -22,6 +22,10 @@ enable_v3_api = true
 <% if @scheduler_default_filters.any? %>
 scheduler_default_filters = <%= @scheduler_default_filters.join(',') %>
 <% end %>
+<% if @alternate_backends_enabled%>
+cinder_internal_tenant_project_id = <%= node['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_project_id'] %>
+cinder_internal_tenant_user_id = <%= node['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_user_id'] %>
+<% end %>
 
 [backend]
 backend_name = <%= node['hostname'] %>


### PR DESCRIPTION

**Describe your changes**
This PR "reverts" some of the commits in #2240 , so we set internal project & user uuids without the complicated look up. The problem I have into in #2240 is that `ruby_block` only runs during convergence, which happens after the template has already been generated in compile stage. The commit in this PR was tested and approved previously. It's less elegant but serves our purpose. Although I'd like to keep #2240 open in case there's a way to dynamically populate the uuids in an existing template. 

**Testing performed**
Tested on a physical test cluster that has alternate Cinder backends enabled.

