### PR TITLE
Enable shuffle_best_same_weighed_hosts for Nova

### DIFF
--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -112,6 +112,7 @@ default['bcpc']['nova']['db-archive']['cron_minute'] = '0'
 
 # select from between this many equally optimal hosts when launching an instance
 default['bcpc']['nova']['scheduler']['host_subset_size'] = 3
+default['bcpc']['nova']['scheduler']['shuffle_best_same_weighed_hosts'] = true
 
 # Anti-affinity availability zone scheduler filter
 default['bcpc']['nova']['scheduler']['filter']['anti_affinity_availability_zone']['enabled'] = false

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -169,6 +169,7 @@ available_filters = <%= available_filter %>
 enabled_filters = <%= @enabled_filters.join(',') %>
 host_subset_size = <%= node['bcpc']['nova']['scheduler']['host_subset_size'] %>
 weight_classes = nova.scheduler.weights.affinity.ServerGroupSoftAffinityWeigher,nova.scheduler.weights.affinity.ServerGroupSoftAntiAffinityWeigher,nova.scheduler.weights.bcpc_cpu.BCPCCPUWeigher,nova.scheduler.weights.bcpc_ram.BCPCRAMWeigher,nova.scheduler.weights.cross_cell.CrossCellWeigher,nova.scheduler.weights.disk.DiskWeigher,nova.scheduler.weights.io_ops.IoOpsWeigher,nova.scheduler.weights.metrics.MetricsWeigher,nova.scheduler.weights.pci.PCIWeigher
+shuffle_best_same_weighed_hosts = true
 
 [vnc]
 enabled = true

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -169,7 +169,7 @@ available_filters = <%= available_filter %>
 enabled_filters = <%= @enabled_filters.join(',') %>
 host_subset_size = <%= node['bcpc']['nova']['scheduler']['host_subset_size'] %>
 weight_classes = nova.scheduler.weights.affinity.ServerGroupSoftAffinityWeigher,nova.scheduler.weights.affinity.ServerGroupSoftAntiAffinityWeigher,nova.scheduler.weights.bcpc_cpu.BCPCCPUWeigher,nova.scheduler.weights.bcpc_ram.BCPCRAMWeigher,nova.scheduler.weights.cross_cell.CrossCellWeigher,nova.scheduler.weights.disk.DiskWeigher,nova.scheduler.weights.io_ops.IoOpsWeigher,nova.scheduler.weights.metrics.MetricsWeigher,nova.scheduler.weights.pci.PCIWeigher
-shuffle_best_same_weighed_hosts = true
+shuffle_best_same_weighed_hosts = <%= node['bcpc']['nova']['scheduler']['shuffle_best_same_weighed_hosts'] %>
 
 [vnc]
 enabled = true


