### PR TITLE
run plays that solely talk to openstack only once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,13 +243,13 @@ enable-compute-service :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/site.yml \
-		-t enable-compute-service --limit headnodes[0]
+		-t enable-compute-service --limit headnodes
 
 register-compute-nodes :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/site.yml \
-		-t register-compute-nodes --limit headnodes[0]
+		-t register-compute-nodes --limit headnodes
 
 sync-chef :
 
@@ -273,13 +273,13 @@ configure-host-aggregates :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/headnodes.yml \
-		-t configure-host-aggregates --limit headnodes[0]
+		-t configure-host-aggregates --limit headnodes
 
 configure-licenses :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/headnodes.yml \
-		-t configure-licenses --limit headnodes[0]
+		-t configure-licenses --limit headnodes
 
 define SUCCESS_BANNER
                 _

--- a/Makefile
+++ b/Makefile
@@ -243,13 +243,13 @@ enable-compute-service :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/site.yml \
-		-t enable-compute-service --limit headnodes
+		-t enable-compute-service --limit headnodes[0]
 
 register-compute-nodes :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/site.yml \
-		-t register-compute-nodes --limit headnodes
+		-t register-compute-nodes --limit headnodes[0]
 
 sync-chef :
 
@@ -273,13 +273,13 @@ configure-host-aggregates :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/headnodes.yml \
-		-t configure-host-aggregates --limit headnodes
+		-t configure-host-aggregates --limit headnodes[0]
 
 configure-licenses :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/headnodes.yml \
-		-t configure-licenses --limit headnodes
+		-t configure-licenses --limit headnodes[0]
 
 define SUCCESS_BANNER
                 _

--- a/ansible/playbooks/roles/headnode/tasks/configure-host-aggregates.yml
+++ b/ansible/playbooks/roles/headnode/tasks/configure-host-aggregates.yml
@@ -25,4 +25,5 @@
     "{{ groups['worknodes'] }}"
   args:
     executable: /bin/bash
+    run_once: true
   changed_when: false

--- a/ansible/playbooks/roles/headnode/tasks/configure-licenses.yml
+++ b/ansible/playbooks/roles/headnode/tasks/configure-licenses.yml
@@ -23,6 +23,7 @@
     "{{ license_traits['traits'] }}"
   args:
     executable: /bin/bash
+    run_once: true
   changed_when: false
 
 - name: configuring host traits
@@ -65,4 +66,5 @@
     "{{ groups['worknodes'] }}"
   args:
     executable: /bin/bash
+    run_once: true
   changed_when: false

--- a/ansible/playbooks/roles/headnode/tasks/enable-compute-service.yml
+++ b/ansible/playbooks/roles/headnode/tasks/enable-compute-service.yml
@@ -16,5 +16,6 @@
       xargs -n 1 -I % openstack compute service set --enable % nova-compute
   args:
     executable: /bin/bash
+    run_once: true
   environment:
     "{{ cloud_vars | osadmin() }}"

--- a/ansible/playbooks/roles/headnode/tasks/register-compute-nodes.yml
+++ b/ansible/playbooks/roles/headnode/tasks/register-compute-nodes.yml
@@ -1,3 +1,5 @@
 - name: nova-manage discover_hosts
   changed_when: false
   command: nova-manage cell_v2 discover_hosts --verbose
+  args:
+    run_once: true


### PR DESCRIPTION
enable-compute-service, configure-host-aggregates and configure-licenses solely talk to openstack via the CLI

register-compute-nodes solely talks to openstack via nova-manage

In both cases after this is done once, there is no purpose to running it on subsequent headnodes.

Tested with a full 3h3w build and got all the way to cloudy ascii art