### PR TITLE
RDTIBCC-5142: Install librados along with glance

### DIFF
--- a/chef/cookbooks/bcpc/recipes/glance.rb
+++ b/chef/cookbooks/bcpc/recipes/glance.rb
@@ -123,6 +123,7 @@ end
 
 # glance package installation and service definition
 package %w(
+  ceph-common
   glance
   qemu-utils
 )


### PR DESCRIPTION
Since we configure glance with an `rbd` backend we need `librados` installed in order to bring up the service. Make this dependency explicit.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
See above.

**Testing performed**
Successfully built a test cluster with change.

**Additional context**
None.