### PR DESCRIPTION
## WHAT & WHY
When deciding which hypervisor shall be used to launch a VM, Nova scheduler will first filter all available hosts, calculate the weight for each hypervisor, and pick one of the top N hypervisors ranked by weights, where N is defined by `host_subset_size` ([currently 3](https://github.com/bloomberg/chef-bcpc/blob/main/chef/cookbooks/bcpc/attributes/nova.rb#L114)). A weight indicates how expensive it is to allocate the VM on a hypervisor, and more details can be found [here](https://docs.openstack.org/nova/latest/admin/scheduling.html#weights). More weight means the hypervisor is more suitable to host the VM. If there are X hypervisors with the same maximum weight and `X > N`, then only N hypervisors will be considered when Nova scheduler determines which one to use. 

The entire workflow is defined [here](https://github.com/openstack/nova/blob/fed123085d9fc2306833840326c1c6a93deba09d/nova/scheduler/manager.py#L700). To make it easier to understand, here is a short version of the function's logic:
```python
all_hosts = [ hyp1, hyp2, hyp3, hyp4, hyp5, hyp6 ]
filtered_hosts = all_hosts.filter(
    vm_spec, host_state, ...
) => [ hyp1, hyp2, hyp3, hyp4, hyp5 ]

weighed_hosts = filtered_hosts.calculate_weight(
    cpu_weigher, mem_weigher, ...
) => [ hyp1: 5.0, hyp2: 5.0, hyp3: 5.0, hyp4: 5.0, hyp5: 4.0 ]

if shuffle_best_same_weighed_hosts:
    best_hosts = [ 
        host for host in weighed_hosts 
        if host.weight == max_weight 
    ].shuffle() => [ hyp3: 5.0, hyp4: 5.0, hyp2: 5.0, hyp1: 5.0 ]

    weighed_hosts = best_hosts + rest_of_non_best_hosts 
                  => [ hyp3: 5.0, hyp4: 5.0, hyp2: 5.0, hyp1: 5.0, hyp5: 3.0 ]

to_pick_hosts = weighed_hosts.top(host_subset_size) => [ hyp3: 5.0, hyp4: 5.0, hyp2: 5.0 ]
picked_host = to_pick_hosts.randomly_pick_one() => hyp2: 5.0

return picked_host + rest_of_weighed_hosts => [ hyp2: 5.0, hyp3: 5.0, hyp4: 5.0, hyp1: 5.0, hyp5: 3.0 ]
```
The question we're trying to solve here is that if multiple threads process scheduling requests at the same time, it is possible for all of them to have the same results and the same order when calculating `weighed_hosts` (sorting algorithm is the same, and assuming there are multiple hosts with the same maximum weight). Using the example above, it is possible for all threads to have the same `weighed_hosts = [hyp1, hyp2, ..., hyp5]` after calling `filtered_hosts.calculate_weight()`. In this case, without enabling `shuffle_best_same_weighed_hosts`, the `to_pick_hosts` will be `[hyp1, hyp2, hyp3]` for all threads, causing `hyp1 ~ hyp3`'s loads to go up quickly, while `hyp4` sits around and do nothing, even though its weight is the same as `hyp1 ~ hyp3`. With shuffling, we can mitigate this issue and distribute the loads more evenly with an easy effort.

The situation where multiple hosts are weighed the same, however, does not happen very often. On hypervisors that are already running some loads, since we have [many weighers](https://github.com/bloomberg/chef-bcpc/blob/f68c5ed204253eb795b0bdb746493ad3d6d1d4c1/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb#L171) when calculating the weights, plus the CPU & memory weighers are now calculating a percentage (float), it is extremely unlikely for these hosts' weights to equal at any time (so the `best_hosts` in the sample code will just be one hypervisor, and it makes no sense to shuffle, but it won't hurt either). 

The only situation that the weights might be the same (and hence the config can make a difference) is when new hypervisors are added to the clusters. If the new hypervisors are identical in hardware and all running with no loads, it is very likely that they will be weighed the same at the moment they are added in and when multiple processes are calculating `weighed_hosts`. If we have a situation where we want to add more than `host_subset_size` hypervisors at the same time (which we do), the config will give us the benefit.

A simple test can demonstrate the case where hosts with no loads are weighed the same, but different when they are loaded with VMs of different sizes:
```
Weighed [
  WeighedHost [host: (test-cloud-hyp1, test-cloud-hyp1) weight: 3.0],
  WeighedHost [host: (test-cloud-hyp2, test-cloud-hyp2) weight: 3.0],
  WeighedHost [host: (test-cloud-hyp3, test-cloud-hyp3) weight: 3.0]
]

# Added a small VM
Weighed [
    WeighedHost [host: (test-cloud-hyp1, test-cloud-hyp1) weight: 3.0],
    WeighedHost [host: (test-cloud-hyp3, test-cloud-hyp3) weight: 3.0],
    WeighedHost [host: (test-cloud-hyp2, test-cloud-hyp2) weight: 2.872863755651268]
]

# Added a small VM
Weighed [
    WeighedHost [host: (test-cloud-hyp1, test-cloud-hyp1) weight: 3.0],
    WeighedHost [host: (test-cloud-hyp2, test-cloud-hyp2) weight: 2.8497167073029144],
    WeighedHost [host: (test-cloud-hyp3, test-cloud-hyp3) weight: 2.8497167073029144]
]

# Added a medium VM
Weighed [
    WeighedHost [host: (test-cloud-hyp1, test-cloud-hyp1) weight: 3.0],
    WeighedHost [host: (test-cloud-hyp2, test-cloud-hyp2) weight: 2.83854534505726],
    WeighedHost [host: (test-cloud-hyp3, test-cloud-hyp3) weight: 2.658666338202082]
]

# Added a medium VM
Weighed [
    WeighedHost [host: (test-cloud-hyp2, test-cloud-hyp2) weight: 3.0],
    WeighedHost [host: (test-cloud-hyp3, test-cloud-hyp3) weight: 2.7869366959370687],
    WeighedHost [host: (test-cloud-hyp1, test-cloud-hyp1) weight: 2.660047187672774]
]

# Added a large VM, migrate the large VM to hyp2, and added a tiny VM
Weighed [
    WeighedHost [host: (test-cloud-hyp3, test-cloud-hyp3) weight: 2.955653739158894],
    WeighedHost [host: (test-cloud-hyp1, test-cloud-hyp1) weight: 2.8483150228366867],
    WeighedHost [host: (test-cloud-hyp2, test-cloud-hyp2) weight: 2.7613214536142467]
]
```
- Advantages:
  - Distribute workloads on hypervisors more evenly when they are newly added in.
- Drawbacks:
  - Even with shuffling, there is still a chance that a single/several hypervisors getting picked by multiple processes. 
  - Shuffling the list can take a little bit longer time (nah, this is neglectable)

## HOW
Build like how we all do. 

## TEST
The config is enabled after building the cloud:
```
% ansible -i ansible/inventory.yml headnodes -m shell -a "sudo cat /etc/nova/nova.conf | grep shuffle_best_same_weighed_hosts -B 8" -b
headnode1 | CHANGED | rc=0 >>

[filter_scheduler]
...
shuffle_best_same_weighed_hosts = true

headnode2 | CHANGED | rc=0 >>

[filter_scheduler]
...
shuffle_best_same_weighed_hosts = true

headnode3 | CHANGED | rc=0 >>

[filter_scheduler]
...
shuffle_best_same_weighed_hosts = true
```
And the debug msg shows that the config is indeed enabled:
```
2024-01-16 16:07:15.724 1384861 DEBUG oslo_service.service [req-3555ecf6-5143-49d8-a736-be387e5d063c - - - - -] filter_scheduler.shuffle_best_same_weighed_hosts = True log_opt_values /usr/lib/python3/dist-packages/oslo_config/cfg.py:2609
```
A simple debug message for comparing the results before/after shuffling:
```
Weighed hosts: [
    WeighedHost [host: (host1, host1.example.com) weight: 3.0],
    WeighedHost [host: (host3, host3.example.com) weight: 3.0],
    WeighedHost [host: (host2, host2.example.com) weight: 3.0]
] _get_sorted_hosts /usr/lib/python3/dist-packages/nova/scheduler/manager.py:617

Weighed hosts after shuffle: [
    WeighedHost [host: (host2, host2.example.com) weight: 3.0],
    WeighedHost [host: (host3, host3.example.com) weight: 3.0],
    WeighedHost [host: (host1, host1.example.com) weight: 3.0]
] _get_sorted_hosts /usr/lib/python3/dist-packages/nova/scheduler/manager.py:632

```