### PR TITLE
Changes to support internal CI

### DIFF
--- a/ansible/playbooks/roles/common/templates/ssh/sshd_config.j2
+++ b/ansible/playbooks/roles/common/templates/ssh/sshd_config.j2
@@ -12,6 +12,8 @@
 # possible, but leave them commented.  Uncommented options override the
 # default value.
 
+Include /etc/ssh/sshd_config.d/*.conf
+
 # Force protocol version 2
 Protocol 2
 


### PR DESCRIPTION
Two small changes to support internal CI changes

  * Add the Include statement in the sshd back into the
    file. This is actually part of the default Ubuntu
    configuration, but we dropped or did not include it
    previously.

  * Add a fallback for determining Ceph rack number.
    Currently, we perform regex on the hostname to
    determine the rack number. In cases where the hostname
    cannot be controlled, fallback to the "pet name" that
    the metadata API provides and match on that instead.

Signed-off-by: Tyler Stachecki <tstachecki@bloomberg.net>