### PR TITLE
provide stages within make all for easier retrying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ storageheadnodes = \
 stubnodes = $$(ansible stubnodes -i ${inventory} --list | tail -n +2 | wc -l)
 
 all : \
+	prechef \
+	runchef \
+	postchef
+
+prechef : \
 	sync-assets \
 	configure-operator \
 	configure-node \
@@ -23,8 +28,12 @@ all : \
 	configure-chef-nodes \
 	configure-web-server \
 	configure-common-node \
-	configure-haproxy \
-	run-chef-client \
+	configure-haproxy
+
+runchef : \
+	run-chef-client
+
+postchef : \
 	configure-ceph \
 	add-cloud-images \
 	register-compute-nodes \


### PR DESCRIPTION
This is no change to behavior when you issue make all. However it adds optional intermediate parts of all such as prechef runchef and postchef so that retrying is a little easier. If the stages before Chefing nodes completed, one can retry the chef stage with make runchef and then make postchef.