### PR TITLE
Vagrant builds still attached to MAC addresses

### DIFF
--- a/virtual/Vagrantfile
+++ b/virtual/Vagrantfile
@@ -104,7 +104,7 @@ Vagrant.configure('2') do |config|
 
       transit.each do |t_iface|
         args = {}.tap do |a|
-          a[:auto_config] = false
+          a[:auto_config] = true
           a[:ip] = t_iface['ip'].split('/')[0]
           a[:mac] = t_iface['mac'].delete(':')
           a[:libvirt__network_name] =

--- a/virtual/Vagrantfile.virtualbox
+++ b/virtual/Vagrantfile.virtualbox
@@ -87,7 +87,7 @@ Vagrant.configure('2') do |config|
           virtualbox__intnet: Util.vbox_name(t_iface['neighbor']['name']),
           mac: t_iface['mac'].delete(':'),
           nic_type: '82543GC',
-          auto_config: false)
+          auto_config: true)
       end
 
       subconfig.vm.provider 'virtualbox' do |vb|


### PR DESCRIPTION
While doing an internal BCC-on-BCC build, I ran into an issue once I moved past [ab52125a82531c2eba846db8f429017b1a738531](https://github.com/bloomberg/chef-bcpc/commit/ab52125a82531c2eba846db8f429017b1a738531).

The issue is that the state of hosts that are newly created, but not yet run through automation is different between a provisioning system like Foreman and those created via Vagrant. The tl;dr is the former now creates a set of hosts with a working pair of transit interfaces with IP addresses assigned while the latter has the transit but not yet assigned with IPs. That's because the Vagrant-based builds relied on the transits being configured in Ansible and the updated `transit_interfaces()` and `find_interface()` functions in the Ansible filter misses those interfaces since they don't have an IP address assigned to them (other than in the Ansible inventory).

This chicken-and-egg problem could be solved by adding back the MAC address checks as a fall-back but given the spirit that systems such as Foreman and `make create `should be aligned, I instead propose changing the private networks created by Vagrant to auto-config themselves. That means after `make create` has completed, the hosts in the cluster will have live, pingable IP addresses that can be looked up by Ansible.

This was tested by doing multiple Vagrant-based builds.