### PR TITLE
Upgrade to Calico 3.27.0 - RDTIBCC-4947

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -184,8 +184,8 @@ assets_files:
     environment: "{{ internet_proxy | default({}) }}"
 
   - name: calicoctl
-    url: https://github.com/projectcalico/calico/releases/download/v3.26.1/calicoctl-linux-amd64
-    checksum: sha256:c8f61c1c8e2504410adaff4a7255c65785fe7805eebfd63340ccd3c472aa42cf
+    url: https://github.com/projectcalico/calico/releases/download/v3.27.0/calicoctl-linux-amd64
+    checksum: sha256:46e79ae146b3dd90998f56511cf5d6db64deb97cb784235caf1f99e0672d66e4
     filename: calicoctl
     environment: "{{ internet_proxy | default({}) }}"
 

--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -165,27 +165,9 @@
     - "linux-image-{{ kernel_version }}-{{ kernel_variant }}"
     - "linux-modules-{{ kernel_version }}-{{ kernel_variant }}"
     - "linux-modules-extra-{{ kernel_version }}-{{ kernel_variant }}"
-    # HWE kernel-specific tools are pulled in by {{ version }}-generic metapackages.
+    # HWE kernel-specific tools are pulled in by {{ version }}-generic
+    # metapackages.
     - "linux-tools-{{ kernel_version }}-{{ 'generic' if kernel_variant != 'lowlatency' else 'lowlatency' }}"
-
-# bpftool workaround for Jammy systems running Lunar and later kernels:
-# Calico 3.26 BPF objects only interop with bpftool linked against libbpf < 1.0
-# Lunar kernel tools ship with a bpftool linked against libbpf 1.1, so...
-- name: Configure older version of bpftool
-  block:
-    - name: Install a version of kernel tools that ships with Jammy kernels
-      apt:
-        name: linux-tools-5.15.0-83-generic
-
-    - name: Symlink the bpftool shim directly to the one from the Jammy kernel
-      file:
-        src: /usr/lib/linux-tools/5.15.0-83-generic/bpftool
-        dest: /usr/sbin/bpftool
-        owner: root
-        group: root
-        state: link
-        force: true
-  when: kernel_variant == 'generic-hwe-22.04-edge'
 
 # Install kexec-tools
 - name: Install kexec-tools

--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -4,7 +4,7 @@
 
 # calico apt repository
 default['bcpc']['calico']['repo']['url'] =
- 'http://ppa.launchpad.net/project-calico/calico-3.26/ubuntu'
+ 'http://ppa.launchpad.net/project-calico/calico-3.27/ubuntu'
 default['bcpc']['calico']['repo']['key'] = 'calico/release.key'
 
 # calicoctl
@@ -12,7 +12,7 @@ default['bcpc']['calico']['calicoctl']['remote']['file'] = 'calicoctl'
 default['bcpc']['calico']['calicoctl']['remote']['source'] =
  "#{default['bcpc']['web_server']['url']}/calicoctl"
 default['bcpc']['calico']['calicoctl']['remote']['checksum'] =
- 'c8f61c1c8e2504410adaff4a7255c65785fe7805eebfd63340ccd3c472aa42cf'
+ '46e79ae146b3dd90998f56511cf5d6db64deb97cb784235caf1f99e0672d66e4'
 
 # calico-felix
 default['bcpc']['calico']['felix']['failsafe']['inbound'] = [


### PR DESCRIPTION
I've tested the upgrade under both a `3h3w` build as well as through a Jenkins build including a full Rally run. All builds were successful and the tests passed.