### PR TITLE
fix ansible deprecation of "include" for tasks, replace with "include_tasks"

### DIFF
--- a/ansible/playbooks/roles/chef-workstation/tasks/extra-cookbooks.yml
+++ b/ansible/playbooks/roles/chef-workstation/tasks/extra-cookbooks.yml
@@ -1,4 +1,4 @@
-- include: upload-extra-cookbook.yml
+- include_tasks: upload-extra-cookbook.yml
   with_items: "{{ all_chef_extra_cookbooks }}"
 
 - name: load external cookbooks info chef

--- a/ansible/playbooks/roles/headnode/tasks/cloud-images.yml
+++ b/ansible/playbooks/roles/headnode/tasks/cloud-images.yml
@@ -1,3 +1,3 @@
-- include: import-cloud-image.yml
+- include_tasks: import-cloud-image.yml
   with_items:
     "{{ all_cloud_images }}"

--- a/ansible/playbooks/roles/localhost/tasks/assets.yml
+++ b/ansible/playbooks/roles/localhost/tasks/assets.yml
@@ -5,6 +5,6 @@
     mode: 0764
     recurse: true
 
-- include: download-asset.yml
+- include_tasks: download-asset.yml
   with_items:
     "{{ assets_files + additional_assets_files | default([]) }}"

--- a/ansible/playbooks/roles/web-server/tasks/web-server.yml
+++ b/ansible/playbooks/roles/web-server/tasks/web-server.yml
@@ -5,7 +5,7 @@
     mode: 0755
     recurse: true
 
-- include: upload-web-server-file.yml
+- include_tasks: upload-web-server-file.yml
   with_items: "{{ all_web_server_assets }}"
 
-- include: chef-web-server.yml
+- include_tasks: chef-web-server.yml


### PR DESCRIPTION
Testing performed: did a full build from scratch of this branch. A 3h3w built all the way to cloudy ascii art in 56m

Fix errors like the following

```
+ vagrant ssh-config
+ /home/cmorgan/work/chef-bcpc/virtual/bin/generate-ansible-inventory.py --ssh-config /tmp/tmp.fYL89WOxcY --topology-config /home/cmorgan/work/chef-bcpc/virtual/topology/topology.yml
ansible-playbook -v \
	-i ansible/inventory.yml ansible/playbooks/site.yml \
	-t sync-assets --limit localhost
Using /home/cmorgan/work/chef-bcpc/ansible/ansible.cfg as config file

PLAY [localhost] ************************************************************************************************************************************************************************************************************************************************

TASK [localhost : create assets folder] *************************************************************************************************************************************************************************************************************************
changed: [127.0.0.1] => {
    "changed": true,
    "gid": 1000,
    "group": "cmorgan",
    "mode": "0764",
    "owner": "cmorgan",
    "path": "/home/cmorgan/work/chef-bcpc/assets",
    "size": 4096,
    "state": "directory",
    "uid": 1000
}
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
make: *** [Makefile:90: sync-assets] Error 1

real	3m9.480s
user	0m34.689s
sys	0m16.377s
```