### PR TITLE
redo use of run_once to be passed in where appropriate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,12 +243,14 @@ enable-compute-service :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/site.yml \
+		-e "run_once=true" \
 		-t enable-compute-service --limit headnodes
 
 register-compute-nodes :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/site.yml \
+		-e "run_once=true" \
 		-t register-compute-nodes --limit headnodes
 
 sync-chef :
@@ -273,12 +275,14 @@ configure-host-aggregates :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/headnodes.yml \
+		-e "run_once=true" \
 		-t configure-host-aggregates --limit headnodes
 
 configure-licenses :
 
 	ansible-playbook -v \
 		-i ${inventory} ${playbooks}/headnodes.yml \
+		-e "run_once=true" \
 		-t configure-licenses --limit headnodes
 
 define SUCCESS_BANNER


### PR DESCRIPTION
enable-compute-service, configure-host-aggregates, configure-licenses talk solely to openstack via the CLI

register-compute-nodes talks solely to openstack via nova-manage

They only need to run once. Explicitly tell ansible this to avoid runs across subsequent head nodes.
