### PR TITLE
Reinstate setting Nova's `enable_new_services` to off

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -11,6 +11,7 @@ ssl_only = false
 key = /etc/nova/ssl-bcpc.key
 cert = /etc/nova/ssl-bcpc.pem
 my_ip = <%= node['service_ip'] %>
+enable_new_services = false
 cpu_allocation_ratio = <%= node['bcpc']['nova']['cpu_allocation_ratio'] %>
 force_config_drive = true
 ram_allocation_ratio = <%= node['bcpc']['nova']['ram_allocation_ratio'] %>


### PR DESCRIPTION
[RDTIBCC-5052]

As part of [6636b92f06829adfe15aa1f25aeff631f02b9a8e](https://github.com/bloomberg/chef-bcpc/commit/6636b92f06829adfe15aa1f25aeff631f02b9a8e), I performed a bit of cleanup on Nova's configuration files and for some explicable reason I accidentally dropped the line that turned off auto-enabling of Nova services. This must be fixed.

Tested by verifying the erroneous section of the configuration file matched what it was prior to the previous commit.
