### PR TITLE
Clean up unneeded users, login shells

### DIFF
--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -135,44 +135,39 @@
   user:
     name: "{{ item }}"
     state: absent
-    remove: no
-  loop: "{{ remove_users }}"
-  vars:
-    remove_users:
-      - 'backup'
-      - 'games'
-      - 'gnats'
-      - 'irc'
-      - 'list'
-      - 'lp'
-      - 'mail'
-      - 'news'
-      - 'proxy'
-      - 'uucp'
+  loop:
+    - 'backup'
+    - 'games'
+    - 'gnats'
+    - 'irc'
+    - 'list'
+    - 'lp'
+    - 'mail'
+    - 'news'
+    - 'proxy'
+    - 'uucp'
 
 # Remove unnecessary groups from defaults
 - name: Remove specified groups
   group:
     name: "{{ item }}"
     state: absent
-  loop: "{{ remove_groups }}"
-  vars:
-    remove_groups:
-      - 'audio'
-      - 'cdrom'
-      - 'fax'
-      - 'floppy'
-      - 'games'
-      - 'gnats'
-      - 'irc'
-      - 'list'
-      - 'lp'
-      - 'mail'
-      - 'news'
-      - 'tape'
-      - 'uucp'
-      - 'video'
-      - 'voice'
+  loop:
+    - 'audio'
+    - 'cdrom'
+    - 'fax'
+    - 'floppy'
+    - 'games'
+    - 'gnats'
+    - 'irc'
+    - 'list'
+    - 'lp'
+    - 'mail'
+    - 'news'
+    - 'tape'
+    - 'uucp'
+    - 'video'
+    - 'voice'
 
 # Purge off dependencies of uneeded packages
 - name: Purge unused packages

--- a/ansible/playbooks/roles/common/tasks/configure-system.yml
+++ b/ansible/playbooks/roles/common/tasks/configure-system.yml
@@ -130,6 +130,50 @@
     - udisks2
     - upower
 
+# Remove unnecessary user accounts (vs. nologin shells)
+- name: Remove specified user accounts
+  user:
+    name: "{{ item }}"
+    state: absent
+    remove: no
+  loop: "{{ remove_users }}"
+  vars:
+    remove_users:
+      - 'backup'
+      - 'games'
+      - 'gnats'
+      - 'irc'
+      - 'list'
+      - 'lp'
+      - 'mail'
+      - 'news'
+      - 'proxy'
+      - 'uucp'
+
+# Remove unnecessary groups from defaults
+- name: Remove specified groups
+  group:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ remove_groups }}"
+  vars:
+    remove_groups:
+      - 'audio'
+      - 'cdrom'
+      - 'fax'
+      - 'floppy'
+      - 'games'
+      - 'gnats'
+      - 'irc'
+      - 'list'
+      - 'lp'
+      - 'mail'
+      - 'news'
+      - 'tape'
+      - 'uucp'
+      - 'video'
+      - 'voice'
+
 # Purge off dependencies of uneeded packages
 - name: Purge unused packages
   apt:


### PR DESCRIPTION
This addresses the issues detailed in RDTIBCC1959 and RDTIBCC1966, related to ensuring that unnecessary user accounts are not included post-automation, and those that are, but do not require interactive logins, have their shells neutered to `nologin`. 