### PR TITLE
Nova databases should be built before services come online - RDTIBCC-4950

### DIFF
--- a/chef/cookbooks/bcpc/recipes/nova-head.rb
+++ b/chef/cookbooks/bcpc/recipes/nova-head.rb
@@ -135,13 +135,6 @@ package %w(
   options '--no-install-recommends'
 end
 
-service 'nova-api'
-service 'nova-scheduler'
-service 'nova-conductor'
-service 'nova-novncproxy' do
-  service_name 'apache2'
-end
-
 # create policy.d dir for policy overrides
 directory '/etc/nova/policy.d' do
   action :create
@@ -337,10 +330,10 @@ template '/etc/nova/nova.conf' do
   )
 
   notifies :run, 'execute[update cell1]', :immediately
-  notifies :restart, 'service[nova-api]', :immediately
-  notifies :restart, 'service[nova-scheduler]', :immediately
-  notifies :restart, 'service[nova-conductor]', :immediately
-  notifies :restart, 'service[nova-novncproxy]', :immediately
+  notifies :restart, 'service[nova-api]', :delayed
+  notifies :restart, 'service[nova-scheduler]', :delayed
+  notifies :restart, 'service[nova-conductor]', :delayed
+  notifies :restart, 'service[nova-novncproxy]', :delayed
 end
 
 execute 'update cell1' do
@@ -414,6 +407,11 @@ if extended_apis['enabled']
     end
   end
 end
+
+service 'nova-api'
+service 'nova-conductor'
+service 'nova-novncproxy'
+service 'nova-scheduler'
 
 execute 'wait for nova to come online' do
   environment os_adminrc


### PR DESCRIPTION
Recently, I've seen build failures where a failure occurs in bcpc::nova-head when it brings the Nova services online via

```
service 'nova-api'
service 'nova-scheduler'
service 'nova-conductor'
service 'nova-novncproxy' do
  service_name 'apache2'
```

The issue appears to be that `nova-scheduler` tries to open repeatedly the database back-end specified in `/etc/nova/nova.conf` file before the database/tables have been created. This race appears obvious looking at the code - we should not have Chef define these services until all of the relevant files have been laid down.

I've tested the upgrade under both a 3h3w build as well as through a Jenkins build including a full Rally run. All builds were successful and the tests passed.