### PR TITLE
Tweak Calico Config IPSetsRefreshInterval

### DIFF
--- a/chef/cookbooks/bcpc/attributes/calico.rb
+++ b/chef/cookbooks/bcpc/attributes/calico.rb
@@ -30,3 +30,5 @@ default['bcpc']['calico']['felix']['failsafe']['outbound'] = [
   'tcp:2379',
   'tcp:2380',
 ]
+
+default['bcpc']['calico']['felix']['IPSetsRefreshInterval'] = 90

--- a/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
+++ b/chef/cookbooks/bcpc/templates/default/calico/felix.cfg.erb
@@ -51,3 +51,6 @@ AllowVXLANPacketsFromWorkloads = true
 
 # Set to true to allow IPIP encapsulated traffic from workloads.
 AllowIPIPPacketsFromWorkloads = true
+
+# Set to longer interval to reduce Felix CPU Usage
+IpsetsRefreshInterval = <%= node['bcpc']['calico']['felix']['IPSetsRefreshInterval'] %>


### PR DESCRIPTION
## WHY
According to Calico's [config documentation](https://docs.tigera.io/calico/latest/reference/felix/configuration), `IpsetsRefreshInterval` is decreased to 10s due to a workaround of a bug in kernel. The bug was fixed, so we can increase the IPSetsRefreshInterval back to 90s, the original default value, to decrease Calico-Felix's CPU usage.
## WHAT
Tweak `IpsetsRefreshInterval` to its original default value (10s -> 90s).
## HOW
`make all`!
## TEST
We want to first make sure that the config file is changed correctly:
```
root@test-cloud-worknode:~# cat /etc/calico/felix.cfg | grep Ipsets
IpsetsRefreshInterval = 90
```
The change can also be reflected in the log message:
```
root@test-cloud-worknode:~# grep -Rnw /var/log/calico --ignore-case -e 'IP sets on'
/var/log/calico/felix.log:6436:2024-02-16 16:29:32.138 [INFO][163325] felix/int_dataplane.go 1926: Will refresh IP sets on timer interval=1m30s
```
And we can see the following logs get generated every 90s, saying that Calico-Felix is refreshing IP sets
```
root@test-cloud-worknode:~# grep -Rnw /var/log/calico --ignore-case -e 'Refreshing IP sets'
/var/log/calico/felix.log:76156:2024-02-16 16:35:09.288 [DEBUG][165330] felix/int_dataplane.go 1849: Refreshing IP sets state
/var/log/calico/felix.log:76815:2024-02-16 16:36:47.456 [DEBUG][165330] felix/int_dataplane.go 1849: Refreshing IP sets state
```
To test Calico-Felix is indeed refreshing IPSets, we can change the IPSets and see if they are reverted after 90s:
```
root@test-cloud-worknode:~# ipset add calico-hosts 123.123.123.123
root@test-cloud-worknode:~# ipset list
...
Name: calico-hosts
Type: hash:ip
...
Number of entries: 8
Members:
IP1
IP2
IP3
IP4
IP5
123.123.123.123
IP6
IP7
...

# After 90s
root@test-cloud-worknode:~# ipset list
...
Name: calico-hosts
Type: hash:ip
...
Number of entries: 7
Members:
IP1
IP2
IP3
IP4
IP5
IP6
IP7
...
```
