### PR TITLE
Reinstate bpftool workaround for Felix

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/calico/override.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/override.conf.erb
@@ -1,0 +1,2 @@
+[Service]
+Environment="PATH=/usr/lib/linux-tools/<%= @linux_tools_version %>-generic:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
This was slated to be fixed in Calico 3.27.0, but the
BPF objects still appear to have not been linked against
a new enough version of libbpf. Thus, ensure that Felix
continues using a version of bpftool that's compatible
with it.

This is slightly less heinous than the former attempt
at a workaround and should allow us to remove it easier
in the future once it is fixed.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>