### PR TITLE
Enable randomize_allocation_candidates for Placement Service

### DIFF
--- a/chef/cookbooks/bcpc/attributes/placement.rb
+++ b/chef/cookbooks/bcpc/attributes/placement.rb
@@ -16,3 +16,6 @@ default['bcpc']['placement']['workers'] = nil
 
 # Placement default log levels
 default['bcpc']['placement']['default_log_levels'] = nil
+
+# Placement candidate allocation configs
+default['bcpc']['placement']['placement']['randomize_allocation_candidates'] = true

--- a/chef/cookbooks/bcpc/templates/default/placement/placement.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/placement/placement.conf.erb
@@ -23,6 +23,9 @@ user_domain_name = Default
 username = <%= @config['placement']['creds']['os']['username'] %>
 password = <%= @config['placement']['creds']['os']['password'] %>
 
+[placement]
+randomize_allocation_candidates = <%= node['bcpc']['placement']['placement']['randomize_allocation_candidates'] %>
+
 [placement_database]
 connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>
 max_overflow = <%= node['bcpc']['placement']['db']['max_overflow'] %>


### PR DESCRIPTION
## WHY
Please check [here](https://bbgithub.dev.bloomberg.com/gist/zzhang953/7b081d9bae9f38aeaa247f8df0e84af3). 

## WHAT
Change `randomize_allocation_candidates` to be `true`.

## HOW
`make all` :D

## TEST
After building the cluster, the following config entry is generated:
```
root@test-cloud:~# cat /etc/placement/placement.conf | grep randomize_allocation_candidates -B 1
[placement]
randomize_allocation_candidates = true
```
A cluster with 3 compute hosts had been spin up for testing. Since this is a config change for placement service, we can test this by directly accessing the Placement API, or checking the log in `nova-scheduler`. To also make sure Placement service is indeed randomly picking allocation candidates, the fetch limit is set to 2 when sending requests and `max_placement_results` has been set to 2 for `nova-scheduler`. With the config enabled, we expect the 2 candidates to differ across different requests.

### Without Changes
Requested 3 times, and all responses returned the same results in the same order:
```
root@test-cloud:~# openstack allocation candidate list --resource VCPU=1 --limit 2 -f json
[
  {
    "#": 1,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-3",
    "inventory used/capacity": "...",
    "traits": "..."
  },
  {
    "#": 2,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-2",
    "inventory used/capacity": "...",
    "traits": "..."
  }
]

root@test-cloud:~# openstack allocation candidate list --resource VCPU=1 --limit 2 -f json
[
  {
    "#": 1,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-3",
    "inventory used/capacity": "...",
    "traits": "..."
  },
  {
    "#": 2,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-2",
    "inventory used/capacity": "...",
    "traits": "..."
  }
]

root@test-cloud:~# openstack allocation candidate list --resource VCPU=1 --limit 2 -f json
[
  {
    "#": 1,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-3",
    "inventory used/capacity": "...",
    "traits": "..."
  },
  {
    "#": 2,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-2",
    "inventory used/capacity": "...",
    "traits": "..."
  }
]
```
And we can also see this from the log in `nova-scheduler`.
```
[
  {"allocations": {
    "resource-provider-2": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-2"]}},
  {"allocations": {
    "resource-provider-3": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-3"]}}
]

[
  {"allocations": {
    "resource-provider-2": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-2"]}},
  {"allocations": {
    "resource-provider-3": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-3"]}}
]

[
  {"allocations": {
    "resource-provider-2": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-2"]}},
  {"allocations": {
    "resource-provider-3": {
      "resources": {...}}},
  "mappings": {"": ["resource-provider-3"]}}
]
```
### With Changes
Requested 3 times, and responses returned different results in different orders:
```
root@test-cloud:~# openstack allocation candidate list --resource VCPU=1 --limit 2 -f json
[
  {
    "#": 1,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-3",
    "inventory used/capacity": "...",
    "traits": "..."
  },
  {
    "#": 2,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-2",
    "inventory used/capacity": "...",
    "traits": "..."
  }
]

root@test-cloud:~# openstack allocation candidate list --resource VCPU=1 --limit 2 -f json
[
  {
    "#": 1,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-3",
    "inventory used/capacity": "...",
    "traits": "..."
  },
  {
    "#": 2,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-1",
    "inventory used/capacity": "...",
    "traits": "..."
  }
]

root@test-cloud:~# openstack allocation candidate list --resource VCPU=1 --limit 2 -f json
[
  {
    "#": 1,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-2",
    "inventory used/capacity": "...",
    "traits": "..."
  },
  {
    "#": 2,
    "allocation": "VCPU=1",
    "resource provider": "resource-provider-1",
    "inventory used/capacity": "...",
    "traits": "..."
  }
]
```
Which can also be reflected in `nova-scheduler`'s log message:
```
[
{"allocations": {
    "resource-provider-3": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-3"]}},
  {"allocations": {
    "resource-provider-2": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-2"]}}
]

[
  {"allocations": {
    "resource-provider-3": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-3"]}},
  {"allocations": {
    "resource-provider-1": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-1"]}}
]

[
  {"allocations": {
    "resource-provider-2": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-2"]}},
  {"allocations": {
    "resource-provider-3": {
      "resources": {...}}},
    "mappings": {"": ["resource-provider-3"]}}
]
```
