### PR TITLE
RDTIBCCOPT-152: mysql: Change error log location and verbosity

### DIFF
--- a/chef/cookbooks/bcpc/attributes/mysql.rb
+++ b/chef/cookbooks/bcpc/attributes/mysql.rb
@@ -28,6 +28,10 @@ default['bcpc']['mysql']['thread_cache_size'] = 1024
 default['bcpc']['mysql']['tmp_table_size'] = '128M'
 default['bcpc']['mysql']['wsrep_slave_threads'] = 16
 
+# error log settings
+default['bcpc']['mysql']['log_error_verbosity'] = 2
+default['bcpc']['mysql']['log_error_location'] = 'syslog'
+
 # slow query log settings
 default['bcpc']['mysql']['slow_query_log'] = true
 default['bcpc']['mysql']['slow_query_log_file'] = '/var/log/mysql/slow.log'

--- a/chef/cookbooks/bcpc/templates/default/mysql/my.cnf.erb
+++ b/chef/cookbooks/bcpc/templates/default/mysql/my.cnf.erb
@@ -7,5 +7,9 @@
 [mysqld]
 pid-file = /var/run/mysqld/mysqld.pid
 socket   = /var/run/mysqld/mysqld.sock
+log_error_verbosity = <%= node['bcpc']['mysql']['log_error_verbosity'] %>
+
+[mysqld_safe]
+<%= node['bcpc']['mysql']['log_error_location'] %>
 
 !includedir /etc/mysql/conf.d/


### PR DESCRIPTION
By default `mysql` 5.7 logs error messages to stderr with a verbosity of Error, Warning, and Note. This behavior is over-written by `mysqld_safe`, the script called by `/etc/init.d/mysql` that executes `mysql`, to instead route stderr to a file in the mysql data directory.

Said error log file is not rotated via the logrotate configuration file bundled with Percona XtraDB Cluster 5.7 because this method of logging errors was deemed 'obsolete', with syslog being recommended.

This commit routes mysql error messages to syslog by default, and limits the verbosity to only Error and Warning. Thus mysql error logs are automatically rotated as part of syslog rotation, and `Note` messages omitted.

**Describe your changes**
See the commit message.

**Testing performed**
Tested on an internal test cluster. New defaults are properly applied on existing clusters and can be rolled back by setting `log_error_verbosity` to 3 and `log_error_location` to `skip-syslog`. 

**Additional context**
None.
