### PR TITLE
Add an auxiliary disk device for use by nodes in `headnode` hardware group

### DIFF
--- a/virtual/topology/hardware.overrides.yml.example
+++ b/virtual/topology/hardware.overrides.yml.example
@@ -6,6 +6,9 @@ profiles:
     ram_gb: 32
     cpus: 4
     swap_gb: 16
+    ext_disks:
+      count: 1
+      size_gb: 32
   worknode:
     ram_gb: 32
     cpus: 8

--- a/virtual/topology/hardware.yml
+++ b/virtual/topology/hardware.yml
@@ -6,6 +6,9 @@ profiles:
     ram_gb: 8
     cpus: 4
     swap_gb: 4
+    ext_disks:
+      count: 1
+      size_gb: 16
   worknode:
     ram_gb: 8
     cpus: 4


### PR DESCRIPTION
[RDTIBCC-4718]

This is simply to allow out-of-the-box a drive to be available in the `headnode` hardware group for use by services like Ceph and Cinder to store their private data.