### PR TITLE
Rewrite Ceph reweight logic with a cleaner, faster alternative

### DIFF
--- a/ansible/playbooks/roles/common/tasks/reweight-ceph-osds.yml
+++ b/ansible/playbooks/roles/common/tasks/reweight-ceph-osds.yml
@@ -4,19 +4,10 @@
     set -o pipefail
     set -xe
 
-    ceph_df=$(ceph osd df tree --format json)
-    ceph_osd_id_size_map=$(echo $ceph_df | \
-      jq '.nodes[] | select(.type == "osd") | .id,.kb' | \
-      paste - -)
-
-    IFS=$'\n'
-    for id_size in $ceph_osd_id_size_map; do
-      id=$(echo $id_size | awk '{print $1}')
-      size_kb=$(echo $id_size | awk '{print $2}')
-
-      # convert the kb representation into tb
-      size_tb=$(echo "scale=5; ${size_kb}/(1024^3)" | bc)
-      ceph osd crush reweight osd.${id} ${size_tb}
+    ceph osd df tree --format json | jq -rc '.nodes[] | \
+        select(.type == "osd") | [.id, (.kb / pow(1024;3))]|@tsv' | \
+    while IFS=$'\t' read -r id size_tb; do
+        ceph osd crush reweight osd.${id} $(printf "%.5f" $size_tb)
     done
   args:
     executable: /bin/bash


### PR DESCRIPTION
Just a bit of optimization I found while rebuilding Thermite multiple times. This reduces several lines of code and repeated subshells to call `awk` and `bc` for string formatting into 2 lines of code. 

Further optimizations could be made to slice the vars and do some string formatting, but this should be sufficient here. 