### PR TITLE
Add Reserved Ports for Various BCPC Services

### DIFF
--- a/ansible/playbooks/roles/common/defaults/main/base.yml
+++ b/ansible/playbooks/roles/common/defaults/main/base.yml
@@ -372,7 +372,68 @@ kernel_version: ''
 
 # Use this to *add* more reserved ports; i.e. modify value of
 # net.ipv4.ip_local_reserved_ports
-system_additional_reserved_ports: []
+system_additional_reserved_ports:
+  # memcached
+  - 11211
+  # rabbitmq
+  - 5672
+  - 15672
+  - 55672
+  # libvirtd
+  - 16509
+  - 16514
+  # erlang
+  - 25672
+  # keystone
+  - 35357
+  - 35358
+  # haproxy
+  - 32768
+  # etcd
+  - 2379
+  - 2380
+  # ceph-mon
+  - 3300
+  # cinder
+  - 8776
+  # glance-API
+  - 9292
+  # amqpchk (xinetd)
+  - 5673
+  # keystone-public
+  - 5000
+  # consul
+  - 8300
+  - 8301
+  - 8302
+  - 8500
+  - 8600
+  # heat-api
+  - 8000
+  - 8004
+  # horizon
+  - 9999
+  # mysql
+  - 3306
+  - 4567
+  # nova
+  - 6080
+  - 8444
+  - 8774
+  # neutron
+  - 9696
+  # placement
+  - 8778
+  # powerdns
+  - 5300
+  - 8081
+  # proxysql
+  - 6032
+  - 6033
+  - 6070
+  - 6071
+  # watcher
+  - 9322
 
 # Select IPv6 support.
 system_enable_ipv6: false

--- a/ansible/playbooks/roles/common/templates/sysctl/bcpc.conf.j2
+++ b/ansible/playbooks/roles/common/templates/sysctl/bcpc.conf.j2
@@ -6,8 +6,7 @@
 net.ipv4.ip_local_port_range = 10000 64999
 
 # Reserve additional ports
-{% set default_reserved = [10050,10051,11211,15672,16509,16514,25672,32768,35357,35358,55672] -%}
-{% set reserved_set = default_reserved + (system_additional_reserved_ports | map('int') | list) -%}
+{% set reserved_set = (system_additional_reserved_ports | map('int') | list) -%}
 net.ipv4.ip_local_reserved_ports = {{ ','.join(reserved_set | sort | map('string')) }}
 
 # Increase Linux autotuning TCP buffer limits


### PR DESCRIPTION
## WHY
To prevent services' ports being occupied by automatic port assignments and thus failing to start, we can reserve the ports by configuring `ip_local_reserved_ports` [doc](https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt).

We never encountered any issue before because we set `ip_local_port_range` to be `10000 ~ 64999`, meaning the automatically assigned ports will only be within this range. Majority of the ports used by services are `< 10000`, and some ports used by services that are `> 10000` are already reserved. However, it doesn't hurt to reserve all ports anyways, in case we want to change `ip_local_port_range` in the future. For example, if I change `ip_local_port_range` to `5000 ~ 64999`, I don't expect this change will break anything (i.e., kernel assigns a port to a random process, which the port is used by one of our services, and thus causing that service fails to start).

## WHAT
Adding reserved ports for services, deleting the ones that are no longer in use, and move the ports to ansible variable.
```
zabbix 10050,10051 (removed)
memcached 11211
rabbitmq 5672,15672,55672
libvirtd 16509,16514
erlang 25672
keystone 35357,35358
haproxy: 32768

etcd: 2379, 2380
ceph-mon: 3300
cinder: 8776
glance-api: 9292
amqpchk (xinetd): 5673
keystone-public: 5000
consul: 8600, 8500, 8300, 8301, 8302
heat-api: 8004
heat-api-cfn: 8000
horizon: 9999
mysql: 3306,4567
nova: 8444, 8774
neutron: 9696
nova-novncproxy: 6080
placement-api: 8778
powerdns: 5300, 8081
proxysql: 6032, 6033, 6070, 6071
watcher: 9322
```

## HOW
`make all`!

## TEST
A build succeeded, and all ports are reserved as well:
```
% ansible -i ansible/inventory.yml cloud -b -m shell -b -a "sudo sysctl -a | grep reserved"  
test-cloud-2 | CHANGED | rc=0 >>
net.ipv4.ip_local_reserved_ports = 2379-2380,3300,3306,4567,5000,5300,5672-5673,6032-6033,6070-6071,6080,8000,8004,8081,8300-8302,8444,8500,8774,8776,8778,9292,9322,9696,9999,11211,15672,16509,16514,25672,32768,35357-35358,55672
...
```