### PR TITLE
RDTIBCCOPT-382: Replace deprecated configs + image cache dir

### DIFF
--- a/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
+++ b/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb
@@ -6,6 +6,7 @@
 # go to: https://docs.openstack.org/glance/yoga/configuration/glance_api.html
 #
 [DEFAULT]
+enabled_backends = ceph:rbd
 debug = <%= node['bcpc']['glance']['debug'] %>
 show_image_direct_url = true
 enable_v1_api = false
@@ -18,7 +19,6 @@ workers = <%= node['bcpc']['glance']['workers'] %>
 workers = <%= node['bcpc']['openstack']['services']['workers'] %>
 <% end %>
 admin_role = <%= node['bcpc']['keystone']['roles']['admin'] %>
-image_cache_dir = /var/lib/glance/image-cache/
 log_file = /var/log/glance/api.log
 transport_url = rabbit://<%= @rmqnodes.map{|x| "#{@config['rabbit']['username']}:#{@config['rabbit']['password']}@#{x['service_ip']}:5672" }.join(',') %>
 image_member_quota = -1
@@ -30,8 +30,9 @@ max_overflow=<%= node['bcpc']['glance']['db']['max_overflow'] %>
 
 
 [glance_store]
-stores = rbd
-default_store = rbd
+default_backend = ceph
+
+[ceph]
 rbd_store_pool = <%= node['bcpc']['glance']['ceph']['pool']['name'] %>
 rbd_store_user = <%= node['bcpc']['glance']['ceph']['user'] %>
 rbd_store_ceph_conf = /etc/ceph/ceph.conf


### PR DESCRIPTION
The image cache is effectively disabled due to `flavor = keystone` under `paste_deploy`, remove reference to an image cache dir.

We use an RBD backend to store images, ephemeral volumes, and volumes. All RBD volumes, including ephemeral ones, created from images are created within the RBD backend using copy-on-write, bypassing the caching layer even if it were enabled. Non-RBD volumes created from images will utilize cinder's volume image cache.

**Describe your changes**
Replaced deprecated configs `stores` and `default_store` with `enabled_backends` and `default_backend`. Also removed `image_cache_dir` since it is not being utilized. Specifically, as per Ceph's [instructions](https://docs.ceph.com/en/latest/rbd/rbd-openstack/#disable-cache-management-any-openstack-version) for integrating with OpenStack, we have set [flavor = keystone](https://github.com/bloomberg/chef-bcpc/blob/development/chef/cookbooks/bcpc/templates/default/glance/glance-api.conf.erb#L66) under `paste_deploy`, thus disabling Glance's caching layer. See [this](https://docs.openstack.org/glance/latest/configuration/configuring.html#enabling-the-image-cache-middleware) for additional information.

**Testing performed**
Deployed on a test cluster, launched and deleted a VM + downloaded and uploaded an image,

**Additional context**
None.
