### PR TITLE
Increase token_cache_time for keystone_authtoken on Openstack Services

### DIFF
--- a/chef/cookbooks/bcpc/attributes/cinder.rb
+++ b/chef/cookbooks/bcpc/attributes/cinder.rb
@@ -32,3 +32,6 @@ default['bcpc']['cinder']['alternate_backends']['enabled'] = false
 default['bcpc']['cinder']['alternate_backends']['backends'] = []
 default['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_project_id'] = nil
 default['bcpc']['cinder']['alternate_backends']['cinder_internal_tenant_user_id'] = nil
+
+# specify keystone_authtoken configs
+default['bcpc']['cinder']['keystone_authtoken']['token_cache_time'] = 600

--- a/chef/cookbooks/bcpc/attributes/glance.rb
+++ b/chef/cookbooks/bcpc/attributes/glance.rb
@@ -22,3 +22,6 @@ default['bcpc']['glance']['ceph']['pool']['size'] = 3
 # image format
 default['bcpc']['glance']['image_format']['container_formats'] = ['bare']
 default['bcpc']['glance']['image_format']['disk_formats'] = ['raw']
+
+# specify keystone_authtoken configs
+default['bcpc']['glance']['keystone_authtoken']['token_cache_time'] = 600

--- a/chef/cookbooks/bcpc/attributes/heat.rb
+++ b/chef/cookbooks/bcpc/attributes/heat.rb
@@ -18,3 +18,6 @@ default['bcpc']['heat']['engine_workers'] = nil
 # defaults to 5 upstream, which can be exceeded with sufficiently complex
 # templates. Bumping this from 5 to 8 provides sufficient headroom.
 default['bcpc']['heat']['max_nested_stack_depth'] = 8
+
+# specify keystone_authtoken configs
+default['bcpc']['heat']['keystone_authtoken']['token_cache_time'] = 600

--- a/chef/cookbooks/bcpc/attributes/neutron.rb
+++ b/chef/cookbooks/bcpc/attributes/neutron.rb
@@ -53,3 +53,6 @@ default['bcpc']['neutron']['calico']['project_name_cache_max'] = nil
 # notifications
 default['bcpc']['neutron']['notifications']['enabled'] = false
 default['bcpc']['neutron']['notifications']['topics'] = []
+
+# specify keystone_authtoken configs
+default['bcpc']['neutron']['keystone_authtoken']['token_cache_time'] = 600

--- a/chef/cookbooks/bcpc/attributes/nova.rb
+++ b/chef/cookbooks/bcpc/attributes/nova.rb
@@ -132,3 +132,6 @@ default['bcpc']['nova']['scheduler']['filter']['isolated_aggregate_filtering']['
 
 # (Integer) Automatically confirm resizes after N seconds.
 default['bcpc']['nova']['resize_confirm_window'] = 30
+
+# specify keystone_authtoken configs
+default['bcpc']['nova']['keystone_authtoken']['token_cache_time'] = 600

--- a/chef/cookbooks/bcpc/attributes/placement.rb
+++ b/chef/cookbooks/bcpc/attributes/placement.rb
@@ -16,3 +16,6 @@ default['bcpc']['placement']['workers'] = nil
 
 # Placement default log levels
 default['bcpc']['placement']['default_log_levels'] = nil
+
+# specify keystone_authtoken configs
+default['bcpc']['placement']['keystone_authtoken']['token_cache_time'] = 600

--- a/chef/cookbooks/bcpc/attributes/watcher.rb
+++ b/chef/cookbooks/bcpc/attributes/watcher.rb
@@ -8,3 +8,6 @@ default['bcpc']['watcher']['enabled'] = false
 default['bcpc']['watcher']['db']['dbname'] = 'watcher'
 
 default['bcpc']['watcher']['api_workers'] = nil
+
+# specify keystone_authtoken configs
+default['bcpc']['watcher']['keystone_authtoken']['token_cache_time'] = 600

--- a/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/cinder/cinder.conf.erb
@@ -70,6 +70,7 @@ username = <%= @config['cinder']['creds']['os']['username'] %>
 password = <%= @config['cinder']['creds']['os']['password'] %>
 service_token_roles = admin
 service_token_roles_required = True
+token_cache_time = <%= node['bcpc']['cinder']['keystone_authtoken']['token_cache_time'] %>
 
 <% @backends.each do |backend| %>
 [<%= backend['name'] %>]

--- a/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
@@ -53,6 +53,7 @@ user_domain_name = Default
 project_name = service
 username = <%= @os['username'] %>
 password = <%= @os['password'] %>
+token_cache_time = <%= node['bcpc']['glance']['keystone_authtoken']['token_cache_time'] %>
 
 [oslo_concurrency]
 lock_path = /var/lock/glance

--- a/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/heat/heat.conf.erb
@@ -95,6 +95,7 @@ user_domain_name = Default
 username = <%= @config['heat']['creds']['os']['username'] %>
 password = <%= @config['heat']['creds']['os']['password'] %>
 www_authenticate_uri = <%= "https://#{@node['bcpc']['cloud']['fqdn']}:5000/" %>
+token_cache_time = <%= node['bcpc']['heat']['keystone_authtoken']['token_cache_time'] %>
 
 # Optionally specify a list of memcached server(s) to use for caching. If left
 # undefined, tokens will instead be cached in-process. (list value)

--- a/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/neutron/neutron.conf.erb
@@ -55,6 +55,7 @@ user_domain_name = Default
 project_name = service
 username = <%= @os['username'] %>
 password = <%= @os['password'] %>
+token_cache_time = <%= node['bcpc']['neutron']['keystone_authtoken']['token_cache_time'] %>
 
 [nova]
 auth_url = <%= "https://#{node['bcpc']['cloud']['fqdn']}:35357" %>

--- a/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/nova/nova.conf.erb
@@ -83,6 +83,7 @@ username = <%= @config['nova']['creds']['os']['username'] %>
 password = <%= @config['nova']['creds']['os']['password'] %>
 service_token_roles = admin
 service_token_roles_required = True
+token_cache_time = <%= node['bcpc']['nova']['keystone_authtoken']['token_cache_time'] %>
 
 [api_database]
 connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}_api" %>

