### PR TITLE
Parameterize Horizon's WSGIDaemon processes and threads

### DIFF
--- a/chef/cookbooks/bcpc/attributes/horizon.rb
+++ b/chef/cookbooks/bcpc/attributes/horizon.rb
@@ -3,5 +3,5 @@
 ###############################################################################
 
 # Configs for Horizon Dashboard's WSGIDaemonProcess
-default['bcpc']['horizon']['workers'] = 3
-default['bcpc']['horizon']['worker_threads'] = 10
+default['bcpc']['horizon']['workers'] = 8
+default['bcpc']['horizon']['worker_threads'] = 16

--- a/chef/cookbooks/bcpc/attributes/horizon.rb
+++ b/chef/cookbooks/bcpc/attributes/horizon.rb
@@ -1,0 +1,7 @@
+###############################################################################
+# horizon
+###############################################################################
+
+# Configs for Horizon Dashboard's WSGIDaemonProcess
+default['bcpc']['horizon']['workers'] = 3
+default['bcpc']['horizon']['worker_threads'] = 10

--- a/chef/cookbooks/bcpc/attributes/openstack.rb
+++ b/chef/cookbooks/bcpc/attributes/openstack.rb
@@ -18,6 +18,7 @@ default['bcpc']['openstack']['admin']['username'] = 'admin'
 default['bcpc']['openstack']['admin']['project'] = 'admin'
 
 default['bcpc']['openstack']['services']['workers'] = 1
+default['bcpc']['openstack']['services']['worker_threads'] = 1
 
 ###############################################################################
 # openstack flavors

--- a/chef/cookbooks/bcpc/recipes/horizon.rb
+++ b/chef/cookbooks/bcpc/recipes/horizon.rb
@@ -33,8 +33,25 @@ file '/etc/apache2/conf-available/openstack-dashboard.conf' do
   action :delete
 end
 
+horizon_processes = if !node['bcpc']['horizon']['workers'].nil?
+                      node['bcpc']['horizon']['workers']
+                    else
+                      node['bcpc']['openstack']['services']['workers']
+                    end
+
+horizon_threads = if !node['bcpc']['horizon']['worker_threads'].nil?
+                    node['bcpc']['horizon']['worker_threads']
+                  else
+                    node['bcpc']['openstack']['services']['worker_threads']
+                  end
+
 template '/etc/apache2/sites-available/openstack-dashboard.conf' do
   source 'horizon/apache-openstack-dashboard.conf.erb'
+
+  variables(
+    processes: horizon_processes,
+    threads: horizon_threads
+  )
   notifies :run, 'execute[enable openstack-dashboard]', :immediately
   notifies :restart, 'service[horizon]', :immediately
 end

--- a/chef/cookbooks/bcpc/templates/default/horizon/apache-openstack-dashboard.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/horizon/apache-openstack-dashboard.conf.erb
@@ -4,7 +4,7 @@ Listen <%= node['service_ip'] %>:9999
   ServerName <%= node['bcpc']['cloud']['fqdn'] %>
 
   WSGIScriptAlias /horizon /usr/lib/python3/dist-packages/openstack_dashboard/wsgi.py process-group=horizon
-  WSGIDaemonProcess horizon user=horizon group=horizon processes=3 threads=10 display-name=%{GROUP}
+  WSGIDaemonProcess horizon user=horizon group=horizon processes=<%= @processes %> threads=<%= @threads %> display-name=%{GROUP}
   WSGIProcessGroup horizon
   WSGIApplicationGroup %{GLOBAL}
 


### PR DESCRIPTION
# WHY
It's always good to parameterize the configurations. We've done this to all other services, Horizon should be included too :)
# WHAT
Parameterize the processes and threads config for Horizon's WSGIDaemon. 
# How
`make all`
# Test
After rebuilding a test cluster with `threads=10` and `processes=3`:
```
$ cat /etc/apache2/sites-enabled/openstack-dashboard.conf
...
  WSGIDaemonProcess horizon user=horizon group=horizon processes=3 threads=10 display-name=%{GROUP}
...
$ cat /etc/apache2/sites-enabled/openstack-dashboard.conf
...
  WSGIDaemonProcess horizon user=horizon group=horizon processes=3 threads=10 display-name=%{GROUP}
...
```
We also want to make sure it works with other numbers (so the parameterization **does** work). Use `threads=20` and `processes=4`
```
$ cat /etc/apache2/sites-enabled/openstack-dashboard.conf
...
  WSGIDaemonProcess horizon user=horizon group=horizon processes=4 threads=20 display-name=%{GROUP}
...
$ cat /etc/apache2/sites-enabled/openstack-dashboard.conf
...
  WSGIDaemonProcess horizon user=horizon group=horizon processes=4 threads=20 display-name=%{GROUP}
...
```