### PR TITLE
calico-work: Disable and mask HAproxy

### DIFF
--- a/chef/cookbooks/bcpc/recipes/calico-work.rb
+++ b/chef/cookbooks/bcpc/recipes/calico-work.rb
@@ -1,7 +1,7 @@
 # Cookbook:: bcpc
 # Recipe:: calico-work
 #
-# Copyright:: 2023 Bloomberg Finance L.P.
+# Copyright:: 2024 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ service 'calico-dhcp-agent'
 # these neutron services are installed/enabled by calico packages
 # these services are superseded by nova-metadata-agent and calico-dhcp-agent
 # so we don't need them to be enabled/running
-%w(neutron-dhcp-agent neutron-metadata-agent).each do |srv|
-  service srv do
-    action %i(disable stop)
+%w(haproxy neutron-dhcp-agent neutron-metadata-agent).each do |srv|
+  systemd_unit srv do
+    action %i(disable stop mask)
   end
 end
 


### PR DESCRIPTION
calico-compute seems to be indirectly pulling in HAproxy,
and it is started by default. This is not a service we
need running on worknodes with Calico, so disable it.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>