--- a/chef/cookbooks/bcpc/templates/default/placement/placement.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/placement/placement.conf.erb
@@ -22,6 +22,7 @@ project_domain_name = Default
 user_domain_name = Default
 username = <%= @config['placement']['creds']['os']['username'] %>
 password = <%= @config['placement']['creds']['os']['password'] %>
+token_cache_time = <%= node['bcpc']['placement']['keystone_authtoken']['token_cache_time'] %>
 
 [placement_database]
 connection = <%= "mysql+pymysql://#{@db['username']}:#{@db['password']}@#{@db['host']}:#{@db['port']}/#{@db['dbname']}" %>

--- a/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/watcher/watcher.conf.erb
@@ -18,6 +18,7 @@ password = <%= @config['watcher']['creds']['os']['password'] %>
 auth_uri = <%= "https://#{@node['bcpc']['cloud']['fqdn']}:5000/" %>
 memcached_servers = <%= @headnodes.map{ |n| "#{n['service_ip']}:11211" }.join(',') %>
 auth_type = password
+token_cache_time = <%= node['bcpc']['watcher']['keystone_authtoken']['token_cache_time'] %>
 
 [oslo_concurrency]
 lock_path = /var/lock/watcher


### PR DESCRIPTION
## WHY
To prevent excessive effort for validating tokens, the `keystone_authtoken` (or `keystonemiddleware`) will cache previously seen tokens and set the cache entry's timeout to be `token_cache_time`. The default 300s is good, but we can take a step futher to increase it to 600s, so the token can stay in cache for a longer period of time. This will be beneficial when there are a lot of requests and thus a lot interactions between Openstack services.

## WHAT
```
token_cache_time = 300s => 600s
```

## HOW
`make all`!

## TEST
After building the testing cluster, the following configs are included in the file:
```
% ansible -i ansible/inventory.yml test-cloud-nodes -b -m shell -b -a "grep -Rnw /etc/*/*.conf -e token_cache_time"
test-cloud-node-1 | CHANGED | rc=0 >>
/etc/cinder/cinder.conf:61:token_cache_time = 600
/etc/glance/glance-api.conf:52:token_cache_time = 600
/etc/heat/heat.conf:86:token_cache_time = 600
/etc/neutron/neutron.conf:41:token_cache_time = 600
/etc/nova/nova.conf:64:token_cache_time = 600
/etc/placement/placement.conf:22:token_cache_time = 600
```

To make sure the config is loaded, we can check the log message of an Openstack service:
```
# Nova
root@test-cloud-node-1:~# grep -Rnw /var/log/nova/nova-api.log -e token_cache_time
35510:2024-03-01 16:01:24.562 704724 DEBUG oslo_service.service [-] keystone_authtoken.token_cache_time = 600 log_opt_values /usr/lib/python3/dist-packages/oslo_config/cfg.py:2609

# Cinder
root@test-cloud-node-1:~# grep -Rnw /var/log/cinder/ -e token_cache_time
/var/log/cinder/cinder-scheduler.log:21285:2024-03-01 16:06:20.237 705779 DEBUG cinder.service [req-d3744fef-bece-4121-bc35-12af7a0d6120 - - - - -] keystone_authtoken.token_cache_time = 600 log_opt_values /usr/lib/python3/dist-packages/oslo_config/cfg.py:2609
/var/log/cinder/cinder-scheduler.log:21719:2024-03-01 16:06:20.337 705779 DEBUG oslo_service.service [req-d3744fef-bece-4121-bc35-12af7a0d6120 - - - - -] keystone_authtoken.token_cache_time = 600 log_opt_values /usr/lib/python3/dist-packages/oslo_config/cfg.py:2609
/var/log/cinder/cinder-volume.log:273:2024-03-01 16:06:20.295 705781 DEBUG oslo_service.service [req-e99b8702-d0b2-4423-bdaf-265fc8a7a71a - - - - -] keystone_authtoken.token_cache_time = 600 log_opt_values /usr/lib/python3/dist-packages/oslo_config/cfg.py:2609
```